### PR TITLE
Critical fixes in handler

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -251,20 +251,22 @@ static int test_app_msg_send (Client *client, Connection *connection) {
 
     int retval = 1;
 
-    Packet *packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
-    if (packet) {
-        packet_set_network_values (packet, NULL, client, connection, NULL);
-        size_t sent = 0;
-        if (packet_send (packet, 0, &sent, false)) {
-            cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to send test to cerver");
+    if ((client->running) && connection->active) {
+        Packet *packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+        if (packet) {
+            packet_set_network_values (packet, NULL, client, connection, NULL);
+            size_t sent = 0;
+            if (packet_send (packet, 0, &sent, false)) {
+                cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to send test to cerver");
+            }
+
+            else {
+                printf ("APP_PACKET sent to cerver: %ld\n", sent);
+                retval = 0;
+            } 
+
+            packet_delete (packet);
         }
-
-        else {
-            printf ("APP_PACKET sent to cerver: %ld\n", sent);
-            retval = 0;
-        } 
-
-        packet_delete (packet);
     }
 
     return retval;

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -279,6 +279,11 @@ extern u8 client_connect_and_start_async (Client *client, struct _Connection *co
 
 /*** end ***/
 
+// terminates the connection & closes the socket
+// but does NOT destroy the current connection
+// returns 0 on success, 1 on error
+extern int client_connection_close (Client *client, Connection *connection);
+
 // terminates and destroy a connection registered to a client
 // that is connected to a cerver
 // returns 0 on success, 1 on error

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -81,6 +81,9 @@ struct _Client {
     struct _Handler *app_error_packet_handler;
     struct _Handler *custom_packet_handler;
 
+    // 17/06/2020 - general client lock
+    pthread_mutex_t *lock;
+
     ClientStats *stats;
 
 };

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -18,6 +18,8 @@
 #define DEFAULT_CONNECTION_MAX_SLEEP                60
 #define DEFAULT_CONNECTION_PROTOCOL                 PROTOCOL_TCP
 
+#define DEFAULT_CONNECTION_UPDATE_SLEEP             200000
+
 struct _Socket;
 struct _Cerver;
 struct _CerverReport;
@@ -84,6 +86,7 @@ struct _Connection {
     Action received_data_delete;
 
     pthread_t update_thread_id;
+    u32 update_sleep;
 
     bool receive_packets;                   // set if the connection will receive packets or not (default true)
     delegate custom_receive;                // custom receive method to handle incomming packets in the connection
@@ -129,6 +132,10 @@ extern void connection_set_receive_buffer_size (Connection *connection, u32 size
 // sets the connection received data
 // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
 extern void connection_set_received_data (Connection *connection, void *data, size_t data_size, Action data_delete);
+
+// 17/06/2020
+// sets the waiting time (sleep) between each call to recv () in connection_update () thread
+extern void connection_set_update_sleep (Connection *connection, u32 sleep);
 
 typedef struct ConnectionCustomReceiveData {
 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.4.4"
-#define CERVER_VERSION_NAME             "Release 1.4.4"
-#define CERVER_VERSION_DATE			    "17/06/2020"
-#define CERVER_VERSION_TIME			    "08:52 CST"
+#define CERVER_VERSION                  "1.4.5"
+#define CERVER_VERSION_NAME             "Release 1.4.5"
+#define CERVER_VERSION_DATE			    "18/06/2020"
+#define CERVER_VERSION_TIME			    "03:08 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -2346,7 +2346,8 @@ void client_cerver_packet_handler (Packet *packet) {
                     #ifdef CERVER_DEBUG
                     cerver_log_msg (stdout, LOG_WARNING, LOG_NO_TYPE, "---> Server teardown! <---");
                     #endif
-                    client_connection_end (packet->client, packet->connection);
+                    client_connection_close (packet->client, packet->connection);
+                    // client_connection_end (packet->client, packet->connection);
                     // client_event_trigger (packet->client, EVENT_DISCONNECTED);
                     break;
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -1368,8 +1368,6 @@ static void client_connection_terminate (Client *client, Connection *connection)
                     packet_delete (packet);
                 }
             }
-
-            connection_end (connection);
         } 
     }
 
@@ -1392,6 +1390,22 @@ static int client_connection_drop (Client *client, Connection *connection) {
 
 }
 
+// terminates the connection & closes the socket
+// but does NOT destroy the current connection
+// returns 0 on success, 1 on error
+int client_connection_close (Client *client, Connection *connection) {
+
+    int retval = 1;
+
+    if (client && connection) {
+        client_connection_terminate (client, connection);
+        connection_end (connection);
+    }
+
+    return retval;
+
+}
+
 // terminates and destroy a connection registered to a client
 // that is connected to a cerver
 // returns 0 on success, 1 on error
@@ -1400,7 +1414,7 @@ int client_connection_end (Client *client, Connection *connection) {
     int retval = 1;
 
     if (client && connection) {
-        client_connection_terminate (client, connection);
+        client_connection_close (client, connection);
         retval = client_connection_drop (client, connection);
     }
 
@@ -1487,7 +1501,7 @@ static void *client_teardown_internal (void *client_ptr) {
 
         // end any ongoing connection
         for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            client_connection_terminate (client, (Connection *) le->data);
+            client_connection_close (client, (Connection *) le->data);
         }
 
         client_handlers_destroy (client);

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1786,9 +1786,11 @@ static inline void cerver_poll_handle (Cerver *cerver) {
                     } break;
 
                     default: {
-                        // 17/06/2020 -- 15:06 -- handle as failed any other signal
-                        // to avoid hanging up at 100% or getting a segfault
-                        cerver_switch_receive_handle_failed (cr);
+                        if (cerver->fds[i].revents != 0) {
+                            // 17/06/2020 -- 15:06 -- handle as failed any other signal
+                            // to avoid hanging up at 100% or getting a segfault
+                            cerver_switch_receive_handle_failed (cr);
+                        }
                     } break;
                 }
             }

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1805,7 +1805,7 @@ u8 cerver_poll (Cerver *cerver) {
     u8 retval = 1;
 
     if (cerver) {
-        char *s = c_string_create ("Cerver %s main handler has started!", cerver->info->name->str);
+        char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
         if (s) {
             cerver_log_msg (stdout, LOG_SUCCESS, LOG_CERVER, s);
             free (s);

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -6,7 +6,7 @@
 #include "cerver/network.h"
 
 // enable/disable blocking on a socket
-// true on LOG_SUCCESS, false if there was an eroror
+// true on success, false if there was an eroror
 bool sock_set_blocking (int32_t fd, bool isBlocking) {
 
     if (fd < 0) return false;

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -582,7 +582,7 @@ u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw) {
                     printf ("\n");
                     #endif
 
-                    if (packet->connection) packet->cerver->stats->sent_packets->n_bad_packets += 1;
+                    if (packet->cerver) packet->cerver->stats->sent_packets->n_bad_packets += 1;
                     if (packet->client) packet->client->stats->sent_packets->n_bad_packets += 1;
                     if (packet->connection) packet->connection->stats->sent_packets->n_bad_packets += 1;
 


### PR DESCRIPTION
## General
- Added client_connection_close () and refactor client end methods
- Added client general purpose mutex
- Refactor connection_update () to set socket to non-blocking. This was done to prevent hanging up when calling for client_teardown () and waiting for mutex to be available from original blocking recv () behavior 

## Fixes
- Fixed critical errors in handler
    - Handling default case (!= 0) in cerver_poll_handle () switch as failed by calling cerver_switch_receive_handle_failed (). 
    - Added extra if statement in cerver_receive_handle_failed () to check if cr->socket is NOT NULL
- Fixed error in packet_send ()