### PR TITLE
Enhanced client internal methods - Better client handlers - Updated client connect & requests methods

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <time.h>
+#include <signal.h>
+
+#include <cerver/version.h>
+#include <cerver/cerver.h>
+
+#include <cerver/utils/log.h>
+#include <cerver/utils/utils.h>
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0
+
+} AppRequest;
+
+static Cerver *client_cerver = NULL;
+
+// correctly closes any on-going server and process when quitting the appplication
+static void end (int dummy) {
+	
+	if (client_cerver) {
+		cerver_stats_print (client_cerver);
+		cerver_teardown (client_cerver);
+	} 
+
+	exit (0);
+
+}
+
+static void handle_test_request (Packet *packet) {
+
+	if (packet) {
+		cerver_log_debug ("Got a test message from client. Sending another one back...");
+		
+		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		if (test_packet) {
+			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
+			size_t sent = 0;
+			if (packet_send (test_packet, 0, &sent, false)) 
+				cerver_log_error ("Failed to send test packet to client!");
+
+			else {
+				// printf ("Response packet sent: %ld\n", sent);
+			}
+			
+			packet_delete (test_packet);
+		}
+	}
+
+}
+
+static void handler (void *data) {
+
+	if (data) {
+		Packet *packet = (Packet *) data;
+		if (packet->data_size >= sizeof (RequestData)) {
+			RequestData *req = (RequestData *) (packet->data);
+
+			switch (req->type) {
+				case TEST_MSG: handle_test_request (packet); break;
+
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
+			}
+		}
+	}
+
+}
+
+int main (void) {
+
+	srand (time (NULL));
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	printf ("\n");
+	cerver_version_print_full ();
+	printf ("\n");
+
+	cerver_log_debug ("Cerver Client Example");
+	printf ("\n");
+	cerver_log_debug ("Cerver creates a new client that will use to make requests to another cerver");
+	printf ("\n");
+
+	client_cerver = cerver_create (CUSTOM_CERVER, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	if (client_cerver) {
+		/*** cerver configuration ***/
+		cerver_set_receive_buffer_size (client_cerver, 4096);
+		cerver_set_thpool_n_threads (client_cerver, 4);
+
+		Handler *app_handler = handler_create (handler);
+		handler_set_direct_handle (app_handler, true);
+		cerver_set_app_handlers (client_cerver, app_handler, NULL);
+
+		if (cerver_start (client_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				client_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (client_cerver);
+		}
+	}
+
+	else {
+		char *s = c_string_create ("Failed to create %s!",
+			client_cerver->info->name->str);
+		if (s) {
+			cerver_log_error (s);
+			free (s);
+		}
+
+		cerver_delete (client_cerver);
+	}
+
+	return 0;
+
+}

--- a/examples/client.c
+++ b/examples/client.c
@@ -49,7 +49,7 @@ static void end (int dummy) {
 
 #pragma region handler
 
-static void handle_test_request (Packet *packet) {
+static void cerver_handle_test_request (Packet *packet) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
@@ -71,7 +71,7 @@ static void handle_test_request (Packet *packet) {
 
 }
 
-static void cerver_app_handler (void *data) {
+static void cerver_app_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
@@ -79,7 +79,7 @@ static void cerver_app_handler (void *data) {
 			RequestData *req = (RequestData *) (packet->data);
 
 			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
+				case TEST_MSG: cerver_handle_test_request (packet); break;
 
 				default: 
 					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
@@ -94,7 +94,7 @@ static void cerver_app_handler (void *data) {
 
 #pragma region client
 
-static void client_app_handler (void *packet_ptr) {
+static void client_app_handler_direct (void *packet_ptr) {
 
 	if (packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
@@ -120,6 +120,30 @@ static void client_app_handler (void *packet_ptr) {
             }
         }
     }
+
+}
+
+static void client_app_handler (void *data) {
+
+	if (data) {
+        HandlerData *handler_data = (HandlerData *) data;
+
+        // AppData *app_data = (AppData *) handler_data->data;
+		Packet *packet = handler_data->packet;
+		if (packet->data_size >= sizeof (RequestData)) {
+			RequestData *req = (RequestData *) (packet->data);
+
+			switch (req->type) {
+				case TEST_MSG: {
+                    cerver_log_debug ("Got a test message from cerver!");
+                } break;
+
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
+			}
+		}
+	}
 
 }
 
@@ -182,6 +206,9 @@ static int request_message (Client *client, Connection *connection) {
 
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
 // create a new client that will connect to a cerver & make a test request
 static void *cerver_client_request (void *args) {
 
@@ -189,7 +216,7 @@ static void *cerver_client_request (void *args) {
     if (client) {
         client_set_name (client, "test-client");
 
-        Handler *app_handler = handler_create (client_app_handler);
+        Handler *app_handler = handler_create (client_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);
         client_set_app_handlers (client, app_handler, NULL);
 
@@ -218,6 +245,88 @@ static void *cerver_client_request (void *args) {
 
 }
 
+#pragma GCC diagnostic pop
+
+static int test_app_msg_send (Client *client, Connection *connection) {
+
+    int retval = 1;
+
+    Packet *packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+    if (packet) {
+        packet_set_network_values (packet, NULL, client, connection, NULL);
+        size_t sent = 0;
+        if (packet_send (packet, 0, &sent, false)) {
+            cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to send test to cerver");
+        }
+
+        else {
+            printf ("APP_PACKET sent to cerver: %ld\n", sent);
+            retval = 0;
+        } 
+
+        packet_delete (packet);
+    }
+
+    return retval;
+
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+static void *cerver_client_connect_and_start (void *args) {
+
+    Client *client = client_create ();
+    if (client) {
+        client_set_name (client, "start-client");
+
+        Handler *app_handler = handler_create (client_app_handler);
+		// handler_set_direct_handle (app_handler, true);
+        client_set_app_handlers (client, app_handler, NULL);
+
+        // wait 2 seconds before connecting to cerver
+        sleep (2);
+        Connection *connection = client_connection_create (client, "127.0.0.1", 8007, PROTOCOL_TCP, false);
+        if (connection) {
+            connection_set_max_sleep (connection, 30);
+
+            if (!client_connect_and_start (client, connection)) {
+                cerver_log_msg (stdout, LOG_SUCCESS, LOG_NO_TYPE, "Connected to cerver!");
+            }
+
+            else {
+                cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to connect to cerver!");
+            }
+        }
+        
+        // send 1 request message every second
+        for (unsigned int i = 0; i < 5; i++) {
+            test_app_msg_send (client, connection);
+
+            sleep (1);
+        }
+
+        client_connection_end (client, connection);
+
+        // destroy the client and its connection
+        // client_teardown_async (client);
+        // cerver_log_success ("client_teardown ()");
+
+        if (!client_teardown (client)) {
+            cerver_log_success ("client_teardown ()");
+        }
+
+        else {
+            cerver_log_error ("client_teardown () has failed!");
+        }
+    }
+
+    return NULL;
+
+}
+
+#pragma GCC diagnostic pop
+
 #pragma endregion
 
 #pragma region start
@@ -244,12 +353,13 @@ int main (void) {
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
 
-		Handler *app_handler = handler_create (cerver_app_handler);
+		Handler *app_handler = handler_create (cerver_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (client_cerver, app_handler, NULL);
 
         pthread_t client_thread = 0;
-        thread_create_detachable (&client_thread, cerver_client_request, NULL);
+        // thread_create_detachable (&client_thread, cerver_client_request, NULL);
+        thread_create_detachable (&client_thread, cerver_client_connect_and_start, NULL);
 
 		if (cerver_start (client_cerver)) {
 			char *s = c_string_create ("Failed to start %s!",
@@ -264,14 +374,10 @@ int main (void) {
 	}
 
 	else {
-		char *s = c_string_create ("Failed to create %s!",
-			client_cerver->info->name->str);
-		if (s) {
-			cerver_log_error (s);
-			free (s);
-		}
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (client_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
 
 	return 0;

--- a/examples/client.c
+++ b/examples/client.c
@@ -8,16 +8,30 @@
 #include <cerver/version.h>
 #include <cerver/cerver.h>
 
+#include <cerver/threads/thread.h>
+
 #include <cerver/utils/log.h>
 #include <cerver/utils/utils.h>
 
 typedef enum AppRequest {
 
-	TEST_MSG		= 0
+	TEST_MSG		= 0,
+
+	GET_MSG			= 1
 
 } AppRequest;
 
+// message from the cerver
+typedef struct AppMessage {
+
+	unsigned int len;
+	char message[128];
+
+} AppMessage;
+
 static Cerver *client_cerver = NULL;
+
+#pragma region end
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
@@ -30,6 +44,10 @@ static void end (int dummy) {
 	exit (0);
 
 }
+
+#pragma endregion
+
+#pragma region handler
 
 static void handle_test_request (Packet *packet) {
 
@@ -53,7 +71,7 @@ static void handle_test_request (Packet *packet) {
 
 }
 
-static void handler (void *data) {
+static void cerver_app_handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
@@ -71,6 +89,138 @@ static void handler (void *data) {
 	}
 
 }
+
+#pragma endregion
+
+#pragma region client
+
+static void client_app_handler (void *packet_ptr) {
+
+	if (packet_ptr) {
+        Packet *packet = (Packet *) packet_ptr;
+        if (packet) {
+            if (packet->data_size >= sizeof (RequestData)) {
+                RequestData *req = (RequestData *) (packet->data);
+
+                switch (req->type) {
+                    case TEST_MSG: cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Got a test message from cerver!"); break;
+
+                    case GET_MSG: {
+                        char *end = (char *) packet->data;
+                        end += sizeof (RequestData);
+
+                        AppMessage *app_message = (AppMessage *) end;
+                        printf ("%s - %d\n", app_message->message, app_message->len);
+                    } break;
+
+                    default: 
+                        cerver_log_msg (stderr, LOG_WARNING, LOG_NO_TYPE, "Got an unknown app request.");
+                        break;
+                }
+            }
+        }
+    }
+
+}
+
+static Connection *cerver_client_connect (Client *client) {
+
+    Connection *connection = NULL;
+
+    if (client) {
+        connection = client_connection_create (client, "127.0.0.1", 8007, PROTOCOL_TCP, false);
+        if (connection) {
+            connection_set_max_sleep (connection, 30);
+
+            if (!client_connect_to_cerver (client, connection)) {
+                cerver_log_msg (stdout, LOG_SUCCESS, LOG_NO_TYPE, "Connected to cerver!");
+            }
+
+            else {
+                cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to connect to cerver!");
+            }
+        }
+    }
+
+    return connection;
+
+}
+
+static int request_message (Client *client, Connection *connection) {
+
+    int retval = 1;
+
+    // manually create a packet to send
+    Packet *packet = packet_new ();
+    if (packet) {
+        size_t packet_len = sizeof (PacketHeader) + sizeof (RequestData);
+        packet->packet = malloc (packet_len);
+        packet->packet_size = packet_len;
+
+        char *end = (char *) packet->packet;
+        PacketHeader *header = (PacketHeader *) end;
+        header->protocol_id = packets_get_protocol_id ();
+        header->protocol_version = packets_get_protocol_version ();
+        header->packet_type = APP_PACKET;
+        header->packet_size = packet_len;
+        header->handler_id = 0;
+
+        end += sizeof (PacketHeader);
+        RequestData *req_data = (RequestData *) end;
+        req_data->type = GET_MSG;
+
+        printf ("Requesting to cerver...\n");
+        if (client_request_to_cerver (client, connection, packet)) {
+            cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to send message request to cerver");
+        }
+        printf ("Request has ended\n");
+
+        packet_delete (packet);
+    }
+
+    return retval;
+
+}
+
+// create a new client that will connect to a cerver & make a test request
+static void *cerver_client_request (void *args) {
+
+    Client *client = client_create ();
+    if (client) {
+        client_set_name (client, "test-client");
+
+        Handler *app_handler = handler_create (client_app_handler);
+		handler_set_direct_handle (app_handler, true);
+        client_set_app_handlers (client, app_handler, NULL);
+
+        // wait 2 seconds before connecting to cerver
+        sleep (2);
+        Connection *connection = cerver_client_connect (client);
+        
+        // send 1 request message every second
+        for (unsigned int i = 0; i < 10; i++) {
+            request_message (client, connection);
+
+            sleep (1);
+        }
+
+        // destroy the client and its connection
+        if (!client_teardown (client)) {
+            cerver_log_success ("client_teardown ()");
+        }
+
+        else {
+            cerver_log_error ("client_teardown () has failed!");
+        }
+    }
+
+    return NULL;
+
+}
+
+#pragma endregion
+
+#pragma region start
 
 int main (void) {
 
@@ -94,9 +244,12 @@ int main (void) {
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
 
-		Handler *app_handler = handler_create (handler);
+		Handler *app_handler = handler_create (cerver_app_handler);
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (client_cerver, app_handler, NULL);
+
+        pthread_t client_thread = 0;
+        thread_create_detachable (&client_thread, cerver_client_request, NULL);
 
 		if (cerver_start (client_cerver)) {
 			char *s = c_string_create ("Failed to start %s!",
@@ -124,3 +277,5 @@ int main (void) {
 	return 0;
 
 }
+
+#pragma endregion

--- a/examples/game.c
+++ b/examples/game.c
@@ -127,14 +127,10 @@ int main (void) {
 		}
 
 		else {
-			char *s = c_string_create ("Failed to create %s!",
-				my_cerver->info->name->str);
-			if (s) {
-				cerver_log_error (s);
-				free (s);
-			}
+			cerver_log_error ("Failed to create cerver!");
 
-			cerver_delete (my_cerver);
+			// DONT call - cerver_teardown () is called automatically if cerver_create () fails
+			// cerver_delete (client_cerver);
 		}
 
 		my_game_end (0);

--- a/examples/game.c
+++ b/examples/game.c
@@ -6,10 +6,12 @@
 #include <signal.h>
 
 #include <cerver/version.h>
-
 #include <cerver/cerver.h>
+
 #include <cerver/game/game.h>
 #include <cerver/game/gametype.h>
+
+#include <cerver/utils/utils.h>
 #include <cerver/utils/log.h>
 
 static Cerver *my_cerver = NULL;
@@ -112,15 +114,27 @@ int main (void) {
 			game_type_set_on_lobby_join (arcade_game_type, arcade_game_join);
 			game_type_register (game_cerver->game_types, arcade_game_type);
 
-			if (!cerver_start (my_cerver)) {
-				cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
-					"Failed to start cerver!");
+			if (cerver_start (my_cerver)) {
+				char *s = c_string_create ("Failed to start %s!",
+					my_cerver->info->name->str);
+				if (s) {
+					cerver_log_error (s);
+					free (s);
+				}
+
+				cerver_delete (my_cerver);
 			}
 		}
 
 		else {
-			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-				"Failed to create game cerver!");
+			char *s = c_string_create ("Failed to create %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
 		}
 
 		my_game_end (0);

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -154,15 +154,25 @@ int main (void) {
 		cerver_set_app_handlers (my_cerver, app_handler, app_error_handler);
 		cerver_set_custom_handler (my_cerver, app_custom_handler);
 
-		if (!cerver_start (my_cerver)) {
-			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
-				"Failed to start magic cerver!");
+		if (cerver_start (my_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
 		}
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-			"Failed to create cerver!");
+		char *s = c_string_create ("Failed to create %s!",
+			my_cerver->info->name->str);
+		if (s) {
+			cerver_log_error (s);
+			free (s);
+		}
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -167,14 +167,10 @@ int main (void) {
 	}
 
 	else {
-		char *s = c_string_create ("Failed to create %s!",
-			my_cerver->info->name->str);
-		if (s) {
-			cerver_log_error (s);
-			free (s);
-		}
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
 
 	return 0;

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -343,16 +343,12 @@ int main (void) {
 	}
 
 	else {
-		char *s = c_string_create ("Failed to create %s!",
-			my_cerver->info->name->str);
-		if (s) {
-			cerver_log_error (s);
-			free (s);
-		}
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
-
+	
 	return 0;
 
 }

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -330,15 +330,25 @@ int main (void) {
 		handler_set_data_create (handler_3, app_data_copy, app_data_3);
 		handler_set_data_delete (handler_3, app_data_delete);
 
-		if (!cerver_start (my_cerver)) {
-			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
-				"Failed to start magic cerver!");
+		if (cerver_start (my_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
 		}
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-			"Failed to create cerver!");
+		char *s = c_string_create ("Failed to create %s!",
+			my_cerver->info->name->str);
+		if (s) {
+			cerver_log_error (s);
+			free (s);
+		}
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -118,7 +118,7 @@ static void end (int dummy) {
 static void handle_test_request (Packet *packet) {
 
 	if (packet) {
-		cerver_log_debug ("Got a TEST request!");
+		cerver_log_debug ("Got a TEST request from client! Sending another one back...");
 
 		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
 		if (test_packet) {

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -237,14 +237,10 @@ int main (void) {
 	}
 
 	else {
-		char *s = c_string_create ("Failed to create %s!",
-			my_cerver->info->name->str);
-		if (s) {
-			cerver_log_error (s);
-			free (s);
-		}
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
 
 	return 0;

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -1,0 +1,242 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <time.h>
+#include <signal.h>
+
+#include <cerver/version.h>
+#include <cerver/cerver.h>
+#include <cerver/handler.h>
+
+#include <cerver/utils/utils.h>
+#include <cerver/utils/log.h>
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0,
+
+	GET_MSG			= 1
+
+} AppRequest;
+
+// data to be allocated directly in handler thread
+// also used as the data args to create a new one (a copy)
+typedef struct AppData {
+
+	int id;
+	estring *message;
+
+} AppData;
+
+// message to be sent to the client
+typedef struct AppMessage {
+
+	unsigned int len;
+	char message[128];
+
+} AppMessage;
+
+AppData *app_data_new (void) {
+
+	AppData *app_data = (AppData *) malloc (sizeof (AppData));
+	if (app_data) {
+		app_data->id = -1;
+		app_data->message = NULL;
+	}
+
+	return app_data;
+
+}
+
+void app_data_delete (void *app_data_ptr) {
+
+	if (app_data_ptr) {
+		AppData *app_data = (AppData *) app_data_ptr;
+
+		estring_delete (app_data->message);
+
+		free (app_data);
+	}
+
+}
+
+AppData *app_data_create (int id, const char *msg) {
+
+	AppData *app_data = app_data_new ();
+	if (app_data) {
+		app_data->id = id;
+		app_data->message = estring_new (msg);
+	}
+
+	return app_data;
+
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+// method that will be used to create unique handler data
+void *app_data_copy (void *app_data_args_ptr) {
+
+	AppData *handler_data = NULL;
+
+	if (app_data_args_ptr) {
+		AppData *app_data = (AppData *) app_data_args_ptr;
+
+		handler_data = app_data_new ();
+		if (handler_data) {
+			handler_data->id = app_data->id;
+			handler_data->message = estring_new (app_data->message->str);
+		}
+	}
+
+	return handler_data;
+
+}
+
+#pragma GCC diagnostic pop
+
+static Cerver *my_cerver = NULL;
+
+AppData *app_data = NULL;
+
+// correctly closes any on-going server and process when quitting the appplication
+static void end (int dummy) {
+	
+	if (my_cerver) {
+		cerver_stats_print (my_cerver);
+		cerver_teardown (my_cerver);
+
+		app_data_delete (app_data);
+	} 
+
+	exit (0);
+
+}
+
+static void handle_test_request (Packet *packet) {
+
+	if (packet) {
+		cerver_log_debug ("Got a TEST request!");
+
+		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		if (test_packet) {
+			packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, NULL);
+			size_t sent = 0;
+			if (packet_send (test_packet, 0, &sent, false)) 
+				cerver_log_error ("Failed to send test packet to client!");
+
+			else {
+				// printf ("Response packet sent: %ld\n", sent);
+			}
+			
+			packet_delete (test_packet);
+		}
+	}
+
+}
+
+static void handle_msg_request (Packet *packet, estring *msg) {
+
+	if (packet && msg) {
+		cerver_log_debug ("Got an APP DATA request!");
+
+		printf ("%s - %d\n", msg->str, msg->len);
+
+		AppMessage *app_message = (AppMessage *) malloc (sizeof (AppMessage));
+		memset (app_message, 0, sizeof (AppMessage));
+		strncpy (app_message->message, msg->str, 128);
+		app_message->len = msg->len;
+		
+		Packet *msg_packet = packet_generate_request (APP_PACKET, GET_MSG, app_message, sizeof (AppMessage));
+		if (msg_packet) {
+			packet_set_network_values (msg_packet, packet->cerver, packet->client, packet->connection, NULL);
+			size_t sent = 0;
+			if (packet_send (msg_packet, 0, &sent, false)) 
+				cerver_log_error ("Failed to send handler's message to client");
+
+			else {
+				printf ("Response packet sent: %ld\n", sent);
+			}
+			
+			packet_delete (msg_packet);
+		}
+
+		free (app_message);
+	}
+
+}
+
+static void app_packet_handler (void *data) {
+
+	if (data) {
+		HandlerData *handler_data = (HandlerData *) data;
+
+		AppData *app_data = (AppData *) handler_data->data;
+		Packet *packet = handler_data->packet;
+		if (packet) {
+			if (packet->data_size >= sizeof (RequestData)) {
+				RequestData *req = (RequestData *) (packet->data);
+
+				switch (req->type) {
+					case TEST_MSG: handle_test_request (packet); break;
+
+					case GET_MSG: handle_msg_request(packet, app_data->message); break;
+
+					default: 
+						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+						break;
+				}
+			}
+		}
+	}
+
+}
+
+int main (void) {
+
+	srand (time (NULL));
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	printf ("\n");
+	cerver_version_print_full ();
+	printf ("\n");
+
+	cerver_log_debug ("Requests Example");
+	printf ("\n");
+
+	my_cerver = cerver_create (CUSTOM_CERVER, "my-cerver", 8007, PROTOCOL_TCP, false, 2, 2000);
+	if (my_cerver) {
+		/*** cerver configuration ***/
+		cerver_set_receive_buffer_size (my_cerver, 4096);
+		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		app_data = app_data_create (0, "Hello there!");
+
+		Handler *app_handler = handler_create (app_packet_handler);
+		// handler_set_direct_handle (app_handler, true);
+		// handler_set_data_create (app_handler, app_data_copy, app_data);
+		handler_set_data (app_handler, app_data);
+		handler_set_data_delete (app_handler, app_data_delete);
+
+		cerver_set_app_handlers (my_cerver, app_handler, NULL);
+		
+		if (!cerver_start (my_cerver)) {
+			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
+				"Failed to start magic cerver!");
+		}
+	}
+
+	else {
+		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
+			"Failed to create cerver!");
+
+		cerver_delete (my_cerver);
+	}
+
+	return 0;
+
+}

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -224,15 +224,25 @@ int main (void) {
 
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 		
-		if (!cerver_start (my_cerver)) {
-			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
-				"Failed to start magic cerver!");
+		if (cerver_start (my_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
 		}
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-			"Failed to create cerver!");
+		char *s = c_string_create ("Failed to create %s!",
+			my_cerver->info->name->str);
+		if (s) {
+			cerver_log_error (s);
+			free (s);
+		}
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/test.c
+++ b/examples/test.c
@@ -112,14 +112,10 @@ int main (void) {
 	}
 
 	else {
-		char *s = c_string_create ("Failed to create %s!",
-			my_cerver->info->name->str);
-		if (s) {
-			cerver_log_error (s);
-			free (s);
-		}
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
 
 	return 0;

--- a/examples/test.c
+++ b/examples/test.c
@@ -6,9 +6,10 @@
 #include <signal.h>
 
 #include <cerver/version.h>
-
 #include <cerver/cerver.h>
+
 #include <cerver/utils/log.h>
+#include <cerver/utils/utils.h>
 
 typedef enum AppRequest {
 
@@ -98,15 +99,25 @@ int main (void) {
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 
-		if (!cerver_start (my_cerver)) {
-			cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE,
-				"Failed to start cerver!");
+		if (cerver_start (my_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
 		}
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-			"Failed to create cerver!");
+		char *s = c_string_create ("Failed to create %s!",
+			my_cerver->info->name->str);
+		if (s) {
+			cerver_log_error (s);
+			free (s);
+		}
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/welcome.c
+++ b/examples/welcome.c
@@ -51,10 +51,10 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
-			"Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        // DONT call - cerver_teardown () is called automatically if cerver_create () fails
+		// cerver_delete (client_cerver);
 	}
 
 	return 0;

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -191,6 +191,8 @@ struct _Cerver {
     // TODO: add ability to control handler execution
     // pthread_cond_t *handlers_wait;
 
+    bool check_packets;                     // enable / disbale packet checking
+
     pthread_t update_thread_id;
     Action update;                          // method to be executed every tick
     void *update_args;                      // args to pass to custom update method
@@ -281,6 +283,13 @@ extern void cerver_set_custom_handler (Cerver *cerver, struct _Handler *custom_h
 // enables the ability of the cerver to have multiple app handlers
 // returns 0 on success, 1 on error
 extern int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers);
+
+// set whether to check or not incoming packets
+// check packet's header protocol id & version compatibility
+// if packets do not pass the checks, won't be handled and will be inmediately destroyed
+// packets size must be cheked in individual methods (handlers)
+// by default, this option is turned off
+extern void cerver_set_check_packets (Cerver *cerver, bool check_packets);
 
 // sets a custom cerver update function to be executed every n ticks
 // a new thread will be created that will call your method each tick

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -36,6 +36,9 @@
 
 #define DEFAULT_SOCKETS_INIT            10
 
+#define DEFAULT_MAX_INACTIVE_TIME           60
+#define DEFAULT_CHECK_INACTIVE_INTERVAL     30
+
 struct _AdminCerver;
 struct _Auth;
 struct _Cerver;
@@ -137,6 +140,13 @@ struct _Cerver {
     // action to be performed when a new client connects
     Action on_client_connected;   
 
+    // 17/06/2020 - ability to check for inactive clients
+    // clients that have not been sent or received from a packet in x time
+    // will be automatically dropped from the cerver
+    bool inactive_clients;              // enable / disable checking
+    u32 max_inactive_time;              // max secs allowed for a client to be inactive
+    u32 check_inactive_interval;        // how often to check for inactive clients
+
     struct pollfd *fds;
     u32 max_n_fds;                      // current max n fds in pollfd
     u16 current_n_fds;                  // n of active fds in the pollfd array
@@ -201,7 +211,7 @@ struct _Cerver {
 
 typedef struct _Cerver Cerver;
 
-/*** Cerver Methods ***/
+#pragma region main
 
 extern Cerver *cerver_new (void);
 
@@ -235,6 +245,14 @@ extern void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets
 // sets an action to be performed by the cerver when a new client connects
 extern void cerver_set_on_client_connected  (Cerver *cerver, Action on_client_connected);
 
+// 17/06/2020
+// enables the ability to check for inactive clients - clients that have not been sent or received from a packet in x time
+// will be automatically dropped from the cerver
+// max_inactive_time - max secs allowed for a client to be inactive, 0 for default
+// check_inactive_interval - how often to check for inactive clients in secs, 0 for default
+extern void cerver_set_inactive_clients (Cerver *cerver, 
+    u32 max_inactive_time, u32 check_inactive_interval);
+
 // sets the cerver poll timeout in ms
 extern void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout);
 
@@ -253,7 +271,8 @@ extern void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_rec
 
 // 27/05/2020 - changed form Action to Handler
 // sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
-extern void cerver_set_app_handlers (Cerver *cerver, struct _Handler *app_handler, struct _Handler *app_error_handler);
+extern void cerver_set_app_handlers (Cerver *cerver, 
+    struct _Handler *app_handler, struct _Handler *app_error_handler);
 
 // 27/05/2020 - changed form Action to Handler
 // sets a CUSTOM_PACKET packet type handler
@@ -276,6 +295,8 @@ extern void cerver_set_update_interval (Cerver *cerver, Action update, void *upd
 // returns 0 on success, 1 on error
 extern u8 cerver_admin_enable (Cerver *cerver, u16 port, bool use_ipv6);
 
+#pragma endregion
+
 /*** sockets ***/
 
 extern int cerver_sockets_pool_push (Cerver *cerver, struct _Socket *socket);
@@ -292,7 +313,7 @@ extern void cerver_handlers_print_info (Cerver *cerver);
 // returns 0 on success, 1 on error
 extern int cerver_handlers_add (Cerver *cerver, struct _Handler *handler);
 
-/*** main **/
+#pragma region start
 
 // returns a new cerver with the specified parameters
 extern Cerver *cerver_create (const CerverType type, const char *name, 
@@ -309,6 +330,10 @@ extern u8 cerver_restart (Cerver *cerver);
 // returns 0 on success, 1 on error
 extern u8 cerver_start (Cerver *cerver);
 
+#pragma endregion
+
+#pragma region end
+
 // disable socket I/O in both ways and stop any ongoing job
 // returns 0 on success, 1 on error
 extern u8 cerver_shutdown (Cerver *cerver);
@@ -316,6 +341,8 @@ extern u8 cerver_shutdown (Cerver *cerver);
 // teardown a server -> stop the server and clean all of its data
 // returns 0 on success, 1 on error
 extern u8 cerver_teardown (Cerver *cerver);
+
+#pragma endregion
 
 // 31/01/2020 -- 11:15 -- aux structure for cerver update methods
 struct _CerverUpdate {
@@ -327,7 +354,7 @@ struct _CerverUpdate {
 
 typedef struct _CerverUpdate CerverUpdate;
 
-/*** Serialization ***/
+#pragma region serialization
 
 // serialized cerver structure
 typedef struct SCerver {
@@ -347,7 +374,9 @@ typedef struct SCerver {
 // creates a cerver info packet ready to be sent
 extern struct _Packet *cerver_packet_generate (Cerver *cerver);
 
-/*** Handler ***/
+#pragma endregion
+
+#pragma region report
 
 // information that we get from another cerver when connecting to it
 struct _CerverReport {
@@ -387,5 +416,7 @@ typedef struct SCerverReport {
 
 // handles cerver type packets
 extern void client_cerver_packet_handler (struct _Packet *packet);
+
+#pragma endregion
 
 #endif

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -146,6 +146,7 @@ struct _Cerver {
     bool inactive_clients;              // enable / disable checking
     u32 max_inactive_time;              // max secs allowed for a client to be inactive
     u32 check_inactive_interval;        // how often to check for inactive clients
+    pthread_t inactive_thread_id;
 
     struct pollfd *fds;
     u32 max_n_fds;                      // current max n fds in pollfd

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -64,7 +64,10 @@ struct _Client {
     time_t time_started;
     u64 uptime;
 
-    // custom packet handlers
+    // 16/06/2020 - custom packet handlers
+    volatile unsigned int num_handlers_alive;       // handlers currently alive
+    volatile unsigned int num_handlers_working;     // handlers currently working
+    pthread_mutex_t *handlers_lock;
     struct _Handler *app_packet_handler;
     struct _Handler *app_error_packet_handler;
     struct _Handler *custom_packet_handler;

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -7,18 +7,20 @@
 #include "cerver/types/types.h"
 #include "cerver/types/estring.h"
 
+#include "cerver/collections/avl.h"
+#include "cerver/collections/dllist.h"
+
 #include "cerver/network.h"
 #include "cerver/cerver.h"
 #include "cerver/packets.h"
 #include "cerver/connection.h"
-
-#include "cerver/collections/avl.h"
-#include "cerver/collections/dllist.h"
+#include "cerver/handler.h"
 
 struct _Cerver;
 struct _Packet;
 struct _PacketsPerType;
 struct _Connection;
+struct _Handler;
 
 struct _ClientStats {
 
@@ -58,9 +60,9 @@ struct _Client {
     u64 uptime;
 
     // custom packet handlers
-    Action app_packet_handler;
-    Action app_error_packet_handler;
-    Action custom_packet_handler;
+    struct _Handler *app_packet_handler;
+    struct _Handler *app_error_packet_handler;
+    struct _Handler *custom_packet_handler;
 
     ClientStats *stats;
 
@@ -95,9 +97,12 @@ extern void *client_get_data (Client *client);
 // deletes the previous data of the client
 extern void client_set_data (Client *client, void *data, Action delete_data);
 
-// sets the client packet handlers
+// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
 extern void client_set_handlers (Client *client, 
-    Action app_handler, Action app_error_handler, Action custom_handler);
+    struct _Handler *app_handler, struct _Handler *app_error_handler);
+
+// sets a CUSTOM_PACKET packet type handler
+extern void client_set_custom_handler (Client *client, struct _Handler *custom_handler);
 
 // compare clients based on their client ids
 extern int client_comparator_client_id (const void *a, const void *b);

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -228,6 +228,8 @@ extern unsigned int client_request_to_cerver (Client *client, struct _Connection
 // returns 0 on success request, 1 on error
 extern unsigned int client_request_to_cerver_async (Client *client, struct _Connection *connection, struct _Packet *request);
 
+/*** start ***/
+
 // starts a client connection -- used to connect a client to another server
 // returns only after a success or failed connection
 // returns 0 on success, 1 on error
@@ -237,6 +239,8 @@ extern int client_connection_start (Client *client, struct _Connection *connecti
 // returns 0 on success, 1 on error
 extern int client_connection_start_async (Client *client, Connection *connection);
 
+/*** end ***/
+
 // terminates and destroy a connection registered to a client
 // that is connected to a cerver
 // returns 0 on success, 1 on error
@@ -244,6 +248,8 @@ extern int client_connection_end (Client *client, struct _Connection *connection
 
 // stop any on going connection and process then, destroys the client
 extern u8 client_teardown (Client *client);
+
+/*** update ***/
 
 // receives incoming data from the socket and handles cerver packets
 extern void client_receive (Client *client, Connection *connection);

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -68,6 +68,8 @@ struct _Client {
 
 typedef struct _Client Client;
 
+#pragma region main
+
 extern Client *client_new (void);
 
 // completely deletes a client and all of its data
@@ -163,6 +165,8 @@ extern Client *client_get_by_session_id (struct _Cerver *cerver, char *session_i
 // broadcast a packet to all clients inside an avl structure
 extern void client_broadcast_to_all_avl (AVLNode *node, struct _Cerver *cerver, 
     struct _Packet *packet);
+
+#pragma endregion
 
 /*** Use these to connect/disconnect a client to/from another server ***/
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -61,6 +61,8 @@ struct _Client {
     // multiple connections can be associated with the same client using the same session id
     estring *session_id;
 
+    time_t last_activity;   // the last time the client sent / receive data
+
     bool drop_client;        // client failed to authenticate
 
     void *data;

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -43,6 +43,9 @@ struct _Client {
     // generated using connection values
     u64 id;
     time_t connected_timestamp;
+    
+    // 16/06/2020 - abiility to add a name to a client
+    estring *name;
 
     DoubleList *connections;
 
@@ -86,6 +89,9 @@ extern Client *client_create (void);
 // creates a new client and registers a new connection
 extern Client *client_create_with_connection (struct _Cerver *cerver, 
     const i32 sock_fd, const struct sockaddr_storage address);
+
+// sets the client's name
+extern void client_set_name (Client *client, const char *name);
 
 // sets the client's session id
 extern void client_set_session_id (Client *client, const char *session_id);

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -228,14 +228,6 @@ extern unsigned int client_request_to_cerver (Client *client, struct _Connection
 // returns 0 on success request, 1 on error
 extern unsigned int client_request_to_cerver_async (Client *client, struct _Connection *connection, struct _Packet *request);
 
-// this is a blocking method and ONLY works for cerver packets
-// connects the client connection and makes a first request to the cerver
-// then listen for packets until the target one is received, 
-// then it returns the packet data as it is
-// returns 0 on success, 1 on error
-extern int client_connection_request_to_cerver (Client *client, struct _Connection *connection, 
-    struct _Packet *request_packet);
-
 // starts a client connection -- used to connect a client to another server
 // returns only after a success or failed connection
 // returns 0 on success, 1 on error

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -282,8 +282,14 @@ extern u8 client_connect_and_start_async (Client *client, struct _Connection *co
 // returns 0 on success, 1 on error
 extern int client_connection_end (Client *client, struct _Connection *connection);
 
-// stop any on going connection and process then, destroys the client
+// stop any on going connection and process and destroys the client
+// returns 0 on success, 1 on error
 extern u8 client_teardown (Client *client);
+
+// calls client_teardown () in a new thread as handlers might need time to stop
+// that will cause the calling thread to wait at least a second
+// returns 0 on success creating thread, 1 on error
+extern u8 client_teardown_async (Client *client);
 
 /*** update ***/
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -209,6 +209,25 @@ extern unsigned int client_connect_to_cerver (Client *client, Connection *connec
 // returns 0 on success connection thread creation, 1 on error
 extern unsigned int client_connect_async (Client *client, struct _Connection *connection);
 
+/*** requests ***/
+
+// when a client is already connected to the cerver, a request can be made to the cerver
+// and the result will be returned
+// this is a blocking method, as it will wait until a complete cerver response has been received
+// the response will be handled using the client's packet handler
+// this method only works if your response consists only of one packet
+// neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
+// retruns 0 when the response has been handled, 1 on error
+extern unsigned int client_request_to_cerver (Client *client, struct _Connection *connection, struct _Packet *request);
+
+// when a client is already connected to the cerver, a request can be made to the cerver
+// the result will be placed inside the connection
+// this method will NOT block, instead EVENT_CONNECTION_DATA will be triggered
+// this method only works if your response consists only of one packet
+// neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
+// returns 0 on success request, 1 on error
+extern unsigned int client_request_to_cerver_async (Client *client, struct _Connection *connection, struct _Packet *request);
+
 // this is a blocking method and ONLY works for cerver packets
 // connects the client connection and makes a first request to the cerver
 // then listen for packets until the target one is received, 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -114,7 +114,7 @@ extern void *client_get_data (Client *client);
 extern void client_set_data (Client *client, void *data, Action delete_data);
 
 // sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
-extern void client_set_handlers (Client *client, 
+extern void client_set_app_handlers (Client *client, 
     struct _Handler *app_handler, struct _Handler *app_error_handler);
 
 // sets a CUSTOM_PACKET packet type handler
@@ -274,14 +274,6 @@ extern u8 client_teardown (Client *client);
 
 // receives incoming data from the socket and handles cerver packets
 extern void client_receive (Client *client, Connection *connection);
-
-#pragma endregion
-
-#pragma region helpers
-
-// logs a message that contains a single reference to a client's identifier
-// returns 0 on success, 1 on error
-extern u8 client_log_with_identifier (Client *client, LogMsgType log_type, const char *log_message);
 
 #pragma endregion
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -287,8 +287,9 @@ extern u8 client_teardown (Client *client);
 
 /*** update ***/
 
-// receives incoming data from the socket and handles cerver packets
-extern void client_receive (Client *client, Connection *connection);
+// receives incoming data from the socket
+// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
+extern unsigned int client_receive (Client *client, struct _Connection *connection);
 
 #pragma endregion
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -220,7 +220,7 @@ extern unsigned int client_connect (Client *client, struct _Connection *connecti
 // performs a first read to get the cerver info packet 
 // this is a blocking method, and works exactly the same as if only calling client_connect ()
 // returns 0 when the connection has been established, 1 on error or failed to connect
-extern unsigned int client_connect_to_cerver (Client *client, Connection *connection);
+extern unsigned int client_connect_to_cerver (Client *client, struct _Connection *connection);
 
 // connects a client to the host with the specified values in the connection
 // it can be a cerver or not
@@ -251,14 +251,22 @@ extern unsigned int client_request_to_cerver_async (Client *client, struct _Conn
 
 /*** start ***/
 
-// starts a client connection -- used to connect a client to another server
-// returns only after a success or failed connection
+// after a client connection successfully connects to a server, 
+// it will start the connection's update thread to enable the connection to
+// receive & handle packets in a dedicated thread
 // returns 0 on success, 1 on error
 extern int client_connection_start (Client *client, struct _Connection *connection);
 
-// starts the client connection async -- creates a new thread to handle how to connect with server
+// connects a client connection to a server
+// and after a success connection, it will start the connection (create update thread for receiving messages)
+// this is a blocking method, returns only after a success or failed connection
 // returns 0 on success, 1 on error
-extern int client_connection_start_async (Client *client, Connection *connection);
+extern int client_connect_and_start (Client *client, struct _Connection *connection);
+
+// connects a client connection to a server in a new thread to avoid blocking the calling thread,
+// and after a success connection, it will start the connection (create update thread for receiving messages)
+// returns 0 on success creating connection thread, 1 on error
+extern u8 client_connect_and_start_async (Client *client, struct _Connection *connection);
 
 /*** end ***/
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -16,6 +16,8 @@
 #include "cerver/connection.h"
 #include "cerver/handler.h"
 
+#include "cerver/utils/log.h"
+
 struct _Cerver;
 struct _Packet;
 struct _PacketsPerType;
@@ -92,6 +94,11 @@ extern Client *client_create_with_connection (struct _Cerver *cerver,
 
 // sets the client's name
 extern void client_set_name (Client *client, const char *name);
+
+// this methods is primarily used for logging
+// returns the client's name directly (if any) & should NOT be deleted, if not
+// returns a newly allocated string with the clients id that should be deleted after use
+extern char *client_get_identifier (Client *client, bool *is_name);
 
 // sets the client's session id
 extern void client_set_session_id (Client *client, const char *session_id);
@@ -264,6 +271,14 @@ extern u8 client_teardown (Client *client);
 
 // receives incoming data from the socket and handles cerver packets
 extern void client_receive (Client *client, Connection *connection);
+
+#pragma endregion
+
+#pragma region helpers
+
+// logs a message that contains a single reference to a client's identifier
+// returns 0 on success, 1 on error
+extern u8 client_log_with_identifier (Client *client, LogMsgType log_type, const char *log_message);
 
 #pragma endregion
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -19,6 +19,7 @@
 #include "cerver/utils/log.h"
 
 struct _Cerver;
+struct _Client;
 struct _Packet;
 struct _PacketsPerType;
 struct _Connection;
@@ -26,11 +27,15 @@ struct _Handler;
 
 struct _ClientStats {
 
-    time_t client_threshold_time;           // every time we want to reset the client's stats
+    time_t threshold_time;                  // every time we want to reset the client's stats
+
+    u64 n_receives_done;                    // n calls to recv ()
+
     u64 total_bytes_received;               // total amount of bytes received from this client
     u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
+
     u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
-    u64 n_packets_send;                     // total number of packets sent to this client (all connections)
+    u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
 
     struct _PacketsPerType *received_packets;
     struct _PacketsPerType *sent_packets;
@@ -38,6 +43,8 @@ struct _ClientStats {
 };
 
 typedef struct _ClientStats ClientStats;
+
+extern void client_stats_print (struct _Client *client);
 
 // anyone that connects to the cerver
 struct _Client {

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -170,8 +170,11 @@ extern void client_broadcast_to_all_avl (AVLNode *node, struct _Cerver *cerver,
 
 /*** Use these to connect/disconnect a client to/from another server ***/
 
+#pragma region client
+
 typedef struct ClientConnection {
 
+    pthread_t connection_thread_id;
     struct _Client *client;
     struct _Connection *connection;
 
@@ -182,6 +185,29 @@ extern void client_connection_aux_delete (ClientConnection *cc);
 // creates a new connection that is ready to connect and registers it to the client
 extern struct _Connection *client_connection_create (Client *client,
     const char *ip_address, u16 port, Protocol protocol, bool use_ipv6);
+
+/*** connect ***/
+
+// connects a client to the host with the specified values in the connection
+// it can be a cerver or not
+// this is a blocking method, as it will wait until the connection has been successfull or a timeout
+// user must manually handle how he wants to receive / handle incomming packets and also send requests
+// returns 0 when the connection has been established, 1 on error or failed to connect
+extern unsigned int client_connect (Client *client, struct _Connection *connection);
+
+// connects a client to the host with the specified values in the connection
+// performs a first read to get the cerver info packet 
+// this is a blocking method, and works exactly the same as if only calling client_connect ()
+// returns 0 when the connection has been established, 1 on error or failed to connect
+extern unsigned int client_connect_to_cerver (Client *client, Connection *connection);
+
+// connects a client to the host with the specified values in the connection
+// it can be a cerver or not
+// this is NOT a blocking method, a new thread will be created to wait for a connection to be established
+// open a success connection, EVENT_CONNECTED will be triggered, otherwise, EVENT_CONNECTION_FAILED will be triggered
+// user must manually handle how he wants to receive / handle incomming packets and also send requests
+// returns 0 on success connection thread creation, 1 on error
+extern unsigned int client_connect_async (Client *client, struct _Connection *connection);
 
 // this is a blocking method and ONLY works for cerver packets
 // connects the client connection and makes a first request to the cerver
@@ -210,5 +236,7 @@ extern u8 client_teardown (Client *client);
 
 // receives incoming data from the socket and handles cerver packets
 extern void client_receive (Client *client, Connection *connection);
+
+#pragma endregion
 
 #endif

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -67,6 +67,9 @@ struct _Connection {
     struct _CerverReport *cerver_report;    // 01/01/2020 - info about the cerver we are connecting to
     struct _SockReceive *sock_receive;      // 01/01/2020 - used for inter-cerver communications
 
+    // 16/06/2020 - used for direct requests to cerver
+    bool full_packet;
+
     // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
     void *received_data;                    
     size_t received_data_size;

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -86,7 +86,7 @@ struct _Connection {
     pthread_t update_thread_id;
 
     bool receive_packets;                   // set if the connection will receive packets or not (default true)
-    Action custom_receive;                  // custom receive method to handle incomming packets in the connection
+    delegate custom_receive;                // custom receive method to handle incomming packets in the connection
     void *custom_receive_args;              // arguments to be passed to the custom receive method
 
     ConnectionStats *stats;
@@ -141,7 +141,8 @@ typedef struct ConnectionCustomReceiveData {
 // sets a custom receive method to handle incomming packets in the connection
 // a reference to the client and connection will be passed to the action as ClientConnection structure
 // alongside the arguments passed to this method
-extern void connection_set_custom_receive (Connection *connection, Action custom_receive, void *args);
+// the method must return 0 on success & 1 on error
+extern void connection_set_custom_receive (Connection *connection, delegate custom_receive, void *args);
 
 // sets up the new connection values
 extern u8 connection_init (Connection *connection);

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -14,18 +14,27 @@
 
 #include "cerver/threads/thread.h"
 
+// used for connection with exponential backoff (secs)
+#define DEFAULT_CONNECTION_MAX_SLEEP                60
+#define DEFAULT_CONNECTION_PROTOCOL                 PROTOCOL_TCP
+
 struct _Socket;
 struct _Cerver;
 struct _CerverReport;
 struct _Client;
+struct _Connection;
 struct _PacketsPerType;
 struct _SockReceive;
 
 struct _ConnectionStats {
     
-    time_t connection_threshold_time;       // every time we want to reset the connection's stats
+    time_t threshold_time;                  // every time we want to reset the connection's stats
+
+    u64 n_receives_done;                    // n calls to recv ()
+
     u64 total_bytes_received;               // total amount of bytes received from this connection
     u64 total_bytes_sent;                   // total amount of bytes that have been sent to the connection
+
     u64 n_packets_received;                 // total number of packets received from this connection (packet header + data)
     u64 n_packets_sent;                     // total number of packets sent to this connection
 
@@ -38,8 +47,7 @@ typedef struct _ConnectionStats ConnectionStats;
 
 extern ConnectionStats *connection_stats_new (void);
 
-#define DEFAULT_CONNECTION_MAX_SLEEP                60        // used for connection with exponential backoff (secs)
-#define DEFAULT_CONNECTION_PROTOCOL                 PROTOCOL_TCP
+extern void connection_stats_print (struct _Connection *connection);
 
 // a connection from a client
 struct _Connection {

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -65,7 +65,8 @@ struct _Handler {
     // the jobs (packets) that are waiting to be handled - passed as args to the handler method
     JobQueue *job_queue;
 
-    struct _Cerver *cerver;      // the cerver this handler belongs to
+    struct _Cerver *cerver;     // the cerver this handler belongs to
+    struct _Client *client;     // the client this handler belongs to
 
 };
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -22,6 +22,15 @@ struct _Connection;
 struct _Lobby;
 struct _Packet;
 
+typedef enum HandlerType {
+
+    HANDLER_TYPE_NONE         = 0,
+
+    HANDLER_TYPE_CERVER       = 1,
+    HANDLER_TYPE_CLIENT       = 2
+
+} HandlerType;
+
 // the strcuture that will be passed to the handler
 typedef struct HandlerData {
 
@@ -33,6 +42,9 @@ typedef struct HandlerData {
 } HandlerData;
 
 struct _Handler {
+
+    HandlerType type;
+    int unique_id;                  // added every time a new handler gets created
 
     int id;
     pthread_t thread_id;

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -244,6 +244,7 @@ extern u8 packet_send_to_sock_fd (const Packet *packet, const i32 sock_fd,
     int flags, size_t *total_sent, bool raw);
 
 // check if packet has a compatible protocol id and a version
-extern u8 packet_check (Packet *packet);
+// returns false on a bad packet
+extern bool packet_check (Packet *packet);
 
 #endif

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.4.3"
-#define CERVER_VERSION_NAME             "Release 1.4.3"
-#define CERVER_VERSION_DATE			    "07/06/2020"
-#define CERVER_VERSION_TIME			    "21:20 CST"
+#define CERVER_VERSION                  "1.4.4"
+#define CERVER_VERSION_NAME             "Release 1.4.4"
+#define CERVER_VERSION_DATE			    "17/06/2020"
+#define CERVER_VERSION_TIME			    "08:52 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/makefile
+++ b/makefile
@@ -19,7 +19,6 @@ SRCEXT      := c
 DEPEXT      := d
 OBJEXT      := o
 
-# CFLAGS      := -g $(DEFINES)
 CFLAGS      := -g $(DEFINES) -Wall -Wno-unknown-pragmas -fPIC
 LIB         := $(PTHREAD) $(MATH) $(CMONGO)
 INC         := -I $(INCDIR) -I /usr/local/include
@@ -70,7 +69,7 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(BUILDDIR)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(BUILDDIR)/$*.$(DEPEXT)
 	@rm -f $(BUILDDIR)/$*.$(DEPEXT).tmp
 
-examples: ./examples/welcome.c ./examples/game.c ./examples/test.c ./examples/handlers.c ./examples/multi.c ./examples/requests.c ./examples/web/web.c
+examples: ./examples/welcome.c ./examples/game.c ./examples/test.c ./examples/handlers.c ./examples/multi.c ./examples/requests.c ./examples/client.c ./examples/web/web.c
 	@mkdir -p ./examples/bin
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/welcome.c -o ./examples/bin/welcome -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/game.c -o ./examples/bin/game -l cerver
@@ -78,6 +77,7 @@ examples: ./examples/welcome.c ./examples/game.c ./examples/test.c ./examples/ha
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/handlers.c -o ./examples/bin/handlers -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/multi.c -o ./examples/bin/multi -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/requests.c -o ./examples/bin/requests -l cerver
+	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/client.c -o ./examples/bin/client -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/web/web.c $(CMONGO) -o ./examples/bin/web -l cerver
 
 .PHONY: all clean examples

--- a/makefile
+++ b/makefile
@@ -70,13 +70,14 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(BUILDDIR)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(BUILDDIR)/$*.$(DEPEXT)
 	@rm -f $(BUILDDIR)/$*.$(DEPEXT).tmp
 
-examples: ./examples/welcome.c ./examples/game.c ./examples/test.c ./examples/handlers.c ./examples/multi.c ./examples/web/web.c
+examples: ./examples/welcome.c ./examples/game.c ./examples/test.c ./examples/handlers.c ./examples/multi.c ./examples/requests.c ./examples/web/web.c
 	@mkdir -p ./examples/bin
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/welcome.c -o ./examples/bin/welcome -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/game.c -o ./examples/bin/game -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/test.c -o ./examples/bin/test -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/handlers.c -o ./examples/bin/handlers -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/multi.c -o ./examples/bin/multi -l cerver
+	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/requests.c -o ./examples/bin/requests -l cerver
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/web/web.c $(CMONGO) -o ./examples/bin/web -l cerver
 
 .PHONY: all clean examples

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1324,10 +1324,9 @@ static void cerver_update (void *args) {
         cerver_log_success ("cerver_update () has started!");
         #endif
 
-        CerverUpdate *cu = cerver_update_new (cerver, cerver->update_interval_args);
+        CerverUpdate *cu = cerver_update_new (cerver, cerver->update_args);
 
-        // FIXME: use real cerver ticks
-        u32 time_per_frame = 1000000 / 15;
+        u32 time_per_frame = 1000000 / cerver->update_ticks;
         // printf ("time per frame: %d\n", time_per_frame);
         u32 temp = 0;
         i32 sleep_time = 0;
@@ -1360,7 +1359,7 @@ static void cerver_update (void *args) {
             fps++;
             // printf ("delta ticks: %ld\n", delta_ticks);
             if (delta_ticks >= 1000) {
-                printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
+                // printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
                 delta_ticks = 0;
                 fps = 0;
             }

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1343,7 +1343,7 @@ static void cerver_inactive_check (AVLNode *node, Cerver *cerver, time_t current
         Client *client = (Client *) node->id;
 
         if ((current_time - client->last_activity) >= cerver->max_inactive_time) {
-            // the client should be dropped
+            // TODO: the client should be dropped
             char *s = c_string_create ("Client %ld has been inactive more than %d secs and should be dropped",
                 client->id, cerver->max_inactive_time);
             if (s) {

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -2177,8 +2177,13 @@ void client_cerver_packet_handler (Packet *packet) {
                     cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Received a cerver info packet.");
                     #endif
                     packet->connection->cerver_report = cerver_report_deserialize ((SCerverReport *) (end += sizeof (RequestData)));
-                    if (cerver_check_info (packet->connection->cerver_report, packet->connection))
+                    if (!cerver_check_info (packet->connection->cerver_report, packet->connection)) {
+                        packet->connection->connected_to_cerver = true;
+                    }
+
+                    else {
                         cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to correctly check cerver info!");
+                    }
                 } break;
 
                 // the cerves is going to be teardown, we have to disconnect
@@ -2187,7 +2192,6 @@ void client_cerver_packet_handler (Packet *packet) {
                     cerver_log_msg (stdout, LOG_WARNING, LOG_NO_TYPE, "---> Server teardown! <---");
                     #endif
                     client_connection_end (packet->client, packet->connection);
-                    // FIXME:
                     // client_event_trigger (packet->client, EVENT_DISCONNECTED);
                     break;
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -208,6 +208,8 @@ Cerver *cerver_new (void) {
         c->client_sock_fd_map = NULL;
         c->on_client_connected = NULL;
 
+        c->inactive_clients = false;
+
         c->fds = NULL;
         c->poll_lock = NULL;
 
@@ -231,6 +233,8 @@ Cerver *cerver_new (void) {
         // 10/05/2020
         c->handlers = NULL;
         c->handlers_lock = NULL;
+
+        c->check_packets = false;
 
         c->update = NULL;
         c->update_args = NULL;
@@ -529,6 +533,19 @@ int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers) {
     }
 
     return retval;
+
+}
+
+// set whether to check or not incoming packets
+// check packet's header protocol id & version compatibility
+// if packets do not pass the checks, won't be handled and will be inmediately destroyed
+// packets size must be cheked in individual methods (handlers)
+// by default, this option is turned off
+void cerver_set_check_packets (Cerver *cerver, bool check_packets) {
+
+    if (cerver) {
+        cerver->check_packets = check_packets;
+    }
 
 }
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -38,7 +38,7 @@
 
 static void cerver_clean (Cerver *cerver);
 
-#pragma region Cerver Info
+#pragma region info
 
 static CerverInfo *cerver_info_new (void) {
 
@@ -84,7 +84,7 @@ u8 cerver_set_welcome_msg (Cerver *cerver, const char *msg) {
 
 #pragma endregion
 
-#pragma region Cerver Stats
+#pragma region stats
 
 static CerverStats *cerver_stats_new (void) {
 
@@ -124,10 +124,10 @@ void cerver_stats_print (Cerver *cerver) {
     if (cerver) {
         if (cerver->stats) {
             printf ("\nCerver's %s stats: ", cerver->info->name->str);
-            printf ("\nThreshold time:              %ld\n", cerver->stats->threshold_time);
+            printf ("Threshold time:                %ld\n", cerver->stats->threshold_time);
 
             if (cerver->auth_required) {
-                printf ("\nClient packets received:       %ld\n", cerver->stats->client_n_packets_received);
+                printf ("Client packets received:       %ld\n", cerver->stats->client_n_packets_received);
                 printf ("Client receives done:          %ld\n", cerver->stats->client_receives_done);
                 printf ("Client bytes received:         %ld\n\n", cerver->stats->client_bytes_received);
 
@@ -136,14 +136,17 @@ void cerver_stats_print (Cerver *cerver) {
                 printf ("On hold bytes received:         %ld\n\n", cerver->stats->on_hold_bytes_received);
             }
 
+            printf ("\n");
             printf ("Total packets received:        %ld\n", cerver->stats->total_n_packets_received);
             printf ("Total receives done:           %ld\n", cerver->stats->total_n_receives_done);
             printf ("Total bytes received:          %ld\n\n", cerver->stats->total_bytes_received);
 
+            printf ("\n");
             printf ("N packets sent:                %ld\n", cerver->stats->n_packets_sent);
             printf ("Total bytes sent:              %ld\n", cerver->stats->total_bytes_sent);
 
-            printf ("\nCurrent active client connections:         %ld\n", cerver->stats->current_active_client_connections);
+            printf ("\n");
+            printf ("Current active client connections:         %ld\n", cerver->stats->current_active_client_connections);
             printf ("Current connected clients:                 %ld\n", cerver->stats->current_n_connected_clients);
             printf ("Current on hold connections:               %ld\n", cerver->stats->current_n_hold_connections);
             printf ("Total clients:                             %ld\n", cerver->stats->total_n_clients);

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -954,38 +954,6 @@ unsigned int client_request_to_cerver_async (Client *client, Connection *connect
 
 #pragma endregion
 
-// this is a blocking method and ONLY works for cerver packets
-// connects the client connection and makes a first request to the cerver
-// then listen for packets until the target one is received, 
-// then it returns the packet data as it is
-// returns 0 on success, 1 on error
-int client_connection_request_to_cerver (Client *client, Connection *connection, Packet *request_packet) {
-
-    int retval = 1;
-
-    if (client && connection) {
-        // connection->sock_receive = sock_receive_new ();
-        if (!connection_connect (connection)) {
-            client_start (client);
-            connection->active = true;
-
-            // send the request to the cerver
-            packet_set_network_values (request_packet, NULL, client, connection, NULL);
-            packet_send (request_packet, 0, NULL, false);
-            // packet_delete (request_packet);
-
-            // read incoming buffer from cerver
-            while (client->running && connection->active) 
-                client_receive (client, connection);
-
-            retval = 0;
-        }
-    }
-
-    return retval;
-
-}
-
 // starts a client connection -- used to connect a client to another server
 // returns only after a success or failed connection
 // returns 0 on success, 1 on error

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -101,6 +101,11 @@ void client_delete (void *ptr) {
             else free (client->data);
         }
 
+        // 16/06/2020
+        handler_delete (client->app_packet_handler);
+        handler_delete (client->app_error_packet_handler);
+        handler_delete (client->custom_packet_handler);
+
         client_stats_delete (client->stats);
 
         free (client);
@@ -175,14 +180,29 @@ void client_set_data (Client *client, void *data, Action delete_data) {
 
 }
 
-// sets the client packet handlers
+// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
 void client_set_handlers (Client *client, 
-    Action app_handler, Action app_error_handler, Action custom_handler) {
+    Handler *app_handler, Handler *app_error_handler) {
 
     if (client) {
         client->app_packet_handler = app_handler;
+        if (client->app_packet_handler)
+            client->app_packet_handler->client = client;
+
         client->app_error_packet_handler = app_error_handler;
+        if (client->app_error_packet_handler)
+            client->app_error_packet_handler->client = client;
+    }
+
+}
+
+// sets a CUSTOM_PACKET packet type handler
+void client_set_custom_handler (Client *client, Handler *custom_handler) {
+
+    if (client) {
         client->custom_packet_handler = custom_handler;
+        if (client->custom_packet_handler)
+            client->custom_packet_handler->client = client;
     }
 
 }

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -29,6 +29,8 @@ void client_receive (Client *client, Connection *connection);
 
 static u64 next_client_id = 0;
 
+#pragma region stats
+
 static ClientStats *client_stats_new (void) {
 
     ClientStats *client_stats = (ClientStats *) malloc (sizeof (ClientStats));
@@ -52,6 +54,10 @@ static inline void client_stats_delete (ClientStats *client_stats) {
     } 
     
 }
+
+#pragma endregion
+
+#pragma region main
 
 Client *client_new (void) {
 
@@ -201,6 +207,9 @@ int client_comparator_client_id (const void *a, const void *b) {
 int client_comparator_session_id (const void *a, const void *b) {
 
     if (a && b) return estring_compare (((Client *) a)->session_id, ((Client *) b)->session_id);
+    if (a && !b) return -1;
+    if (!a && b) return 1;
+
     return 0;
 
 }
@@ -688,6 +697,10 @@ void client_broadcast_to_all_avl (AVLNode *node, Cerver *cerver, Packet *packet)
 
 }
 
+#pragma endregion
+
+#pragma region aux
+
 static ClientConnection *client_connection_aux_new (Client *client, Connection *connection) {
 
     ClientConnection *cc = (ClientConnection *) malloc (sizeof (ClientConnection));
@@ -701,6 +714,8 @@ static ClientConnection *client_connection_aux_new (Client *client, Connection *
 }
 
 void client_connection_aux_delete (ClientConnection *cc) { if (cc) free (cc); }
+
+#pragma endregion
 
 static u8 client_start (Client *client) {
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -1495,6 +1495,7 @@ static void client_app_packet_handler (Packet *packet) {
             if (packet->client->app_packet_handler->direct_handle) {
                 // printf ("app_packet_handler - direct handle!\n");
                 packet->client->app_packet_handler->handler (packet);
+                packet_delete (packet);
             }
 
             else {
@@ -1535,6 +1536,7 @@ static void client_app_error_packet_handler (Packet *packet) {
             if (packet->client->app_error_packet_handler->direct_handle) {
                 // printf ("app_error_packet_handler - direct handle!\n");
                 packet->client->app_error_packet_handler->handler (packet);
+                packet_delete (packet);
             }
 
             else {
@@ -1575,6 +1577,7 @@ static void client_custom_packet_handler (Packet *packet) {
             if (packet->client->custom_packet_handler->direct_handle) {
                 // printf ("custom_packet_handler - direct handle!\n");
                 packet->client->custom_packet_handler->handler (packet);
+                packet_delete (packet);
             }
 
             else {
@@ -1678,7 +1681,17 @@ static void client_packet_handler (void *data) {
             }
         // }
 
-        packet_delete (packet);
+        switch (packet->header->packet_type) {
+            case APP_PACKET:
+            case APP_ERROR_PACKET:
+            case CUSTOM_PACKET:
+                // do nothing - packet gets deleted in handler method
+                break;
+
+            default:
+                packet_delete (packet);
+                break;
+        }
     }
 
 }

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -55,6 +55,41 @@ static inline void client_stats_delete (ClientStats *client_stats) {
     
 }
 
+void client_stats_print (Client *client) {
+
+    if (client) {
+        if (client->stats) {
+            printf ("\nClient's stats:\n");
+            printf ("Threshold time:            %ld\n", client->stats->threshold_time);
+
+            printf ("N receives done:           %ld\n", client->stats->n_receives_done);
+
+            printf ("Total bytes received:      %ld\n", client->stats->total_bytes_received);
+            printf ("Total bytes sent:          %ld\n", client->stats->total_bytes_sent);
+
+            printf ("N packets received:        %ld\n", client->stats->n_packets_received);
+            printf ("N packets sent:            %ld\n", client->stats->n_packets_sent);
+
+            printf ("\nReceived packets:\n");
+            packets_per_type_print (client->stats->received_packets);
+
+            printf ("\nSent packets:\n");
+            packets_per_type_print (client->stats->sent_packets);
+        }
+
+        else {
+            cerver_log_msg (stderr, LOG_ERROR, LOG_CLIENT, 
+                "Client does not have a reference to a client stats!");
+        }
+    }
+
+    else {
+        cerver_log_msg (stderr, LOG_WARNING, LOG_CLIENT, 
+            "Can't get stats of a NULL client!");
+    }
+
+}
+
 #pragma endregion
 
 #pragma region main
@@ -1916,11 +1951,11 @@ void client_receive (Client *client, Connection *connection) {
                     //     free (s);
                     // }
 
-                    // client->stats->n_receives_done += 1;
+                    client->stats->n_receives_done += 1;
                     client->stats->total_bytes_received += rc;
 
-                    // connection->stats->n_receives_done += 1;
-                    // connection->stats->total_bytes_received += rc;
+                    connection->stats->n_receives_done += 1;
+                    connection->stats->total_bytes_received += rc;
 
                     // handle the recived packet buffer -> split them in packets of the correct size
                     client_receive_handle_buffer (

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -1675,30 +1675,35 @@ static void client_packet_handler (void *data) {
                 case CERVER_PACKET:
                     // packet->client->stats->received_packets->n_cerver_packets += 1; 
                     client_cerver_packet_handler (packet); 
+                    packet_delete (packet);
                     break;
 
                 // handles an error from the server
                 case ERROR_PACKET: 
                     packet->client->stats->received_packets->n_error_packets += 1;
                     // error_packet_handler (packet); 
+                    packet_delete (packet);
                     break;
 
                 // handles authentication packets
                 case AUTH_PACKET: 
                     packet->client->stats->received_packets->n_auth_packets += 1;
                     // client_auth_packet_handler (packet); 
+                    packet_delete (packet);
                     break;
 
                 // handles a request made from the server
                 case REQUEST_PACKET: 
                     // packet->client->stats->received_packets->n_request_packets += 1; 
                     // client_request_packet_handler (packet);
+                    packet_delete (packet);
                     break;
 
                 // handles a game packet sent from the server
                 case GAME_PACKET: 
                     // packet->client->stats->received_packets->n_game_packets += 1;
                     // client_game_packet_handler (packet);
+                    packet_delete (packet);
                     break;
 
                 // user set handler to handler app specific packets
@@ -1723,6 +1728,7 @@ static void client_packet_handler (void *data) {
                 case TEST_PACKET: 
                     packet->client->stats->received_packets->n_test_packets += 1;
                     cerver_log_msg (stdout, LOG_TEST, LOG_NO_TYPE, "Got a test packet from cerver.");
+                    packet_delete (packet);
                     break;
 
                 default:
@@ -1730,21 +1736,10 @@ static void client_packet_handler (void *data) {
                     #ifdef CERVER_DEBUG
                     cerver_log_msg (stdout, LOG_WARNING, LOG_NO_TYPE, "Got a packet of unknown type.");
                     #endif
+                    packet_delete (packet);
                     break;
             }
         // }
-
-        switch (packet->header->packet_type) {
-            case APP_PACKET:
-            case APP_ERROR_PACKET:
-            case CUSTOM_PACKET:
-                // do nothing - packet gets deleted in handler method
-                break;
-
-            default:
-                packet_delete (packet);
-                break;
-        }
     }
 
 }

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -705,6 +705,7 @@ static ClientConnection *client_connection_aux_new (Client *client, Connection *
 
     ClientConnection *cc = (ClientConnection *) malloc (sizeof (ClientConnection));
     if (cc) {
+        cc->connection_thread_id = 0;   
         cc->client = client;
         cc->connection = connection;
     }
@@ -716,6 +717,8 @@ static ClientConnection *client_connection_aux_new (Client *client, Connection *
 void client_connection_aux_delete (ClientConnection *cc) { if (cc) free (cc); }
 
 #pragma endregion
+
+#pragma region client
 
 static u8 client_start (Client *client) {
 
@@ -752,6 +755,106 @@ Connection *client_connection_create (Client *client,
     return connection;
 
 }
+
+#pragma region connect
+
+// connects a client to the host with the specified values in the connection
+// it can be a cerver or not
+// this is a blocking method, as it will wait until the connection has been successfull or a timeout
+// user must manually handle how he wants to receive / handle incomming packets and also send requests
+// returns 0 when the connection has been established, 1 on error or failed to connect
+unsigned int client_connect (Client *client, Connection *connection) {
+
+    unsigned int retval = 1;
+
+    if (client && connection) {
+        if (!connection_connect (connection)) {
+            // client_event_trigger (client, EVENT_CONNECTED);
+            // connection->connected = true;
+            connection->active = true;
+            time (&connection->connected_timestamp);
+            
+            client_start (client);
+
+            retval = 0;     // success - connected to cerver
+        }
+    }
+
+    return retval;
+
+}
+
+// connects a client to the host with the specified values in the connection
+// performs a first read to get the cerver info packet 
+// this is a blocking method, and works exactly the same as if only calling client_connect ()
+// returns 0 when the connection has been established, 1 on error or failed to connect
+unsigned int client_connect_to_cerver (Client *client, Connection *connection) {
+
+    unsigned int retval = 1;
+
+    if (!client_connect (client, connection)) {
+        client_receive (client, connection);
+
+        retval = 0;
+    }
+
+    return retval;
+
+}
+
+static void *client_connect_thread (void *client_connection_ptr) {
+
+    if (client_connection_ptr) {
+        ClientConnection *cc = (ClientConnection *) client_connection_ptr;
+
+        if (!connection_connect (cc->connection)) {
+            // client_event_trigger (cc->client, EVENT_CONNECTED);
+            // cc->connection->connected = true;
+            cc->connection->active = true;
+            time (&cc->connection->connected_timestamp);
+            
+            client_start (cc->client);
+        }
+
+        client_connection_aux_delete (cc);
+    }
+
+    return NULL;
+
+}
+
+// connects a client to the host with the specified values in the connection
+// it can be a cerver or not
+// this is NOT a blocking method, a new thread will be created to wait for a connection to be established
+// open a success connection, EVENT_CONNECTED will be triggered, otherwise, EVENT_CONNECTION_FAILED will be triggered
+// user must manually handle how he wants to receive / handle incomming packets and also send requests
+// returns 0 on success connection thread creation, 1 on error
+unsigned int client_connect_async (Client *client, Connection *connection) {
+
+    unsigned int retval = 1;
+
+    if (client && connection) {
+        ClientConnection *cc = client_connection_aux_new (client, connection);
+        if (cc) {
+            if (!thread_create_detachable (&cc->connection_thread_id, client_connect_thread, cc)) {
+                retval = 0;         // success
+            }
+
+            else {
+                #ifdef CLIENT_DEBUG
+                client_log_error ("Failed to create client_connect_thread () detachable thread!");
+                #endif
+            }
+        }
+    }
+
+    return retval;
+
+}
+
+#pragma endregion
+
+#pragma endregion
 
 // this is a blocking method and ONLY works for cerver packets
 // connects the client connection and makes a first request to the cerver

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -63,9 +63,10 @@ Client *client_new (void) {
 
     Client *client = (Client *) malloc (sizeof (Client));
     if (client) {
-        memset (client, 0, sizeof (Client));
-
+        client->id = 0;
         client->session_id = NULL;
+
+        client->name = NULL;
 
         client->connections = NULL;
 
@@ -75,6 +76,8 @@ Client *client_new (void) {
         client->delete_data = NULL;
 
         client->running = false;
+        client->time_started = 0;
+        client->uptime = 0;
 
         client->app_packet_handler = NULL;
         client->app_error_packet_handler = NULL;
@@ -93,6 +96,8 @@ void client_delete (void *ptr) {
         Client *client = (Client *) ptr;
 
         estring_delete (client->session_id);
+
+        estring_delete (client->name);
 
         dlist_delete (client->connections);
 
@@ -148,6 +153,16 @@ Client *client_create_with_connection (Cerver *cerver,
     }
 
     return client;
+
+}
+
+// sets the client's name
+void client_set_name (Client *client, const char *name) {
+
+    if (client) {
+        if (client->name) estring_delete (client->name);
+        client->name = name ? estring_new (name) : NULL;
+    }
 
 }
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -854,6 +854,104 @@ unsigned int client_connect_async (Client *client, Connection *connection) {
 
 #pragma endregion
 
+#pragma region requests
+
+// when a client is already connected to the cerver, a request can be made to the cerver
+// and the result will be returned
+// this is a blocking method, as it will wait until a complete cerver response has been received
+// the response will be handled using the client's packet handler
+// this method only works if your response consists only of one packet
+// neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
+// retruns 0 when the response has been handled, 1 on error
+unsigned int client_request_to_cerver (Client *client, Connection *connection, Packet *request) {
+
+    unsigned int retval = 1;
+
+    if (client && connection && request) {
+        // send the request to the cerver
+        packet_set_network_values (request, client, connection);
+
+        size_t sent = 0;
+        if (!packet_send (request, 0, &sent, false)) {
+            printf ("Request to cerver: %ld\n", sent);
+
+            // receive the data directly
+            connection->full_packet = false;
+            while (!connection->full_packet) {
+                client_receive (client, connection);
+            }
+
+            retval = 0;
+        }
+
+        else {
+            #ifdef CLIENT_DEBUG
+            client_log_error ("client_request_to_cerver () - failed to send request packet!");
+            #endif
+        }
+    }
+
+    return retval;
+
+}
+
+static void *client_request_to_cerver_thread (void *cc_ptr) {
+
+    if (cc_ptr) {
+        ClientConnection *cc = (ClientConnection *) cc_ptr;
+
+        cc->connection->full_packet = false;
+        while (!cc->connection->full_packet) {
+            client_receive (cc->client, cc->connection);
+        }
+
+        client_connection_aux_delete (cc);
+    }
+
+    return NULL;
+
+}
+
+// when a client is already connected to the cerver, a request can be made to the cerver
+// the result will be placed inside the connection
+// this method will NOT block and the response will be handled using the client's packet handler
+// this method only works if your response consists only of one packet
+// neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
+// returns 0 on success request, 1 on error
+unsigned int client_request_to_cerver_async (Client *client, Connection *connection, Packet *request) {
+
+    unsigned int retval = 1;
+
+    if (client && connection && request) {
+        // send the request to the cerver
+        packet_set_network_values (request, NULL, client, connection, NULL);
+        if (!packet_send (request, 0, NULL, false)) {
+            ClientConnection *cc = client_connection_aux_new (client, connection);
+            if (cc) {
+                // create a new thread to receive & handle the response
+                if (!thread_create_detachable (&cc->connection_thread_id, client_request_to_cerver_thread, cc)) {
+                    retval = 0;         // success
+                }
+
+                else {
+                    #ifdef CLIENT_DEBUG
+                    client_log_error ("Failed to create client_request_to_cerver_thread () detachable thread!");
+                    #endif
+                }
+            }
+        }
+
+        else {
+            #ifdef CLIENT_DEBUG
+            client_log_error ("client_request_to_cerver_async () - failed to send request packet!");
+            #endif
+        }
+    }
+
+    return retval;
+
+}
+
 #pragma endregion
 
 // this is a blocking method and ONLY works for cerver packets

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -869,7 +869,7 @@ unsigned int client_request_to_cerver (Client *client, Connection *connection, P
 
     if (client && connection && request) {
         // send the request to the cerver
-        packet_set_network_values (request, client, connection);
+        packet_set_network_values (request, NULL, client, connection, NULL);
 
         size_t sent = 0;
         if (!packet_send (request, 0, &sent, false)) {

--- a/src/cerver/connection.c
+++ b/src/cerver/connection.c
@@ -21,6 +21,8 @@
 #include "cerver/utils/log.h"
 #include "cerver/utils/utils.h"
 
+#pragma region stats
+
 ConnectionStats *connection_stats_new (void) {
 
     ConnectionStats *stats = (ConnectionStats *) malloc (sizeof (ConnectionStats));
@@ -44,6 +46,45 @@ static inline void connection_stats_delete (ConnectionStats *stats) {
     } 
     
 }
+
+void connection_stats_print (Connection *connection) {
+
+    if (connection) {
+        if (connection->stats) {
+            printf ("\nConnection's stats:\n");
+            printf ("Threshold time:            %ld\n", connection->stats->threshold_time);
+
+            printf ("N receives done:           %ld\n", connection->stats->n_receives_done);
+
+            printf ("Total bytes received:      %ld\n", connection->stats->total_bytes_received);
+            printf ("Total bytes sent:          %ld\n", connection->stats->total_bytes_sent);
+
+            printf ("N packets received:        %ld\n", connection->stats->n_packets_received);
+            printf ("N packets sent:            %ld\n", connection->stats->n_packets_sent);
+
+            printf ("\nReceived packets:\n");
+            packets_per_type_print (connection->stats->received_packets);
+
+            printf ("\nSent packets:\n");
+            packets_per_type_print (connection->stats->sent_packets);
+        }
+
+        else {
+            cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, 
+                "Connection does not have a reference to a connection stats!");
+        }
+    }
+
+    else {
+        cerver_log_msg (stderr, LOG_WARNING, LOG_NO_TYPE, 
+            "Can't get stats of a NULL connection!");
+    }
+
+}
+
+#pragma endregion
+
+#pragma region main
 
 Connection *connection_new (void) {
 
@@ -639,3 +680,5 @@ void connection_update (void *ptr) {
     }
 
 }
+
+#pragma endregion

--- a/src/cerver/connection.c
+++ b/src/cerver/connection.c
@@ -69,6 +69,8 @@ Connection *connection_new (void) {
         connection->cerver_report = NULL;
         connection->sock_receive = NULL;
 
+        connection->full_packet = false;
+
         connection->received_data = NULL;
         connection->received_data_delete = NULL;
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -68,6 +68,7 @@ static Handler *handler_new (void) {
         handler->job_queue = NULL;
 
         handler->cerver = NULL;
+        handler->client = NULL;
     }
 
     return handler;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1304,6 +1304,8 @@ void cerver_receive (void *ptr) {
                     cr->cerver->stats->total_n_receives_done += 1;
                     cr->cerver->stats->total_bytes_received += rc;
 
+                    // TODO: also update client & connection stats
+
                     // handle the received packet buffer -> split them in packets of the correct size
                     ReceiveHandle *receive = receive_handle_new (
                         cr->cerver,

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -717,7 +717,12 @@ static void cerver_packet_handler (void *ptr) {
         packet->cerver->stats->total_n_packets_received += 1;
         if (packet->lobby) packet->lobby->stats->n_packets_received += 1;
 
-        // if (!packet_check (packet)) {
+        bool good = true;
+        if (packet->cerver->check_packets) {
+            good = packet_check (packet);
+        }
+
+        if (good) {
             switch (packet->header->packet_type) {
                 // handles an error from the client
                 case ERROR_PACKET: 
@@ -811,7 +816,7 @@ static void cerver_packet_handler (void *ptr) {
                     packet_delete (packet);
                 } break;
             }
-        // }
+        }
     }
 
 }

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -474,7 +474,7 @@ void cerver_test_packet_handler (Packet *packet) {
 
 // 27/01/2020
 // handles a APP_PACKET packet type
-static void app_packet_handler (Packet *packet) {
+static void cerver_app_packet_handler (Packet *packet) {
 
     if (packet) {
         // 11/05/2020
@@ -538,7 +538,7 @@ static void app_packet_handler (Packet *packet) {
 
 // 27/05/2020
 // handles a APP_ERROR_PACKET packet type
-static void app_error_packet_handler (Packet *packet) {
+static void cerver_app_error_packet_handler (Packet *packet) {
 
     if (packet) {
         if (packet->cerver->app_error_packet_handler) {
@@ -578,7 +578,7 @@ static void app_error_packet_handler (Packet *packet) {
 
 // 27/05/2020
 // handles a CUSTOM_PACKET packet type
-static void custom_packet_handler (Packet *packet) {
+static void cerver_custom_packet_handler (Packet *packet) {
 
     if (packet) {
         if (packet->cerver->custom_packet_handler) {
@@ -669,7 +669,7 @@ static void cerver_packet_handler (void *ptr) {
                     packet->client->stats->received_packets->n_app_packets += 1;
                     packet->connection->stats->received_packets->n_app_packets += 1;
                     if (packet->lobby) packet->lobby->stats->received_packets->n_app_packets += 1;
-                    app_packet_handler (packet);
+                    cerver_app_packet_handler (packet);
                     break;
 
                 // user set handler to handle app specific errors
@@ -678,7 +678,7 @@ static void cerver_packet_handler (void *ptr) {
                     packet->client->stats->received_packets->n_app_error_packets += 1;
                     packet->connection->stats->received_packets->n_app_error_packets += 1;
                     if (packet->lobby) packet->lobby->stats->received_packets->n_app_error_packets += 1;
-                    app_error_packet_handler (packet);
+                    cerver_app_error_packet_handler (packet);
                     break;
 
                 // custom packet hanlder
@@ -687,7 +687,7 @@ static void cerver_packet_handler (void *ptr) {
                     packet->client->stats->received_packets->n_custom_packets += 1;
                     packet->connection->stats->received_packets->n_custom_packets += 1;
                     if (packet->lobby) packet->lobby->stats->received_packets->n_custom_packets += 1;
-                    custom_packet_handler (packet);
+                    cerver_custom_packet_handler (packet);
                     break;
 
                 // acknowledge the client we have received his test packet

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -628,31 +628,34 @@ u8 packet_send_to_sock_fd (const Packet *packet, const i32 sock_fd,
 }
 
 // check if packet has a compatible protocol id and a version
-// returns 0 on success, 1 on error
-u8 packet_check (Packet *packet) {
+// returns false on a bad packet
+bool packet_check (Packet *packet) {
 
-    u8 errors = 0;
+    bool retval = false;
 
     if (packet) {
         PacketHeader *header = packet->header;
 
-        if (header->protocol_id != protocol_id) {
+        if (header->protocol_id == protocol_id) {
+            if ((header->protocol_version.major > protocol_version.major)
+                || (header->protocol_version.minor > protocol_version.minor)) {
+                retval = true;
+            }
+
+            else {
+                #ifdef CERVER_DEBUG
+                cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with incompatible version.");
+                #endif
+            }
+        }
+
+        else {
             #ifdef CERVER_DEBUG
             cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with unknown protocol ID.");
             #endif
-            errors |= 1;
-        }
-
-        if (header->protocol_version.major != protocol_version.major) {
-            #ifdef CERVER_DEBUG
-            cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with incompatible version.");
-            #endif
-            errors |= 1;
         }
     }
 
-    else errors |= 1;
-
-    return errors;
+    return retval;
 
 }

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -477,7 +477,7 @@ static void packet_send_update_stats (PacketType packet_type, size_t sent,
     }
 
     if (client) {
-        client->stats->n_packets_send += 1;
+        client->stats->n_packets_sent += 1;
         client->stats->total_bytes_sent += sent;
     }
 


### PR DESCRIPTION
## General
- Added full_packet filed in connection structure
- Added handler types
- Added additional checks when creating cerver handlers
- Refactor handler methods to correctly manage cerver & client structures
- Added client & connection print stats methods
- Added cerver_set_check_packets () & refactor refactor packet_check ()

### Clients
- Added new client connect & request methods from latest cerver client
- Removed old client_connection_request_to_cerver ()
- Refactor internal client handler methods
- Changed client handlers from actions to Handlers
- Added the ability to set client's name
- Refactor client start & end methods

## Examples
- Added new requests example
- Fixed examples checks when creating & starting cerver
- Added new base client example top showcase how to connect cerver to another one using a client (the same way as cerver-client does it)

## Fixes
- Fixed errors in cerver_update ()
- Fixed segfault caused for incorrect packet delete in client handlers
- Default & custom client receive methods must have a return value. This fixes a segfault caused by no handling correctly when client_receive_handle_failed () is called due to a failure in recv ()
- Fixed connection->connected_to_cerver which remained unset
- Fixed how packets get deleted in both cerver & client packet_handlers

## Experimental 
**Subroutine to check for inactive clients - Issue #9**

Due to time limitations and the need to roll version 1.4.4 to production, this issue will be remain as experimental and should not be used until further notice.
This feature will surely require some refactor in cerver handler methods as described in Issue #50 for greater performance than the one available with current methods.