### PR TITLE
Update with Release 1.5-rc13

### DIFF
--- a/examples/admin.c
+++ b/examples/admin.c
@@ -73,16 +73,12 @@ static void admin_handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
 
-			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
-
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+				break;
 		}
 	}
 

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -72,16 +72,12 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
 
-			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
-
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+				break;
 		}
 	}
 

--- a/examples/client.c
+++ b/examples/client.c
@@ -171,8 +171,6 @@ static int request_message (Client *client, Connection *connection) {
 
         char *end = (char *) packet->packet;
         PacketHeader *header = (PacketHeader *) end;
-        header->protocol_id = packets_get_protocol_id ();
-        header->protocol_version = packets_get_protocol_version ();
         header->packet_type = APP_PACKET;
         header->packet_size = packet_len;
         header->handler_id = 0;

--- a/examples/client.c
+++ b/examples/client.c
@@ -75,17 +75,14 @@ static void cerver_app_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
 
-			switch (req->type) {
-				case TEST_MSG: cerver_handle_test_request (packet); break;
+		switch (packet->header->request_type) {
+            case TEST_MSG: cerver_handle_test_request (packet); break;
 
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
-		}
+            default: 
+                cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+                break;
+        }
 	}
 
 }
@@ -99,24 +96,19 @@ static void client_app_handler_direct (void *packet_ptr) {
 	if (packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
         if (packet) {
-            if (packet->data_size >= sizeof (RequestData)) {
-                RequestData *req = (RequestData *) (packet->data);
+            switch (packet->header->request_type) {
+                case TEST_MSG: cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Got a test message from cerver!"); break;
 
-                switch (req->type) {
-                    case TEST_MSG: cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Got a test message from cerver!"); break;
+                case GET_MSG: {
+                    char *end = (char *) packet->data;
 
-                    case GET_MSG: {
-                        char *end = (char *) packet->data;
-                        end += sizeof (RequestData);
+                    AppMessage *app_message = (AppMessage *) end;
+                    printf ("%s - %d\n", app_message->message, app_message->len);
+                } break;
 
-                        AppMessage *app_message = (AppMessage *) end;
-                        printf ("%s - %d\n", app_message->message, app_message->len);
-                    } break;
-
-                    default: 
-                        cerver_log_msg (stderr, LOG_WARNING, LOG_NO_TYPE, "Got an unknown app request.");
-                        break;
-                }
+                default: 
+                    cerver_log_msg (stderr, LOG_WARNING, LOG_NO_TYPE, "Got an unknown app request.");
+                    break;
             }
         }
     }
@@ -130,19 +122,15 @@ static void client_app_handler (void *data) {
 
         // AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
+        switch (packet->header->request_type) {
+            case TEST_MSG: {
+                cerver_log_debug ("Got a test message from cerver!");
+            } break;
 
-			switch (req->type) {
-				case TEST_MSG: {
-                    cerver_log_debug ("Got a test message from cerver!");
-                } break;
-
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
-		}
+            default: 
+                cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+                break;
+        }
 	}
 
 }
@@ -177,7 +165,7 @@ static int request_message (Client *client, Connection *connection) {
     // manually create a packet to send
     Packet *packet = packet_new ();
     if (packet) {
-        size_t packet_len = sizeof (PacketHeader) + sizeof (RequestData);
+        size_t packet_len = sizeof (PacketHeader);
         packet->packet = malloc (packet_len);
         packet->packet_size = packet_len;
 
@@ -188,10 +176,7 @@ static int request_message (Client *client, Connection *connection) {
         header->packet_type = APP_PACKET;
         header->packet_size = packet_len;
         header->handler_id = 0;
-
-        end += sizeof (PacketHeader);
-        RequestData *req_data = (RequestData *) end;
-        req_data->type = GET_MSG;
+        header->request_type = GET_MSG;
 
         printf ("Requesting to cerver...\n");
         if (client_request_to_cerver (client, connection, packet)) {

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -60,19 +60,16 @@ static void my_app_handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
 
-			switch (req->type) {
-				case TEST_MSG: 
-					cerver_log_debug ("Got a APP_PACKET test request!");
-					handle_test_request (packet, APP_PACKET); 
-					break;
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a APP_PACKET test request!");
+				handle_test_request (packet, APP_PACKET); 
+				break;
 
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_PACKET request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_PACKET request.");
+				break;
 		}
 	}
 
@@ -82,19 +79,16 @@ static void my_app_error_handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
 
-			switch (req->type) {
-				case TEST_MSG: 
-					cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
-					handle_test_request (packet, APP_ERROR_PACKET); 
-					break;
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
+				handle_test_request (packet, APP_ERROR_PACKET); 
+				break;
 
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_ERROR_PACKET request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_ERROR_PACKET request.");
+				break;
 		}
 	}
 
@@ -104,19 +98,16 @@ static void my_custom_handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
+		
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a CUSTOM_PACKET test request!");
+				handle_test_request (packet, CUSTOM_PACKET); 
+				break;
 
-			switch (req->type) {
-				case TEST_MSG: 
-					cerver_log_debug ("Got a CUSTOM_PACKET test request!");
-					handle_test_request (packet, CUSTOM_PACKET); 
-					break;
-
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown CUSTOM_PACKET request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown CUSTOM_PACKET request.");
+				break;
 		}
 	}
 

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -12,6 +12,15 @@
 #include <cerver/utils/utils.h>
 #include <cerver/utils/log.h>
 
+typedef enum HandlersType {
+
+	HANDLERS_TYPE_NONE			= 0,
+
+	HANDLERS_TYPE_DIRECT		= 1,
+	HANDLERS_TYPE_QUEUE			= 2,
+
+} HandlersType;
+
 static Cerver *my_cerver = NULL;
 
 typedef enum AppRequest {
@@ -21,6 +30,8 @@ typedef enum AppRequest {
 	GET_MSG			= 1
 
 } AppRequest;
+
+#pragma region end
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
@@ -33,6 +44,10 @@ static void end (int dummy) {
 	exit (0);
 
 }
+
+#pragma endregion
+
+#pragma region handlers
 
 static void handle_test_request (Packet *packet, PacketType packet_type) {
 
@@ -56,7 +71,75 @@ static void handle_test_request (Packet *packet, PacketType packet_type) {
 
 }
 
-static void my_app_handler (void *data) {
+#pragma endregion
+
+#pragma region queue
+
+static void my_app_handler_queue (void *handler_data_ptr) {
+
+	if (handler_data_ptr) {
+		HandlerData *handler_data = (HandlerData *) handler_data_ptr;
+		Packet *packet = handler_data->packet;
+
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a APP_PACKET test request!");
+				handle_test_request (packet, APP_PACKET); 
+				break;
+
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_PACKET request.");
+				break;
+		}
+	}
+
+}
+
+static void my_app_error_handler_queue (void *handler_data_ptr) {
+
+	if (handler_data_ptr) {
+		HandlerData *handler_data = (HandlerData *) handler_data_ptr;
+		Packet *packet = handler_data->packet;
+
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
+				handle_test_request (packet, APP_ERROR_PACKET); 
+				break;
+
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown APP_ERROR_PACKET request.");
+				break;
+		}
+	}
+
+}
+
+static void my_custom_handler_queue (void *handler_data_ptr) {
+
+	if (handler_data_ptr) {
+		HandlerData *handler_data = (HandlerData *) handler_data_ptr;
+		Packet *packet = handler_data->packet;
+		
+		switch (packet->header->request_type) {
+			case TEST_MSG: 
+				cerver_log_debug ("Got a CUSTOM_PACKET test request!");
+				handle_test_request (packet, CUSTOM_PACKET); 
+				break;
+
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown CUSTOM_PACKET request.");
+				break;
+		}
+	}
+
+}
+
+#pragma endregion
+
+#pragma region direct
+
+static void my_app_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
@@ -75,7 +158,7 @@ static void my_app_handler (void *data) {
 
 }
 
-static void my_app_error_handler (void *data) {
+static void my_app_error_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
@@ -94,7 +177,7 @@ static void my_app_error_handler (void *data) {
 
 }
 
-static void my_custom_handler (void *data) {
+static void my_custom_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
@@ -113,20 +196,11 @@ static void my_custom_handler (void *data) {
 
 }
 
-int main (void) {
+#pragma endregion
 
-	srand (time (NULL));
+#pragma region start
 
-	// register to the quit signal
-	signal (SIGINT, end);
-
-	printf ("\n");
-	cerver_version_print_full ();
-	printf ("\n");
-
-	cerver_log_debug ("App & Custom Handlers Example");
-	cerver_log_debug ("Testing correct handling of APP_PACKET, APP_ERROR_PACKET & CUSTOM_PACKET packet types");
-	printf ("\n");
+static void start (HandlersType type) {
 
 	my_cerver = cerver_create (CUSTOM_CERVER, "my-cerver", 8007, PROTOCOL_TCP, false, 2, 2000);
 	if (my_cerver) {
@@ -135,14 +209,45 @@ int main (void) {
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 
-		Handler *app_handler = handler_create (my_app_handler);
-		handler_set_direct_handle (app_handler, true);
+		Handler *app_handler = NULL;
+		Handler *app_error_handler = NULL;
+		Handler *app_custom_handler = NULL;
 
-		Handler *app_error_handler = handler_create (my_app_error_handler);
-		handler_set_direct_handle (app_error_handler, true);
+		switch (type) {
+			case HANDLERS_TYPE_NONE: break;
 
-		Handler *app_custom_handler = handler_create (my_custom_handler);
-		handler_set_direct_handle (app_custom_handler, true);
+			case HANDLERS_TYPE_DIRECT: {
+				printf ("\n");
+				cerver_log_debug ("Handlers to handle packets directly!");
+				printf ("\n");
+
+				app_handler = handler_create (my_app_handler_direct);
+				handler_set_direct_handle (app_handler, true);
+
+				app_error_handler = handler_create (my_app_error_handler_direct);
+				handler_set_direct_handle (app_error_handler, true);
+
+				app_custom_handler = handler_create (my_custom_handler_direct);
+				handler_set_direct_handle (app_custom_handler, true);
+			} break;
+
+			case HANDLERS_TYPE_QUEUE: {
+				printf ("\n");
+				cerver_log_debug ("Handlers to use job queue!");
+				printf ("\n");
+
+				app_handler = handler_create (my_app_handler_queue);
+				handler_set_direct_handle (app_handler, false);
+
+				app_error_handler = handler_create (my_app_error_handler_queue);
+				handler_set_direct_handle (app_error_handler, false);
+
+				app_custom_handler = handler_create (my_custom_handler_queue);
+				handler_set_direct_handle (app_custom_handler, false);
+			} break;
+
+			default: break;
+		}
 
 		cerver_set_app_handlers (my_cerver, app_handler, app_error_handler);
 		cerver_set_custom_handler (my_cerver, app_custom_handler);
@@ -166,6 +271,81 @@ int main (void) {
 		// cerver_delete (client_cerver);
 	}
 
+}
+
+#pragma endregion
+
+#pragma region main
+
+static void print_help (void) {
+
+	printf ("\n");
+	printf ("Usage: ./bin/handlers -t [type]\n");
+	printf ("-h       	Print this help\n");
+	printf ("-t [type]  Type to tun (d for direct / q for job queue)\n");
+	printf ("\n");
+
+}
+
+int main (int argc, char **argv) {
+
+	srand (time (NULL));
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	printf ("\n");
+	cerver_version_print_full ();
+	printf ("\n");
+
+	cerver_log_debug ("App & Custom Handlers Example");
+	cerver_log_debug ("Testing correct handling of APP_PACKET, APP_ERROR_PACKET & CUSTOM_PACKET packet types");
+	printf ("\n");
+
+	char *type = NULL;
+	int j = 0;
+	if (argc > 1) {
+		const char *curr_arg = NULL;
+		for (int i = 1; i < argc; i++) {
+			curr_arg = argv[i];
+
+			if (!strcmp (curr_arg, "-h")) print_help ();
+			else if (!strcmp (curr_arg, "-t")) {
+				// get the type to run
+				j = i + 1;
+				if (j <= argc) {
+					type = argv[j];
+					i++;
+					// printf ("\nSelected type: %s\n", type->str);
+				}
+			}
+
+			else {
+				char *status = c_string_create ("Unknown argument: %s", curr_arg);
+				if (status) {
+					cerver_log_warning (status);
+					free (status);
+				}
+			}
+		}
+
+		if (type) {
+			if (!strcmp (type, "d")) start (HANDLERS_TYPE_DIRECT);
+			else if (!strcmp (type, "q")) start (HANDLERS_TYPE_QUEUE);
+			else {
+				char *status = c_string_create ("Unknown type: %s", type);
+				if (status) {
+					cerver_log_error (status);
+					free (status);
+				}
+			}
+		}
+	}
+
+	else print_help ();
+
 	return 0;
 
 }
+
+#pragma endregion

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -185,18 +185,14 @@ static void handler_cero (void *data) {
 		AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
 		if (packet) {
-			if (packet->data_size >= sizeof (RequestData)) {
-				RequestData *req = (RequestData *) (packet->data);
+			switch (packet->header->request_type) {
+				case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
 
-				switch (req->type) {
-					case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
+				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-					case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
-
-					default: 
-						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-						break;
-				}
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
 			}
 		}
 	}
@@ -211,18 +207,14 @@ static void handler_one (void *data) {
 		AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
 		if (packet) {
-			if (packet->data_size >= sizeof (RequestData)) {
-				RequestData *req = (RequestData *) (packet->data);
+			switch (packet->header->request_type) {
+				case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
 
-				switch (req->type) {
-					case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
+				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-					case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
-
-					default: 
-						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-						break;
-				}
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
 			}
 		}
 	}
@@ -237,18 +229,14 @@ static void handler_two (void *data) {
 		AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
 		if (packet) {
-			if (packet->data_size >= sizeof (RequestData)) {
-				RequestData *req = (RequestData *) (packet->data);
+			switch (packet->header->request_type) {
+				case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
 
-				switch (req->type) {
-					case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
+				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-					case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
-
-					default: 
-						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-						break;
-				}
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
 			}
 		}
 	}
@@ -263,18 +251,14 @@ static void handler_three (void *data) {
 		AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
 		if (packet) {
-			if (packet->data_size >= sizeof (RequestData)) {
-				RequestData *req = (RequestData *) (packet->data);
+			switch (packet->header->request_type) {
+				case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
 
-				switch (req->type) {
-					case TEST_MSG: handle_test_request (packet, handler_data->handler_id); break;
+				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-					case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
-
-					default: 
-						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-						break;
-				}
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
 			}
 		}
 	}

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -28,6 +28,7 @@ typedef enum AppRequest {
 
 	TEST_MSG		= 0,
 	APP_MSG			= 1,
+	MULTI_MSG		= 2,
 
 } AppRequest;
 
@@ -143,6 +144,25 @@ static void handle_app_message (Packet *packet) {
 
 }
 
+static void handle_multi_message (Packet *packet) {
+
+	if (packet) {
+		cerver_log_debug ("MULTI message!");
+
+		char *end = packet->data;
+
+		AppData *app_data = NULL;
+		for (u32 i = 0; i < 5; i++) {
+			app_data = (AppData *) end;
+			printf ("Message (%ld): %s\n", app_data->message_len, app_data->message);
+			printf ("\n");
+
+			end += sizeof (AppData);
+		}
+	}
+
+}
+
 static void handler (void *data) {
 
 	if (data) {
@@ -152,6 +172,8 @@ static void handler (void *data) {
 			case TEST_MSG: handle_test_request (packet); break;
 
 			case APP_MSG: handle_app_message (packet); break;
+
+			case MULTI_MSG: handle_multi_message (packet); break;
 
 			default: 
 				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -135,7 +135,6 @@ static void handle_app_message (Packet *packet) {
 
 	if (packet) {
 		char *end = packet->data;
-		end += sizeof (RequestData);
 
 		AppData *app_data = (AppData *) end;
 		app_data_print (app_data);
@@ -148,18 +147,15 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
 
-			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
 
-				case APP_MSG: handle_app_message (packet); break;
+			case APP_MSG: handle_app_message (packet); break;
 
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+				break;
 		}
 	}
 

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -176,18 +176,14 @@ static void app_packet_handler (void *data) {
 		AppData *app_data = (AppData *) handler_data->data;
 		Packet *packet = handler_data->packet;
 		if (packet) {
-			if (packet->data_size >= sizeof (RequestData)) {
-				RequestData *req = (RequestData *) (packet->data);
+			switch (packet->header->request_type) {
+				case TEST_MSG: handle_test_request (packet); break;
 
-				switch (req->type) {
-					case TEST_MSG: handle_test_request (packet); break;
+				case GET_MSG: handle_msg_request(packet, app_data->message); break;
 
-					case GET_MSG: handle_msg_request(packet, app_data->message); break;
-
-					default: 
-						cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-						break;
-				}
+				default: 
+					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+					break;
 			}
 		}
 	}

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -73,16 +73,13 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
 
-			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
 
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+				break;
 		}
 	}
 

--- a/examples/test.c
+++ b/examples/test.c
@@ -65,16 +65,13 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-		if (packet->data_size >= sizeof (RequestData)) {
-			RequestData *req = (RequestData *) (packet->data);
+		
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
 
-			switch (req->type) {
-				case TEST_MSG: handle_test_request (packet); break;
-
-				default: 
-					cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
-					break;
-			}
+			default: 
+				cerver_log_msg (stderr, LOG_WARNING, LOG_PACKET, "Got an unknown app request.");
+				break;
 		}
 	}
 

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -97,6 +97,7 @@ typedef enum PacketType {
 
 struct _PacketsPerType {
 
+	u64 n_cerver_packets;
 	u64 n_error_packets;
 	u64 n_auth_packets;
 	u64 n_request_packets;

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -224,6 +224,7 @@ struct _Packet {
 
 	// the actual packet to be sent
 	PacketHeader *header;
+	PacketVersion *version;
 	size_t packet_size;
 	void *packet;
 	bool packet_ref;

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -39,7 +39,6 @@ typedef struct ProtocolVersion {
 	
 } ProtocolVersion;
 
-
 // gets the current version set in your application
 extern ProtocolVersion packets_get_protocol_version (void);
 
@@ -48,6 +47,27 @@ extern ProtocolVersion packets_get_protocol_version (void);
 // If the versions of your packet don't match, it will be considered a bad packet
 // This value is only cheked if you enable packet checking for your cerver
 extern void packets_set_protocol_version (ProtocolVersion version);
+
+#pragma endregion
+
+#pragma region version
+
+struct _PacketVersion {
+
+	ProtocolID protocol_id;
+	ProtocolVersion protocol_version;
+
+};
+
+typedef struct _PacketVersion PacketVersion;
+
+extern PacketVersion *packet_version_new (void);
+
+extern void packet_version_delete (PacketVersion *version);
+
+extern PacketVersion *packet_version_create (void);
+
+extern void packet_version_print (PacketVersion *version);
 
 #pragma endregion
 
@@ -104,9 +124,6 @@ extern void packets_per_type_print (PacketsPerType *packets_per_type);
 #pragma region header
 
 struct _PacketHeader {
-
-	ProtocolID protocol_id;
-	ProtocolVersion protocol_version;
 
 	PacketType packet_type;
 	size_t packet_size;

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -219,8 +219,8 @@ struct _Packet {
 	// serilized data
 	size_t data_size;
 	void *data;
-	char *data_end;
 	char *data_ptr;
+	char *data_end;
 	bool data_ref;
 
 	// the actual packet to be sent

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -107,11 +107,13 @@ struct _PacketHeader {
 
 	ProtocolID protocol_id;
 	ProtocolVersion protocol_version;
+
 	PacketType packet_type;
 	size_t packet_size;
 
-	// 10/05/2020 -- select which app packet handler to use
 	u8 handler_id;
+	
+	u32 request_type;
 
 };
 
@@ -185,14 +187,6 @@ typedef enum GamePacketType {
 	GAME_SEND_MSG               = 8,
 
 } GamePacketType;
-
-struct _RequestData {
-
-	u32 type;
-
-};
-
-typedef struct _RequestData RequestData;
 
 struct _Packet {
 

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -220,6 +220,7 @@ struct _Packet {
 	size_t data_size;
 	void *data;
 	char *data_end;
+	char *data_ptr;
 	bool data_ref;
 
 	// the actual packet to be sent

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -317,6 +317,17 @@ extern u8 packet_send_split (const Packet *packet, int flags, size_t *total_sent
 extern u8 packet_send_to_split (const Packet *packet, size_t *total_sent,
     struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby);
 
+// sends a packet in pieces, taking the header from the packet's field
+// sends each buffer as they are with they respective sizes
+// socket mutex will be locked for the entire operation
+// returns 0 on success, 1 on error
+extern u8 packet_send_pieces (
+    const Packet *packet, 
+    void **pieces, size_t *sizes, u32 n_pieces, 
+    int flags, 
+    size_t *total_sent
+);
+
 // sends a packet directly to the socket
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -112,7 +112,7 @@ struct _PacketHeader {
 	size_t packet_size;
 
 	u8 handler_id;
-	
+
 	u32 request_type;
 
 };
@@ -123,7 +123,7 @@ extern PacketHeader *packet_header_new (void);
 
 extern void packet_header_delete (PacketHeader *header);
 
-extern PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size);
+extern PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, u32 req_type);
 
 // prints an already existing PacketHeader. Mostly used for debugging
 extern void packet_header_print (PacketHeader *header);
@@ -197,7 +197,7 @@ struct _Packet {
 	struct _Lobby *lobby;
 
 	PacketType packet_type;
-	estring *custom_type;
+	u32 req_type;
 
 	// serilized data
 	size_t data_size;

--- a/include/cerver/types/estring.h
+++ b/include/cerver/types/estring.h
@@ -11,21 +11,40 @@ typedef struct estring {
 } estring;
 
 extern estring *estring_new (const char *str);
-extern estring *estring_create (const char *format, ...);
+
 extern void estring_delete (void *str_ptr);
 
-extern void estring_copy (estring *to, estring *from);
-extern estring *estring_concat (estring *s1, estring *s2);
-
-extern void estring_to_upper (estring *str);
-extern void estring_to_lower (estring *str);
+extern estring *estring_create (const char *format, ...);
 
 extern int estring_compare (const estring *s1, const estring *s2);
+
 extern int estring_comparator (const void *a, const void *b);
 
-extern char **estring_split (estring *str, const char delim, int *n_tokens);
+extern void estring_copy (estring *to, estring *from);
 
-extern void estring_remove_char (estring *str, char garbage);
+extern void estring_replace (estring *old, const char *str);
+
+// concatenates two strings into a new one
+extern estring *estring_concat (estring *s1, estring *s2);
+
+// appends a char to the end of the string
+// reallocates the same string
+extern void estring_append_char (estring *s, const char c);
+
+// appends a c string at the end of the string
+// reallocates the same string
+extern void estring_append_c_string (estring *s, const char *c_str);
+
+extern void estring_to_upper (estring *string);
+
+extern void estring_to_lower (estring *string);
+
+extern char **estring_split (estring *string, const char delim, int *n_tokens);
+
+extern void estring_remove_char (estring *string, char garbage);
+
+// removes the last char from a string
+extern void estring_remove_last_char (estring *string);
 
 // check if a str (to_find) is inside str
 // returns 0 on exact match

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.5rc-9"
-#define CERVER_VERSION_NAME             "Release 1.5rc-9"
-#define CERVER_VERSION_DATE			    "13/07/2020"
-#define CERVER_VERSION_TIME			    "17:29 CST"
+#define CERVER_VERSION                  "1.5rc-10"
+#define CERVER_VERSION_NAME             "Release 1.5rc-10"
+#define CERVER_VERSION_DATE			    "21/07/2020"
+#define CERVER_VERSION_TIME			    "16:58 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.5rc-12"
-#define CERVER_VERSION_NAME             "Release 1.5rc-12"
-#define CERVER_VERSION_DATE			    "23/07/2020"
-#define CERVER_VERSION_TIME			    "12:43 CST"
+#define CERVER_VERSION                  "1.5rc-13"
+#define CERVER_VERSION_NAME             "Release 1.5rc-13"
+#define CERVER_VERSION_DATE			    "25/07/2020"
+#define CERVER_VERSION_TIME			    "15:59 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.5rc-11"
-#define CERVER_VERSION_NAME             "Release 1.5rc-11"
-#define CERVER_VERSION_DATE			    "22/07/2020"
-#define CERVER_VERSION_TIME			    "23:48 CST"
+#define CERVER_VERSION                  "1.5rc-12"
+#define CERVER_VERSION_NAME             "Release 1.5rc-12"
+#define CERVER_VERSION_DATE			    "23/07/2020"
+#define CERVER_VERSION_TIME			    "12:43 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.5rc-10"
-#define CERVER_VERSION_NAME             "Release 1.5rc-10"
-#define CERVER_VERSION_DATE			    "21/07/2020"
-#define CERVER_VERSION_TIME			    "16:58 CST"
+#define CERVER_VERSION                  "1.5rc-11"
+#define CERVER_VERSION_NAME             "Release 1.5rc-11"
+#define CERVER_VERSION_DATE			    "22/07/2020"
+#define CERVER_VERSION_TIME			    "23:48 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -1477,7 +1477,17 @@ void admin_packet_handler (Packet *packet) {
     if (packet) {
         bool good = true;
         if (packet->cerver->check_packets) {
-            good = packet_check (packet);
+            // we expect the packet version in the packet's data
+            if (packet->data) {
+                packet->version = (PacketVersion *) packet->data_ptr;
+                packet->data_ptr += sizeof (PacketVersion);
+                good = packet_check (packet);
+            }
+
+            else {
+                cerver_log_error ("admin_packet_handler () - No packet version to check!");
+                good = false;
+            }
         }
 
         if (good) {

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -664,6 +664,7 @@ u8 admin_cerver_register_admin (AdminCerver *admin_cerver, Admin *admin) {
             dlist_insert_after (admin_cerver->admins, dlist_end (admin_cerver->admins), admin);
 
             admin_cerver->stats->current_connected_admins += 1;
+            admin_cerver->stats->total_n_admins += 1;
 
             #ifdef CERVER_STATS
             char *status = c_string_create ("Cerver %s ADMIN current connected admins: %ld", 
@@ -1579,6 +1580,7 @@ u8 admin_cerver_poll_register_connection (AdminCerver *admin_cerver, Connection 
             admin_cerver->current_n_fds++;
 
             admin_cerver->stats->current_connections++;
+            admin_cerver->stats->total_admin_connections++;
 
             #ifdef ADMIN_DEBUG
             char *s = c_string_create ("Added sock fd <%d> to cerver %s ADMIN poll, idx: %i", 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -663,6 +663,17 @@ u8 admin_cerver_register_admin (AdminCerver *admin_cerver, Admin *admin) {
         )) {
             dlist_insert_after (admin_cerver->admins, dlist_end (admin_cerver->admins), admin);
 
+            admin_cerver->stats->current_connected_admins += 1;
+
+            #ifdef CERVER_STATS
+            char *status = c_string_create ("Cerver %s ADMIN current connected admins: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins);
+            if (status) {
+                cerver_log_msg (stdout, LOG_CERVER, LOG_ADMIN, status);
+                free (status);
+            }
+            #endif
+
             retval = 0;     // success
         }
     }
@@ -683,6 +694,17 @@ u8 admin_cerver_unregister_admin (AdminCerver *admin_cerver, Admin *admin) {
             for (ListElement *le = dlist_start (admin->client->connections); le; le = le->next) {
                 admin_cerver_poll_unregister_connection (admin_cerver, (Connection *) le->data);
             }
+
+            admin_cerver->stats->current_connected_admins -= 1;
+
+            #ifdef CERVER_STATS
+            char *status = c_string_create ("Cerver %s ADMIN current connected admins: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins);
+            if (status) {
+                cerver_log_msg (stdout, LOG_CERVER, LOG_ADMIN, status);
+                free (status);
+            }
+            #endif
 
             retval = 0;
         }

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -1292,11 +1292,8 @@ u8 admin_cerver_end (AdminCerver *admin_cerver) {
 static void admin_cerver_request_packet_handler (Packet *packet) {
 
     if (packet) {
-        if (packet->data && (packet->data_size >= (sizeof (RequestData)))) {
-            char *end = (char *) packet->data;
-            RequestData *req_data = (RequestData *) end;
-
-            switch (req_data->type) {
+        if (packet->header) {
+            switch (packet->header->request_type) {
                 // the client is going to close its current connection
                 // but will remain in the cerver if it has another connection active
                 // if not, it will be dropped

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -423,13 +423,11 @@ static AuthData *auth_strip_auth_data (Packet *packet) {
 
     if (packet) {
         // check we have a big enough packet
-        if (packet->data_size > sizeof (RequestData)) {
+        if (packet->data_size > 0) {
             char *end = (char *) packet->data;
 
-            end += sizeof (RequestData);
-
             // check if we have a token
-            if (packet->data_size == (sizeof (RequestData) + sizeof (SToken))) {
+            if (packet->data_size == (sizeof (SToken))) {
                 SToken *s_token = (SToken *) (end);
                 auth_data = auth_data_create (s_token->token, NULL, 0);
             }
@@ -760,10 +758,8 @@ static void cerver_on_hold_handle_max_bad_packets (Cerver *cerver, Connection *c
 static void cerver_auth_packet_handler (Packet *packet) {
 
     if (packet) {
-        if (packet->data_size > sizeof (RequestData)) {
-            RequestData *req = (RequestData *) (packet->data);
-
-            switch (req->type) {
+        if (packet->header && (packet->data_size > 0)) {
+            switch (packet->header->request_type) {
                 // the client sent use its data to authenticate itself
                 case AUTH_PACKET_TYPE_CLIENT_AUTH: auth_try (packet); break;
 

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -792,7 +792,17 @@ void on_hold_packet_handler (void *packet_ptr) {
 
         bool good = true;
         if (packet->cerver->on_hold_check_packets) {
-            good = packet_check (packet);
+            // we expect the packet version in the packet's data
+            if (packet->data) {
+                packet->version = (PacketVersion *) packet->data_ptr;
+                packet->data_ptr += sizeof (PacketVersion);
+                good = packet_check (packet);
+            }
+
+            else {
+                cerver_log_error ("on_hold_packet_handler () - No packet version to check!");
+                good = false;
+            }
         }
 
         if (good) {

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -268,7 +268,7 @@ Cerver *cerver_new (void) {
         c->on_hold_poll_timeout = DEFAULT_POLL_TIMEOUT;
         c->on_hold_poll_lock = NULL;
         c->on_hold_max_bad_packets = DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
-        c->on_hold_check_packets = true;
+        c->on_hold_check_packets = false;
 
         c->use_sessions = false;
         c->session_id_generator = NULL;

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -1625,24 +1625,32 @@ u8 client_teardown_async (Client *client) {
 
 #pragma endregion
 
-#pragma region handler 
+#pragma region handler
+
+static void client_cerver_packet_handle_info (Packet *packet) {
+
+    if (packet->data && (packet->data_size > 0)) {
+        char *end = (char *) packet->data;
+
+         #ifdef CLIENT_DEBUG
+        cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Received a cerver info packet.");
+        #endif
+
+        CerverReport *cerver = cerver_deserialize ((SCerver *) end);
+        if (cerver_report_check_info (cerver, packet->connection))
+            cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to correctly check cerver info!");
+    }
+
+}
 
 // handles cerver type packets
 void client_cerver_packet_handler (Packet *packet) {
 
     if (packet) {
-        if (packet->data_size >= sizeof (RequestData)) {
-            char *end = (char *) packet->data;
-            RequestData *req = (RequestData *) (end);
-
-            switch (req->type) {
+        if (packet->header) {
+            switch (packet->header->request_type) {
                 case CERVER_INFO: {
-                    #ifdef CLIENT_DEBUG
-                    cerver_log_msg (stdout, LOG_DEBUG, LOG_NO_TYPE, "Received a cerver info packet.");
-                    #endif
-                    CerverReport *cerver = cerver_deserialize ((SCerver *) (end += sizeof (RequestData)));
-                    if (cerver_report_check_info (cerver, packet->connection))
-                        cerver_log_msg (stderr, LOG_ERROR, LOG_NO_TYPE, "Failed to correctly check cerver info!");
+                    client_cerver_packet_handle_info (packet);
                 } break;
 
                 // the cerves is going to be teardown, we have to disconnect

--- a/src/cerver/game/game.c
+++ b/src/cerver/game/game.c
@@ -235,9 +235,9 @@ void game_cerver_unregister_lobby (GameCerver *game_cerver, Lobby *lobby) {
 static void game_lobby_create (Packet *packet) {
 
     if (packet) {
-        if (packet->data_size >= sizeof (RequestData) + sizeof (SStringS)) {
+        if (packet->data_size >= sizeof (SStringS)) {
             char *end = (char *) packet->data;
-            SStringS *stype = (SStringS *) (end += sizeof (RequestData));
+            SStringS *stype = (SStringS *) end;
 
             #ifdef CERVER_DEBUG
             char *s = c_string_create ("Client %ld requested to create a new lobby in cerver %s of type: %s",
@@ -461,9 +461,8 @@ static void game_lobby_join_search (Packet *packet, LobbyJoin *lj) {
 static void game_lobby_join (Packet *packet) {
 
     if (packet) {
-        if (packet->data_size >= sizeof (RequestData) + sizeof (LobbyJoin)) {
+        if (packet->data_size >= sizeof (LobbyJoin)) {
             char *end = (char *) packet->data;
-            end += sizeof (RequestData);
             LobbyJoin *lj = (LobbyJoin *) end;
 
             // check if we have to search a lobby for the player
@@ -508,9 +507,8 @@ static void game_lobby_init (Packet *packet) {
 static void game_lobby_start (Packet *packet) {
 
     if (packet) {
-        if (packet->data_size >= sizeof (RequestData) + sizeof (SStringS)) {
+        if (packet->data_size >= sizeof (SStringS)) {
             char *end = (char *) packet->data;
-            end += sizeof (RequestData);
             SStringS *lobby_id = (SStringS *) end;
 
             #ifdef CERVER_DEBUG
@@ -620,9 +618,8 @@ static void game_lobby_start (Packet *packet) {
 void game_packet_handler (Packet *packet) {
 
     if (packet) {
-        if (packet->data && (packet->data_size >= sizeof (RequestData))) {
-            RequestData *req = (RequestData *) (packet->data);
-            switch (req->type) {
+        if (packet->header) {
+            switch (packet->header->request_type) {
                 case GAME_LOBBY_CREATE: game_lobby_create (packet); break;
                 case GAME_LOBBY_JOIN: game_lobby_join (packet); break;
                 case GAME_LOBBY_LEAVE: game_lobby_leave (packet); break;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -709,7 +709,17 @@ static void cerver_packet_handler (void *ptr) {
 
         bool good = true;
         if (packet->cerver->check_packets) {
-            good = packet_check (packet);
+            // we expect the packet version in the packet's data
+            if (packet->data) {
+                packet->version = (PacketVersion *) packet->data_ptr;
+                packet->data_ptr += sizeof (PacketVersion);
+                good = packet_check (packet);
+            }
+
+            else {
+                cerver_log_error ("cerver_packet_handler () - No packet version to check!");
+                good = false;
+            }
         }
 
         if (good) {

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -439,11 +439,8 @@ void sock_receive_delete (void *sock_receive_ptr) {
 static void cerver_request_packet_handler (Packet *packet) {
 
     if (packet) {
-        if (packet->data && (packet->data_size >= (sizeof (RequestData)))) {
-            char *end = (char *) packet->data;
-            RequestData *req_data = (RequestData *) end;
-
-            switch (req_data->type) {
+        if (packet->header) {
+            switch (packet->header->request_type) {
                 // the client is going to close its current connection
                 // but will remain in the cerver if it has another connection active
                 // if not, it will be dropped

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -178,6 +178,8 @@ static void handler_do_while_cerver (Handler *handler) {
                 Job *job = job_queue_pull (handler->job_queue);
                 if (job) {
                     Packet *packet = (Packet *) job->args;
+                    PacketType packet_type = packet->header->packet_type;
+
                     HandlerData *handler_data = handler_data_new (handler->id, handler->data, packet);
 
                     handler->handler (handler_data);
@@ -185,7 +187,7 @@ static void handler_do_while_cerver (Handler *handler) {
                     handler_data_delete (handler_data);
                     job_delete (job);
 
-                    switch (packet->header->packet_type) {
+                    switch (packet_type) {
                         case APP_PACKET: if (handler->cerver->app_packet_handler_delete_packet) packet_delete (packet); break;
                         case APP_ERROR_PACKET: if (handler->cerver->app_error_packet_handler_delete_packet) packet_delete (packet); break;
                         case CUSTOM_PACKET: if (handler->cerver->custom_packet_handler_delete_packet) packet_delete (packet); break;
@@ -253,6 +255,8 @@ static void handler_do_while_admin (Handler *handler) {
                 Job *job = job_queue_pull (handler->job_queue);
                 if (job) {
                     Packet *packet = (Packet *) job->args;
+                    PacketType packet_type = packet->header->packet_type;
+
                     HandlerData *handler_data = handler_data_new (handler->id, handler->data, packet);
 
                     handler->handler (handler_data);
@@ -260,7 +264,7 @@ static void handler_do_while_admin (Handler *handler) {
                     handler_data_delete (handler_data);
                     job_delete (job);
 
-                    switch (packet->header->packet_type) {
+                    switch (packet_type) {
                         case APP_PACKET: if (handler->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet); break;
                         case APP_ERROR_PACKET: if (handler->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet); break;
                         case CUSTOM_PACKET: if (handler->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet); break;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1499,6 +1499,8 @@ void cerver_receive (void *ptr) {
 
                                 cerver_switch_receive_handle_failed (cr);
                             }
+
+                            free (packet_buffer);
                         } break;
 
                         case 0: {
@@ -1515,6 +1517,8 @@ void cerver_receive (void *ptr) {
                             // #endif
 
                             cerver_switch_receive_handle_failed (cr);
+
+                            free (packet_buffer);
                         } break;
 
                         default: {

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -191,7 +191,8 @@ Packet *packet_new (void) {
         packet->data_end = NULL;
         packet->data_ref = false;
 
-        packet->header = NULL;  
+        packet->header = NULL;
+        packet->version = NULL;
         packet->packet_size = 0;
         packet->packet = NULL;
         packet->packet_ref = false;
@@ -230,6 +231,8 @@ void packet_delete (void *ptr) {
         }
 
         packet_header_delete (packet->header);
+        packet_version_delete (packet->version);
+
         if (!packet->packet_ref) {
             if (packet->packet) free (packet->packet);
         }
@@ -818,25 +821,25 @@ bool packet_check (Packet *packet) {
     bool retval = false;
 
     if (packet) {
-        PacketHeader *header = packet->header;
+        if (packet->version) {
+            if (packet->version->protocol_id == protocol_id) {
+                if ((packet->version->protocol_version.major <= protocol_version.major)
+                    && (packet->version->protocol_version.minor >= protocol_version.minor)) {
+                    retval = true;
+                }
 
-        if (header->protocol_id == protocol_id) {
-            if ((header->protocol_version.major <= protocol_version.major)
-                && (header->protocol_version.minor >= protocol_version.minor)) {
-                retval = true;
+                else {
+                    #ifdef PACKETS_DEBUG
+                    cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with incompatible version.");
+                    #endif
+                }
             }
 
             else {
                 #ifdef PACKETS_DEBUG
-                cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with incompatible version.");
+                cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with unknown protocol ID.");
                 #endif
             }
-        }
-
-        else {
-            #ifdef PACKETS_DEBUG
-            cerver_log_msg (stdout, LOG_WARNING, LOG_PACKET, "Packet with unknown protocol ID.");
-            #endif
         }
     }
 

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -277,7 +277,7 @@ u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
             packet->data_end += packet->data_size;
 
             // point to the start of the data
-            packet->data_ptr = packet->data;
+            packet->data_ptr = (char *) packet->data;
 
             retval = 0;
         }
@@ -312,7 +312,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
                 packet->data_size = new_size;
 
                 // point to the start of the data
-                packet->data_ptr = packet->data;
+                packet->data_ptr = (char *) packet->data;
 
                 retval = 0;
             }
@@ -337,7 +337,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
                 packet->data_end += packet->data_size;
 
                 // point to the start of the data
-                packet->data_ptr = packet->data;
+                packet->data_ptr = (char *) packet->data;
 
                 retval = 0;
             }

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -102,10 +102,12 @@ PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size) 
 void packet_header_print (PacketHeader *header) {
 
     if (header) {
-        printf ("protocol id: %d\n", header->protocol_id);
-        printf ("protocol version: { %d - %d }\n", header->protocol_version.major, header->protocol_version.minor);
-        printf ("packet type: %d\n", header->packet_type);
-        printf ("packet size: %ld\n", header->packet_size);
+        printf ("Protocol id: %d\n", header->protocol_id);
+        printf ("Protocol version: { %d - %d }\n", header->protocol_version.major, header->protocol_version.minor);
+        printf ("Packet type: %d\n", header->packet_type);
+        printf ("Packet size: %ld\n", header->packet_size);
+        printf ("Handler id: %d\n", header->handler_id);
+        printf ("Request type: %d\n", header->request_type);
     }
 
 }
@@ -138,19 +140,21 @@ Packet *packet_new (void) {
 
     Packet *packet = (Packet *) malloc (sizeof (Packet));
     if (packet) {
-        memset (packet, 0, sizeof (Packet));
         packet->cerver = NULL;
         packet->client = NULL;
         packet->connection = NULL;
         packet->lobby = NULL;
 
+        packet->packet_type = DONT_CHECK_TYPE;
         packet->custom_type = NULL;
 
+        packet->data_size = 0;
         packet->data = NULL;
         packet->data_end = NULL;
         packet->data_ref = false;
 
         packet->header = NULL;  
+        packet->packet_size = 0;
         packet->packet = NULL;
         packet->packet_ref = false;
     }
@@ -418,14 +422,6 @@ Packet *packet_generate_request (PacketType packet_type, u32 req_type,
     Packet *packet = packet_new ();
     if (packet) {
         packet->packet_type = packet_type;
-
-        // generate the request
-        packet->data = malloc (sizeof (RequestData));
-        ((RequestData *) packet->data)->type = req_type;
-
-        packet->data_size = sizeof (RequestData);
-        packet->data_end = (char *) packet->data;
-        packet->data_end += sizeof (RequestData);
 
         // if there is data, append it to the packet data buffer
         if (data) {

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -38,6 +38,45 @@ void packets_set_protocol_version (ProtocolVersion version) { protocol_version =
 
 #pragma endregion
 
+#pragma region version
+
+PacketVersion *packet_version_new (void) {
+
+    PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
+    if (version) {
+        version->protocol_id = 0;
+        version->protocol_version.minor = version->protocol_version.major = 0;
+    }
+
+    return version;
+
+}
+
+void packet_version_delete (PacketVersion *version) { if (version) free (version); }
+
+PacketVersion *packet_version_create (void) {
+
+    PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
+    if (version) {
+        version->protocol_id = protocol_id;
+        version->protocol_version = protocol_version;
+    }
+
+    return version;
+
+}
+
+void packet_version_print (PacketVersion *version) {
+
+    if (version) {
+        printf ("Protocol id: %d\n", version->protocol_id);
+        printf ("Protocol version: { %d - %d }\n", version->protocol_version.major, version->protocol_version.minor);        
+    }
+
+}
+
+#pragma endregion
+
 #pragma region types
 
 PacketsPerType *packets_per_type_new (void) {
@@ -88,9 +127,6 @@ PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, 
 
     PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
     if (header) {
-        header->protocol_id = protocol_id;
-        header->protocol_version = protocol_version;
-
         header->packet_type = packet_type;
         header->packet_size = packet_size;
 
@@ -106,8 +142,6 @@ PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, 
 void packet_header_print (PacketHeader *header) {
 
     if (header) {
-        printf ("Protocol id: %d\n", header->protocol_id);
-        printf ("Protocol version: { %d - %d }\n", header->protocol_version.major, header->protocol_version.minor);
         printf ("Packet type: %d\n", header->packet_type);
         printf ("Packet size: %ld\n", header->packet_size);
         printf ("Handler id: %d\n", header->handler_id);

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -188,6 +188,7 @@ Packet *packet_new (void) {
 
         packet->data_size = 0;
         packet->data = NULL;
+        packet->data_ptr = NULL;
         packet->data_end = NULL;
         packet->data_ref = false;
 
@@ -275,6 +276,9 @@ u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
             packet->data_end = (char *) packet->data;
             packet->data_end += packet->data_size;
 
+            // point to the start of the data
+            packet->data_ptr = packet->data;
+
             retval = 0;
         }
     }
@@ -307,6 +311,9 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
                 packet->data = new_data;
                 packet->data_size = new_size;
 
+                // point to the start of the data
+                packet->data_ptr = packet->data;
+
                 retval = 0;
             }
 
@@ -328,6 +335,9 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
                 memcpy (packet->data, data, data_size);
                 packet->data_end = (char *) packet->data;
                 packet->data_end += packet->data_size;
+
+                // point to the start of the data
+                packet->data_ptr = packet->data;
 
                 retval = 0;
             }

--- a/src/cerver/types/estring.c
+++ b/src/cerver/types/estring.c
@@ -16,17 +16,31 @@ static inline void char_copy (char *to, char *from) {
 estring *estring_new (const char *str) {
 
     estring *s = (estring *) malloc (sizeof (estring));
-    if (str) {
-        memset (s, 0, sizeof (estring));
-
+    if (s) {
         if (str) {
             s->len = strlen (str);
             s->str = (char *) calloc (s->len + 1, sizeof (char));
-            char_copy (s->str, (char *) str);
+            if (s->str) char_copy (s->str, (char *) str);
         }
+
+        else {
+			s->len = 0;
+			s->str = NULL;
+		}
     }
 
     return s;
+
+}
+
+void estring_delete (void *str_ptr) {
+
+    if (str_ptr) {
+        estring *str = (estring *) str_ptr;
+
+        if (str->str) free (str->str);
+        free (str);
+    }
 
 }
 
@@ -59,14 +73,21 @@ estring *estring_create (const char *format, ...) {
 
 }
 
-void estring_delete (void *str_ptr) {
+int estring_compare (const estring *s1, const estring *s2) { 
 
-    if (str_ptr) {
-        estring *str = (estring *) str_ptr;
+    if (s1 && s2) return strcmp (s1->str, s2->str); 
+    else if (s1 && !s2) return -1;
+    else if (!s1 && s2) return 1;
+    return 0;
+    
+}
 
-        if (str->str) free (str->str);
-        free (str);
-    }
+int estring_comparator (const void *a, const void *b) {
+
+    if (a && b) return strcmp (((estring *) a)->str, ((estring *) b)->str);
+    else if (a && !b) return -1;
+    else if (!a && b) return 1;
+    return 0;
 
 }
 
@@ -78,6 +99,17 @@ void estring_copy (estring *to, estring *from) {
 
         *to->str = '\0';
         to->len = from->len;
+    }
+
+}
+
+void estring_replace (estring *old, const char *str) {
+
+    if (old && str) {
+        if (old->str) free (old->str);
+        old->len = strlen (str);
+        old->str = (char *) calloc (old->len + 1, sizeof (char));
+		if (old->str) char_copy (old->str, (char *) str);
     }
 
 }
@@ -102,6 +134,40 @@ estring *estring_concat (estring *s1, estring *s2) {
 
 }
 
+// appends a char to the end of the string
+// reallocates the same string
+void estring_append_char (estring *s, const char c) {
+
+    if (s) {
+        unsigned int new_len = s->len + 1;   
+
+        s->str = (char *) realloc (s->str, new_len);
+        if (s->str) {
+            char *des = s->str + (s->len);
+            *des = c;
+            s->len = new_len;
+        }
+    }
+
+}
+
+// appends a c string at the end of the string
+// reallocates the same string
+void estring_append_c_string (estring *s, const char *c_str) {
+
+    if (s && c_str) {
+        unsigned int new_len = s->len + strlen (c_str);
+
+        s->str = (char *) realloc (s->str, new_len);
+        if (s->str) {
+            char *des = s->str + (s->len);
+            char_copy (des, (char *) c_str);
+            s->len = new_len;
+        }
+    }
+
+}
+
 void estring_to_upper (estring *str) {
 
     if (str) for (unsigned int i = 0; i < str->len; i++) str->str[i] = toupper (str->str[i]);
@@ -114,31 +180,13 @@ void estring_to_lower (estring *str) {
 
 }
 
-int estring_compare (const estring *s1, const estring *s2) { 
-
-    if (s1 && s2) return strcmp (s1->str, s2->str); 
-    else if (s1 && !s2) return -1;
-    else if (!s1 && s2) return 1;
-    return 0;
-    
-}
-
-int estring_comparator (const void *a, const void *b) {
-
-    if (a && b) return strcmp (((estring *) a)->str, ((estring *) b)->str);
-    else if (a && !b) return -1;
-    else if (!a && b) return 1;
-    return 0;
-
-}
-
 char **estring_split (estring *str, const char delim, int *n_tokens) {
 
-    char **result = 0;
+    char **result = NULL;
     size_t count = 0;
     char *temp = str->str;
-    char *last = 0;
-    char dlm[2];
+    char *last = NULL;
+    char dlm[2] = { 0 };
     dlm[0] = delim;
     dlm[1] = 0;
 
@@ -185,6 +233,23 @@ void estring_remove_char (estring *str, char garbage) {
         if (*dst != garbage) dst++;
     }
     *dst = '\0';
+
+}
+
+// removes the last char from a string
+void estring_remove_last_char (estring *s) {
+
+    if (s) {
+        if (s->len > 0) {
+            unsigned int new_len = s->len - 1;
+
+            s->str = (char *) realloc (s->str, s->len);
+            if (s->str) {
+                s->str[s->len - 1] = '\0';
+                s->len = new_len;
+            }
+        }
+    }
 
 }
 


### PR DESCRIPTION
## General
- Updated estring type

## Handler
- Deleting packet buffer on recv () failure in cerver_receive ()
- Updated how packets are checked in cerver_packet_handler () as well as auth & admin handlers
- Fixes in handler_do_while () methods - related to Issue #94
- Changes in handler_do_while () methods - related to Issue #95

## Packets
- Removed RequestData & added it directly into PacketHeader
- Replaced packet custom type with request type field
- Moved protocol id & version from PacketHeader into a dedicated structure
- Added version field to main Packet structure
- Added data_ptr field to Packet to safely traverse the data
- Added base packet_send_pieces () - related to Issue #92
- Added cerver packets to packet types

## Auth
- Cerver on_hold_check_packets option now defaults to false

## Admin
- Updating more admin stats

## Examples
- Refactor examples to use new packets & removed RequestData
- Refactor handlers example to correctly test direct & queue types
