### PR TITLE
HTTP Beta 2.0b-2

### DIFF
--- a/examples/packets.c
+++ b/examples/packets.c
@@ -137,7 +137,7 @@ static void handle_test_request (Packet *packet) {
 static void handle_app_message (Packet *packet) {
 
 	if (packet) {
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 
 		AppData *app_data = (AppData *) end;
 		app_data_print (app_data);
@@ -151,7 +151,7 @@ static void handle_multi_message (Packet *packet) {
 	if (packet) {
 		cerver_log_debug ("MULTI message!");
 
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 
 		AppData *app_data = NULL;
 		for (u32 i = 0; i < 5; i++) {

--- a/examples/web/api.c
+++ b/examples/web/api.c
@@ -164,7 +164,7 @@ static void *user_parse_from_json (void *user_json_ptr) {
 // GET api/users
 static void main_users_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Users route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Users route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -229,7 +229,7 @@ static void users_login_handler (CerverReceive *cr, HttpRequest *request) {
 				}
 
 				else {
-					HttpResponse *res = http_response_json_error (500, "Internal error!");
+					HttpResponse *res = http_response_json_error ((http_status) 500, "Internal error!");
 					if (res) {
 						http_response_print (res);
 						http_response_send (res, cr->cerver, cr->connection);
@@ -241,7 +241,7 @@ static void users_login_handler (CerverReceive *cr, HttpRequest *request) {
 			}
 
 			else {
-				HttpResponse *res = http_response_json_error (400, "Password is incorrect!");
+				HttpResponse *res = http_response_json_error ((http_status) 400, "Password is incorrect!");
 				if (res) {
 					http_response_print (res);
 					http_response_send (res, cr->cerver, cr->connection);
@@ -251,7 +251,7 @@ static void users_login_handler (CerverReceive *cr, HttpRequest *request) {
 		}
 
 		else {
-			HttpResponse *res = http_response_json_error (404, "User not found!");
+			HttpResponse *res = http_response_json_error ((http_status) 404, "User not found!");
 			if (res) {
 				http_response_print (res);
 				http_response_send (res, cr->cerver, cr->connection);
@@ -261,7 +261,7 @@ static void users_login_handler (CerverReceive *cr, HttpRequest *request) {
 	}
 
 	else {
-		HttpResponse *res = http_response_json_error (400, "Missing user values!");
+		HttpResponse *res = http_response_json_error ((http_status) 400, "Missing user values!");
 		if (res) {
 			http_response_print (res);
 			http_response_send (res, cr->cerver, cr->connection);
@@ -296,7 +296,7 @@ static void users_register_handler (CerverReceive *cr, HttpRequest *request) {
 			cerver_log_success ("Created a new user!");
 			printf ("\n");
 
-			HttpResponse *res = http_response_json_msg (200, "Created a new user!");
+			HttpResponse *res = http_response_json_msg ((http_status) 200, "Created a new user!");
 			if (res) {
 				http_response_print (res);
 				http_response_send (res, cr->cerver, cr->connection);
@@ -305,7 +305,7 @@ static void users_register_handler (CerverReceive *cr, HttpRequest *request) {
 		}
 
 		else {
-			HttpResponse *res = http_response_json_error (500, "Internal error!");
+			HttpResponse *res = http_response_json_error ((http_status) 500, "Internal error!");
 			if (res) {
 				http_response_print (res);
 				http_response_send (res, cr->cerver, cr->connection);
@@ -315,7 +315,7 @@ static void users_register_handler (CerverReceive *cr, HttpRequest *request) {
 	}
 
 	else {
-		HttpResponse *res = http_response_json_error (400, "Missing user values!");
+		HttpResponse *res = http_response_json_error ((http_status) 400, "Missing user values!");
 		if (res) {
 			http_response_print (res);
 			http_response_send (res, cr->cerver, cr->connection);
@@ -332,7 +332,7 @@ static void users_profile_handler (CerverReceive *cr, HttpRequest *request) {
 
 	char *message = c_string_create ("%s profile!", user->name->str);
 
-	HttpResponse *res = http_response_json_msg (200, message);
+	HttpResponse *res = http_response_json_msg ((http_status) 200, message);
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -346,7 +346,7 @@ static void users_profile_handler (CerverReceive *cr, HttpRequest *request) {
 // *
 static void catch_all_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Cerver API implementation!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Cerver API implementation!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);

--- a/examples/web/sockets.c
+++ b/examples/web/sockets.c
@@ -44,7 +44,7 @@ void end (int dummy) {
 
 void test_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Test route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Test route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -55,7 +55,7 @@ void test_handler (CerverReceive *cr, HttpRequest *request) {
 
 void echo_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Echo route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Echo route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -94,7 +94,7 @@ void echo_handler_on_message (
 
 void chat_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Chat route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Chat route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);

--- a/examples/web/upload.c
+++ b/examples/web/upload.c
@@ -46,7 +46,7 @@ void end (int dummy) {
 // GET /test
 void test_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Test route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Test route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -60,7 +60,7 @@ void upload_handler (CerverReceive *cr, HttpRequest *request) {
 
 	http_request_multi_parts_print (request);
 
-	HttpResponse *res = http_response_json_msg (200, "Upload route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Upload route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);

--- a/examples/web/web.c
+++ b/examples/web/web.c
@@ -54,7 +54,7 @@ void main_handler (CerverReceive *cr, HttpRequest *request) {
 // GET /test
 void test_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Test route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Test route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -66,7 +66,7 @@ void test_handler (CerverReceive *cr, HttpRequest *request) {
 // GET /text
 void text_handler (CerverReceive *cr, HttpRequest *request) {
 
-	char *text = "<!DOCTYPE html><html><head><meta charset=\"utf-8\" /><title>Cerver</title></head><body><h2>hola_handler () works!</h2></body></html>";
+	char const *text = "<!DOCTYPE html><html><head><meta charset=\"utf-8\" /><title>Cerver</title></head><body><h2>hola_handler () works!</h2></body></html>";
 	size_t text_len = strlen (text);
 
 	if (http_response_render_text (cr, text, text_len)) {
@@ -78,7 +78,7 @@ void text_handler (CerverReceive *cr, HttpRequest *request) {
 // GET /json
 void json_handler (CerverReceive *cr, HttpRequest *request) {
 
-	char *json = "{\"msg\": \"okay\"}";
+	char const *json = "{\"msg\": \"okay\"}";
 	size_t json_len = strlen (json);
 
 	if (http_response_render_json (cr, json, json_len)) {
@@ -90,7 +90,7 @@ void json_handler (CerverReceive *cr, HttpRequest *request) {
 // GET /hola
 void hola_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Hola route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Hola route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);
@@ -102,7 +102,7 @@ void hola_handler (CerverReceive *cr, HttpRequest *request) {
 // GET /adios
 void adios_handler (CerverReceive *cr, HttpRequest *request) {
 
-	HttpResponse *res = http_response_json_msg (200, "Adios route works!");
+	HttpResponse *res = http_response_json_msg ((http_status) 200, "Adios route works!");
 	if (res) {
 		http_response_print (res);
 		http_response_send (res, cr->cerver, cr->connection);

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-1"
-#define CERVER_VERSION_NAME             "Beta 2.0b-1"
+#define CERVER_VERSION                  "2.0b-2"
+#define CERVER_VERSION_NAME             "Beta 2.0b-2"
 #define CERVER_VERSION_DATE			    "18/10/2020"
-#define CERVER_VERSION_TIME			    "13:18 CST"
+#define CERVER_VERSION_TIME			    "19:17 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/utils/log.c
+++ b/src/cerver/utils/log.c
@@ -172,7 +172,7 @@ void cerver_log (
 ) {
 
 	if (format) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, format);
 
 		cerver_log_internal (
@@ -193,7 +193,7 @@ void cerver_log_msg (
 ) {
 
 	if (__stream && msg) {
-		va_list args = { 0 };
+		va_list args;
 
 		cerver_log_internal (
 			__stream,
@@ -208,7 +208,7 @@ void cerver_log_msg (
 void cerver_log_error (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		cerver_log_internal (
@@ -226,7 +226,7 @@ void cerver_log_error (const char *msg, ...) {
 void cerver_log_warning (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		cerver_log_internal (
@@ -244,7 +244,7 @@ void cerver_log_warning (const char *msg, ...) {
 void cerver_log_success (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		cerver_log_internal (
@@ -262,7 +262,7 @@ void cerver_log_success (const char *msg, ...) {
 void cerver_log_debug (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		cerver_log_internal (


### PR DESCRIPTION
## Fixes

- Refactor logs methods to fix cpp errors. Compiler error mesage: **error: cannot convert ‘int’ to ‘__va_list_tag’ in initialization**
- Fixed cast error warnings in packets example
- Fixed warnings in web examples when compiling with g++