### PR TITLE
Update with version 1.6rc-3

### DIFF
--- a/include/cerver/utils/utils.h
+++ b/include/cerver/utils/utils.h
@@ -51,7 +51,7 @@ extern char **c_string_split (const char *original, const char delim, size_t *n_
 
 // revers a c string
 // returns a newly allocated c string
-extern char *c_string_reverse (char *str);
+extern char *c_string_reverse (const char *str);
 
 // removes all ocurrances of a char from a string
 extern void c_string_remove_char (char *string, char garbage);

--- a/include/cerver/utils/utils.h
+++ b/include/cerver/utils/utils.h
@@ -40,8 +40,11 @@ extern void c_string_copy (char *to, const char *from);
 // creates a new c string with the desired format, as in printf
 extern char *c_string_create (const char *format, ...);
 
+// get how many tokens will be extracted by counting the number of apperances of the delim
+extern unsigned int c_string_count_tokens (char *original, const char delim);
+
 // splits a c string into tokens based on a delimiter
-extern char **c_string_split (char *string, const char delim, int *n_tokens);
+extern char **c_string_split (char *string, const char delim, unsigned int *n_tokens);
 
 // revers a c string
 // returns a newly allocated c string

--- a/include/cerver/utils/utils.h
+++ b/include/cerver/utils/utils.h
@@ -41,10 +41,13 @@ extern void c_string_copy (char *to, const char *from);
 extern char *c_string_create (const char *format, ...);
 
 // get how many tokens will be extracted by counting the number of apperances of the delim
-extern unsigned int c_string_count_tokens (char *original, const char delim);
+// the original string won't be affected
+extern size_t c_string_count_tokens (const char *original, const char delim);
 
 // splits a c string into tokens based on a delimiter
-extern char **c_string_split (char *string, const char delim, unsigned int *n_tokens);
+// the original string won't be affected
+// this method is thread safe as it uses __strtok_r () instead of the regular strtok ()
+extern char **c_string_split (const char *original, const char delim, size_t *n_tokens);
 
 // revers a c string
 // returns a newly allocated c string

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -1,10 +1,10 @@
 #ifndef _CERVER_VERSION_H_
 #define _CERVER_VERSION_H_
 
-#define CERVER_VERSION                  "1.6rc-2"
-#define CERVER_VERSION_NAME             "Release 1.6rc-2"
-#define CERVER_VERSION_DATE			    "28/07/2020"
-#define CERVER_VERSION_TIME			    "21:19 CST"
+#define CERVER_VERSION                  "1.6rc-3"
+#define CERVER_VERSION_NAME             "Release 1.6rc-3"
+#define CERVER_VERSION_DATE			    "29/07/2020"
+#define CERVER_VERSION_TIME			    "23:51 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,8 +3,8 @@
 
 #define CERVER_VERSION                  "1.6rc-3"
 #define CERVER_VERSION_NAME             "Release 1.6rc-3"
-#define CERVER_VERSION_DATE			    "29/07/2020"
-#define CERVER_VERSION_TIME			    "23:51 CST"
+#define CERVER_VERSION_DATE			    "30/07/2020"
+#define CERVER_VERSION_TIME			    "22:07 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -33,6 +33,8 @@
 #include "cerver/threads/thread.h"
 #include "cerver/threads/thpool.h"
 
+#include "cerver/http/http.h"
+
 #include "cerver/game/game.h"
 
 #include "cerver/utils/log.h"
@@ -1073,6 +1075,25 @@ Cerver *cerver_create (const CerverType type, const char *name,
 
             cerver_set_network_values (cerver, port, protocol, use_ipv6, connection_queue);
 
+            // init cerver type based values
+            switch (cerver->type) {
+                case CERVER_TYPE_CUSTOM: break;
+
+                case CERVER_TYPE_GAME: {
+                    cerver->cerver_data = game_new ();
+                    cerver->delete_cerver_data = game_delete;
+                } break;
+                
+                case CERVER_TYPE_WEB: {
+                    // cerver->cerver_data = http_cerver_create (cerver);
+                    // cerver->delete_cerver_data = http_cerver_delete;
+                } break;
+
+                case CERVER_TYPE_FILE: break;
+                
+                default: break;
+            }
+
             cerver->handler_type = CERVER_HANDLER_TYPE_POLL;
             
             cerver_set_poll_time_out (cerver, poll_timeout);
@@ -1282,22 +1303,6 @@ static u8 cerver_init_data_structures (Cerver *cerver) {
             cerver->client_sock_fd_map = htab_create (poll_n_fds, NULL, NULL);
             if (cerver->client_sock_fd_map) {
                 u8 errors = 0;
-
-                // init cerver type based values
-                switch (cerver->type) {
-                    case CERVER_TYPE_CUSTOM: break;
-
-                    case CERVER_TYPE_GAME: {
-                        cerver->cerver_data = game_new ();
-                        cerver->delete_cerver_data = game_delete;
-                    } break;
-                    
-                    case CERVER_TYPE_WEB: break;
-
-                    case CERVER_TYPE_FILE: break;
-                    
-                    default: break;
-                }
 
                 // init cerver handler type based values
                 switch (cerver->handler_type) {

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1472,22 +1472,34 @@ static u8 cerver_one_time_init (Cerver *cerver) {
             // init the cerver thpool
             errors |= cerver_one_time_init_thpool (cerver);
 
-            // if we have a game cerver, we might wanna load game data -> set by cerver admin
-            if (cerver->type == CERVER_TYPE_GAME) {
-                GameCerver *game_data = (GameCerver *) cerver->cerver_data;
-                game_data->cerver = cerver;
-                if (game_data && game_data->load_game_data) {
-                    game_data->load_game_data (NULL);
-                }
+            // perform one time init methods by cerver type
+            switch (cerver->type) {
+                case CERVER_TYPE_CUSTOM: break;
 
-                else {
-                    char *s = c_string_create ("Game cerver %s doesn't have a reference to a game data!",
-                        cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_WARNING, LOG_GAME, s);
-                        free (s);
+                case CERVER_TYPE_GAME: {
+                    GameCerver *game_data = (GameCerver *) cerver->cerver_data;
+                    game_data->cerver = cerver;
+                    if (game_data && game_data->load_game_data) {
+                        game_data->load_game_data (NULL);
                     }
-                } 
+
+                    else {
+                        char *s = c_string_create ("Game cerver %s doesn't have a reference to a game data!",
+                            cerver->info->name->str);
+                        if (s) {
+                            cerver_log_msg (stdout, LOG_WARNING, LOG_GAME, s);
+                            free (s);
+                        }
+                    }
+                } break;
+                
+                case CERVER_TYPE_WEB: {
+                    // http_cerver_init ((HttpCerver *) cerver->cerver_data);
+                } break;
+
+                case CERVER_TYPE_FILE: break;
+                
+                default: break;
             }
 
             cerver->info->cerver_info_packet = cerver_packet_generate (cerver);

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1649,6 +1649,7 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 
     CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
+    i32 sock_fd = cr->socket->sock_fd;
     ssize_t rc = 0;
     do {
         char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
@@ -1657,19 +1658,21 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 
             switch (rc) {
                 case -1: {
-                    #ifdef CERVER_DEBUG 
-                    char *s = c_string_create (
-                        "cerver_receive_threads () - rc < 0 - sock fd: %d", 
-                        cr->socket->sock_fd
-                    );
-                    
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_ERROR, LOG_CERVER, s);
-                        free (s);
-                    }
+                    if (cr->socket->sock_fd > -1) {
+                        #ifdef CERVER_DEBUG 
+                        char *s = c_string_create (
+                            "cerver_receive_threads () - rc < 0 - sock fd: %d", 
+                            cr->socket->sock_fd
+                        );
+                        
+                        if (s) {
+                            cerver_log_msg (stderr, LOG_ERROR, LOG_CERVER, s);
+                            free (s);
+                        }
 
-                    perror ("Error ");
-                    #endif
+                        perror ("Error ");
+                        #endif
+                    }
 
                     free (packet_buffer);
                 } break;
@@ -1729,6 +1732,7 @@ static void *cerver_receive_http (void *cerver_receive_ptr) {
 
     CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
+    i32 sock_fd = cr->socket->sock_fd;
     ssize_t rc = 0;
     do {
         char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
@@ -1737,19 +1741,21 @@ static void *cerver_receive_http (void *cerver_receive_ptr) {
 
             switch (rc) {
                 case -1: {
-                    #ifdef CERVER_DEBUG 
-                    char *s = c_string_create (
-                        "cerver_receive_http () - rc < 0 - sock fd: %d", 
-                        cr->socket->sock_fd
-                    );
-                    
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_ERROR, LOG_CERVER, s);
-                        free (s);
-                    }
+                    if (cr->socket->sock_fd > -1) {
+                        #ifdef CERVER_DEBUG 
+                        char *s = c_string_create (
+                            "cerver_receive_http () - rc < 0 - sock fd: %d", 
+                            cr->socket->sock_fd
+                        );
+                        
+                        if (s) {
+                            cerver_log_msg (stderr, LOG_ERROR, LOG_CERVER, s);
+                            free (s);
+                        }
 
-                    perror ("Error ");
-                    #endif
+                        perror ("Error ");
+                        #endif
+                    }
                 } break;
 
                 case 0: {
@@ -1791,7 +1797,7 @@ static void *cerver_receive_http (void *cerver_receive_ptr) {
 
     char *status = c_string_create (
         "cerver_receive_http () - loop has ended - dropping sock fd <%d> connection...",
-        cr->connection->socket->sock_fd
+        sock_fd
     );
 
     if (status) {

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1649,7 +1649,6 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 
     CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
-    i32 sock_fd = cr->socket->sock_fd;
     ssize_t rc = 0;
     do {
         char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));

--- a/src/cerver/types/estring.c
+++ b/src/cerver/types/estring.c
@@ -183,45 +183,49 @@ void estring_to_lower (estring *str) {
 char **estring_split (estring *str, const char delim, int *n_tokens) {
 
     char **result = NULL;
-    size_t count = 0;
-    char *temp = str->str;
-    char *last = NULL;
-    char dlm[2] = { 0 };
-    dlm[0] = delim;
-    dlm[1] = 0;
 
-    // count how many elements will be extracted
-    while (*temp) {
-        if (delim == *temp) {
-            count++;
-            last = temp;
-        }
+	if (str) {
+		char *string = strdup (str->str);
+		if (string) {
+			// count tokens
+			size_t count = 0;
+			char *temp = (char *) str->str;
+			char last = '\0';
 
-        temp++;
-    }
+			while (*temp) {
+				if (delim == *temp) {
+					if (last != delim) count++;
+				}
 
-    count += last < (str->str + strlen (str->str) - 1);
+				last = *temp;
+				temp++;
+			}
 
-    count++;
+			if (last == delim) count--;
 
-    result = (char **) calloc (count, sizeof (char *));
-    *n_tokens = count;
+			result = (char **) calloc (count, sizeof (char *));
+			if (result) {
+				if (n_tokens) *n_tokens = count;
 
-    if (result) {
-        size_t idx = 0;
-        char *token = strtok (str->str, dlm);
+				size_t idx = 0;
 
-        while (token) {
-            // assert (idx < count);
-            *(result + idx++) = strdup (token);
-            token = strtok (0, dlm);
-        }
+				char dlm[2];
+				dlm[0] = delim;
+				dlm[1] = '\0';
 
-        // assert (idx == count - 1);
-        *(result + idx) = 0;
-    }
+				char *token = NULL;
+				char *rest = string;
+				while ((token = __strtok_r (rest, dlm, &rest))) {
+					result[idx] = strdup (token);
+					idx++;
+				}
+			}
 
-    return result;
+			free (string);
+		}
+	}
+
+	return result;
 
 }
 

--- a/src/cerver/utils/utils.c
+++ b/src/cerver/utils/utils.c
@@ -152,27 +152,25 @@ char *c_string_create (const char *format, ...) {
 }
 
 // get how many tokens will be extracted by counting the number of apperances of the delim
-unsigned int c_string_count_tokens (char *original, const char delim) {
+// the original string won't be affected
+size_t c_string_count_tokens (const char *original, const char delim) {
 
-	unsigned int count = 0;
+	size_t count = 0;
 
 	if (original) {
-		char *temp = original;
-		char *last = NULL;
+		char *temp = (char *) original;
+		char last = '\0';
 
-		// count how many elements will be extracted
 		while (*temp) {
 			if (delim == *temp) {
-				count++;
-				last = temp;
+				if (last != delim) count++;
 			}
 
+			last = *temp;
 			temp++;
 		}
 
-		count += last < (original + strlen (original) - 1);
-
-		// count++;
+		if (last == delim) count--;
 	}
 
 	return count;
@@ -180,51 +178,33 @@ unsigned int c_string_count_tokens (char *original, const char delim) {
 }
 
 // splits a c string into tokens based on a delimiter
-char **c_string_split (char *original, const char delim, unsigned int *n_tokens) {
+// the original string won't be affected
+// this method is thread safe as it uses __strtok_r () instead of the regular strtok ()
+char **c_string_split (const char *original, const char delim, size_t *n_tokens) {
 
 	char **result = NULL;
 
 	if (original) {
-		char *string = (char *) calloc (strlen (original) + 1, sizeof (char));
+		char *string = strdup (original);
 		if (string) {
-			c_string_copy (string, original);
-
-			size_t count = 0;
-			char *temp = string;
-			char *last = NULL;
-			char dlm[2];
-			dlm[0] = delim;
-			dlm[1] = 0;
-
-			// count how many elements will be extracted
-			while (*temp) {
-				if (delim == *temp) {
-					count++;
-					last = temp;
-				}
-
-				temp++;
-			}
-
-			count += last < (string + strlen (string) - 1);
-
-			count++;
+			size_t count = c_string_count_tokens (original, delim);
 
 			result = (char **) calloc (count, sizeof (char *));
-			if (n_tokens) *n_tokens = count;
-
 			if (result) {
+				if (n_tokens) *n_tokens = count;
+
 				size_t idx = 0;
-				char *token = strtok (string, dlm);
 
-				while (token) {
-					// assert (idx < count);
-					*(result + idx++) = strdup (token);
-					token = strtok (0, dlm);
+				char dlm[2];
+				dlm[0] = delim;
+				dlm[1] = '\0';
+
+				char *token = NULL;
+				char *rest = string;
+				while ((token = __strtok_r (rest, dlm, &rest))) {
+					result[idx] = strdup (token);
+					idx++;
 				}
-
-				// assert (idx == count - 1);
-				*(result + idx) = 0;
 			}
 
 			free (string);

--- a/src/cerver/utils/utils.c
+++ b/src/cerver/utils/utils.c
@@ -217,22 +217,23 @@ char **c_string_split (const char *original, const char delim, size_t *n_tokens)
 
 // revers a c string
 // returns a newly allocated c string
-char *c_string_reverse (char *str) {
+char *c_string_reverse (const char *str) {
 
 	char *reverse = NULL;
 
 	if (str) {
 		size_t len = strlen (str);
-		reverse = (char *) calloc (len, sizeof (char));
+		reverse = (char *) calloc (len + 1, sizeof (char));
+		if (reverse) {
+			size_t end = len - 1;
+			size_t begin = 0;
+			for (; begin < len; begin++) {
+				reverse[begin] = str[end];
+				end--;
+			}
 
-		size_t end = len - 1;
-		size_t begin = 0;
-		for ( ; begin < len; begin++) {
-			reverse[begin] = str[end];
-			end--;
+			reverse[begin] = '\0';
 		}
-
-		reverse[begin] = '\0';
 	}
 
 	return reverse;

--- a/src/cerver/utils/utils.c
+++ b/src/cerver/utils/utils.c
@@ -151,8 +151,36 @@ char *c_string_create (const char *format, ...) {
 
 }
 
+// get how many tokens will be extracted by counting the number of apperances of the delim
+unsigned int c_string_count_tokens (char *original, const char delim) {
+
+	unsigned int count = 0;
+
+	if (original) {
+		char *temp = original;
+		char *last = NULL;
+
+		// count how many elements will be extracted
+		while (*temp) {
+			if (delim == *temp) {
+				count++;
+				last = temp;
+			}
+
+			temp++;
+		}
+
+		count += last < (original + strlen (original) - 1);
+
+		// count++;
+	}
+
+	return count;
+
+}
+
 // splits a c string into tokens based on a delimiter
-char **c_string_split (char *original, const char delim, int *n_tokens) {
+char **c_string_split (char *original, const char delim, unsigned int *n_tokens) {
 
 	char **result = NULL;
 


### PR DESCRIPTION
## General
- Added base c_string_count_tokens () utility
- Creating base dedicated cerver type data in cerver_create (). This was previously being done in cerver_init_data_structures ()
- Performing cerver type based one type init as well in one_time_init ()
- New estring_split () implementation

## Handler
- Small refactor in cerver_receive_http () & cerver_receive_threads ()