### PR TITLE
HTTP Beta 2.0b-3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ keys
 
 data
 uploads
+
+logs

--- a/examples/admin.c
+++ b/examples/admin.c
@@ -33,7 +33,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -53,18 +53,18 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from ADMIN. Sending another one back...");
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -78,8 +78,8 @@ static void admin_handler (void *data) {
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -117,7 +117,7 @@ static u8 my_auth_method_username (AuthMethod *auth_method, const char *username
 }
 
 static u8 my_auth_method_password (AuthMethod *auth_method, const char *password) {
-
+	
 	u8 retval = 1;
 
 	if (password) {
@@ -191,17 +191,13 @@ static void on_hold_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
 			"Conenction %d is on hold in cerver %s!\n",
 			event_data->connection->socket->sock_fd,
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CERVER, status);
-			free (status);
-		}
 	}
 
 }
@@ -211,16 +207,12 @@ static void on_hold_disconnected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection disconnected in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection disconnected in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -230,16 +222,12 @@ static void on_hold_drop (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection was dropped in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection was dropped in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -249,17 +237,13 @@ static void on_admin_failed_auth (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"Admin failed to authenticate connection with sock fd %d to cerver %s!\n",
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -269,18 +253,14 @@ static void on_admin_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"Admin with client %ld authenticated connection with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -290,18 +270,14 @@ static void on_admin_new_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"Admin with client %ld new connection with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -311,16 +287,12 @@ static void on_admin_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"An admin closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -330,16 +302,12 @@ static void on_admin_disconnected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"An admin disconnected from cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -349,16 +317,12 @@ static void on_admin_dropped (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_ADMIN,
 			"An admin was dropped from cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_ADMIN, status);
-			free (status);
-		}
 	}
 
 }
@@ -377,7 +341,7 @@ void admin_update_thread (void *data) {
 }
 
 void admin_update_internal_thread (void *data) {
-
+	
 	printf ("Updating every second!\n");
 
 }
@@ -430,63 +394,63 @@ int main (void) {
 		admin_cerver_set_app_handlers (my_cerver->admin, admin_app_handler, NULL);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_CONNECTED,
 			on_hold_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DISCONNECTED,
 			on_hold_disconnected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DROPPED,
 			on_hold_drop, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_FAILED_AUTH,
 			on_admin_failed_auth, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_CONNECTED,
 			on_admin_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_NEW_CONNECTION,
 			on_admin_new_connection, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_CLOSE_CONNECTION,
 			on_admin_close_connection, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_DISCONNECTED,
 			on_admin_disconnected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ADMIN_DROPPED,
 			on_admin_dropped, NULL, NULL,
 			false, false

--- a/examples/advanced.c
+++ b/examples/advanced.c
@@ -27,18 +27,18 @@ static void handle_test_request (Packet *packet, PacketType packet_type) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
-
+		
 		Packet *test_packet = packet_generate_request (packet_type, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -51,13 +51,13 @@ static void my_app_handler_direct (void *data) {
 		Packet *packet = (Packet *) data;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_PACKET test request!");
-				handle_test_request (packet, APP_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP test request!");
+				handle_test_request (packet, PACKET_TYPE_APP); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP request.");
 				break;
 		}
 	}
@@ -70,13 +70,13 @@ static void my_app_error_handler_direct (void *data) {
 		Packet *packet = (Packet *) data;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
-				handle_test_request (packet, APP_ERROR_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP_ERROR test request!");
+				handle_test_request (packet, PACKET_TYPE_APP_ERROR); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_ERROR_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP_ERROR request.");
 				break;
 		}
 	}
@@ -87,15 +87,15 @@ static void my_custom_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-
+		
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a CUSTOM_PACKET test request!");
-				handle_test_request (packet, CUSTOM_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_CUSTOM test request!");
+				handle_test_request (packet, PACKET_TYPE_CUSTOM); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown CUSTOM_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_CUSTOM request.");
 				break;
 		}
 	}
@@ -118,7 +118,7 @@ void update_thread (void *data) {
 }
 
 void update_interval_thread (void *data) {
-
+	
 	CerverUpdate *cerver_update = (CerverUpdate *) data;
 
 	printf ("%s\n", ((String *) cerver_update->args)->str);
@@ -136,18 +136,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -157,16 +153,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -176,7 +168,7 @@ static void on_client_close_connection (void *event_data_ptr) {
 #pragma region main
 
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -227,14 +219,14 @@ int main (void) {
 		cerver_set_custom_handler (my_cerver, app_custom_handler);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -261,7 +253,7 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -32,7 +32,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -52,18 +52,18 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -77,8 +77,8 @@ static void handler (void *data) {
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -116,7 +116,7 @@ static u8 my_auth_method_username (AuthMethod *auth_method, const char *username
 }
 
 static u8 my_auth_method_password (AuthMethod *auth_method, const char *password) {
-
+	
 	u8 retval = 1;
 
 	if (password) {
@@ -190,17 +190,13 @@ static void on_hold_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
 			"Conenction %d is on hold in cerver %s!\n",
 			event_data->connection->socket->sock_fd,
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CERVER, status);
-			free (status);
-		}
 	}
 
 }
@@ -210,16 +206,12 @@ static void on_hold_disconnected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection disconnected in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection disconnected in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -229,16 +221,12 @@ static void on_hold_drop (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection was dropped in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection was dropped in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -248,18 +236,14 @@ static void on_client_success_auth (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld authenticated connection with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -269,17 +253,13 @@ static void on_client_failed_auth (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client failed to authenticate connection with sock fd %d to cerver %s!\n",
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -289,18 +269,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -310,16 +286,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -362,49 +334,49 @@ int main (void) {
 		cerver_set_auth (my_cerver, 2, my_auth_method);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_CONNECTED,
 			on_hold_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DISCONNECTED,
 			on_hold_disconnected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DROPPED,
 			on_hold_drop, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_SUCCESS_AUTH,
 			on_client_success_auth, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_FAILED_AUTH,
 			on_client_failed_auth, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -423,7 +395,7 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/client/auth.c
+++ b/examples/client/auth.c
@@ -71,10 +71,10 @@ static void client_app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG: cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -104,7 +104,7 @@ static u8 cerver_client_connect (Client *client, Connection **connection) {
 			);
 
 			if (!client_connect_to_cerver (client, *connection)) {
-				cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+				cerver_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 
 				client_connection_start (client, *connection);
 
@@ -112,7 +112,7 @@ static u8 cerver_client_connect (Client *client, Connection **connection) {
 			}
 
 			else {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 			}
 		}
 	}
@@ -127,12 +127,10 @@ static void client_event_connection_close (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_connection_close () - connection <%s> has been closed!",
-				client_event_data->connection->name->str);
-			if (status) {
-				cerver_log_warning (status);
-				free (status);
-			}
+			cerver_log_warning (
+				"client_event_connection_close () - connection <%s> has been closed!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -146,12 +144,10 @@ static void client_event_auth_sent (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_auth_sent () - sent connection <%s> auth data!",
-				client_event_data->connection->name->str);
-			if (status) {
-				cerver_log_debug (status);
-				free (status);
-			}
+			cerver_log_debug (
+				"client_event_auth_sent () - sent connection <%s> auth data!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -165,12 +161,10 @@ static void client_error_failed_auth (void *client_error_data_ptr) {
 		ClientErrorData *client_error_data = (ClientErrorData *) client_error_data_ptr;
 
 		if (client_error_data->connection) {
-			char *status = c_string_create ("client_error_failed_auth () - connection <%s> failed to authenticate!",
-				client_error_data->connection->name->str);
-			if (status) {
-				cerver_log_error (status);
-				free (status);
-			}
+			cerver_log_error (
+				"client_error_failed_auth () - connection <%s> failed to authenticate!",
+				client_error_data->connection->name->str
+			);
 		}
 
 		client_error_data_delete (client_error_data);
@@ -184,12 +178,10 @@ static void client_event_success_auth (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_success_auth () - connection <%s> has been authenticated!",
-				client_event_data->connection->name->str);
-			if (status) {
-				cerver_log_success (status);
-				free (status);
-			}
+			cerver_log_success (
+				"client_event_success_auth () - connection <%s> has been authenticated!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -202,16 +194,16 @@ static int client_test_app_msg_send (Client *client, Connection *connection) {
 	int retval = 1;
 
 	if ((client->running) && connection->active) {
-		Packet *packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (packet) {
 			packet_set_network_values (packet, NULL, client, connection, NULL);
 			size_t sent = 0;
 			if (packet_send (packet, 0, &sent, false)) {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
 			}
 
 			else {
-				printf ("APP_PACKET sent to cerver: %ld\n", sent);
+				printf ("PACKET_TYPE_APP sent to cerver: %ld\n", sent);
 				retval = 0;
 			}
 
@@ -231,9 +223,9 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		// cerver_log_debug ("Got a test message from client. Sending another one back...");
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
 
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
@@ -259,7 +251,7 @@ static void handler (void *data) {
 			case TEST_MSG: handle_test_request (packet); break;
 
 			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -56,7 +56,7 @@ static void cerver_handle_test_request (Packet *packet) {
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
 
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
@@ -82,7 +82,7 @@ static void cerver_app_handler_direct (void *data) {
 			case TEST_MSG: cerver_handle_test_request (packet); break;
 
 			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -99,7 +99,7 @@ static void client_app_handler_direct (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 		if (packet) {
 			switch (packet->header->request_type) {
-				case TEST_MSG: cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+				case TEST_MSG: cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 				case GET_MSG: {
 					char *end = (char *) packet->data;
@@ -109,7 +109,7 @@ static void client_app_handler_direct (void *packet_ptr) {
 				} break;
 
 				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -130,7 +130,7 @@ static void client_app_handler (void *data) {
 			} break;
 
 			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -147,11 +147,11 @@ static Connection *cerver_client_connect (Client *client) {
 			connection_set_max_sleep (connection, 30);
 
 			if (!client_connect_to_cerver (client, connection)) {
-				cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+				cerver_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 			}
 
 			else {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 			}
 		}
 	}
@@ -173,14 +173,14 @@ static int request_message (Client *client, Connection *connection) {
 
 		char *end = (char *) packet->packet;
 		PacketHeader *header = (PacketHeader *) end;
-		header->packet_type = APP_PACKET;
+		header->packet_type = PACKET_TYPE_APP;
 		header->packet_size = packet_len;
 		header->handler_id = 0;
 		header->request_type = GET_MSG;
 
 		printf ("Requesting to cerver...\n");
 		if (client_request_to_cerver (client, connection, packet)) {
-			cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
+			cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
 		}
 		printf ("Request has ended\n");
 
@@ -237,16 +237,16 @@ static int test_app_msg_send (Client *client, Connection *connection) {
 	int retval = 1;
 
 	if ((client->running) && connection->active) {
-		Packet *packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (packet) {
 			packet_set_network_values (packet, NULL, client, connection, NULL);
 			size_t sent = 0;
 			if (packet_send (packet, 0, &sent, false)) {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
 			}
 
 			else {
-				printf ("APP_PACKET sent to cerver: %ld\n", sent);
+				printf ("PACKET_TYPE_APP sent to cerver: %ld\n", sent);
 				retval = 0;
 			}
 
@@ -278,11 +278,11 @@ static void *cerver_client_connect_and_start (void *args) {
 			connection_set_max_sleep (connection, 30);
 
 			if (!client_connect_and_start (client, connection)) {
-				cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+				cerver_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 			}
 
 			else {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 			}
 		}
 

--- a/examples/client/files.c
+++ b/examples/client/files.c
@@ -1,0 +1,254 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <time.h>
+#include <signal.h>
+
+#include <cerver/version.h>
+#include <cerver/cerver.h>
+
+#include <cerver/threads/thread.h>
+
+#include <cerver/utils/log.h>
+#include <cerver/utils/utils.h>
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0,
+
+	GET_MSG			= 1
+
+} AppRequest;
+
+// message from the cerver
+typedef struct AppMessage {
+
+	unsigned int len;
+	char message[128];
+
+} AppMessage;
+
+static Cerver *client_cerver = NULL;
+
+#pragma region end
+
+// correctly closes any on-going server and process when quitting the appplication
+static void end (int dummy) {
+
+	if (client_cerver) {
+		cerver_stats_print (client_cerver, true, true);
+		cerver_teardown (client_cerver);
+	}
+
+	cerver_end ();
+
+	exit (0);
+
+}
+
+#pragma endregion
+
+#pragma region handler
+
+static void cerver_handle_test_request (Packet *packet) {
+
+	if (packet) {
+		cerver_log_debug ("Got a test message from client. Sending another one back...");
+
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
+		if (test_packet) {
+			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
+			size_t sent = 0;
+			if (packet_send (test_packet, 0, &sent, false))
+				cerver_log_error ("Failed to send test packet to client!");
+
+			else {
+				// printf ("Response packet sent: %ld\n", sent);
+			}
+
+			packet_delete (test_packet);
+		}
+	}
+
+}
+
+static void cerver_app_handler_direct (void *data) {
+
+	if (data) {
+		Packet *packet = (Packet *) data;
+
+		switch (packet->header->request_type) {
+			case TEST_MSG: cerver_handle_test_request (packet); break;
+
+			default:
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				break;
+		}
+	}
+
+}
+
+#pragma endregion
+
+#pragma region client
+
+static void client_app_handler (void *data) {
+
+	if (data) {
+		HandlerData *handler_data = (HandlerData *) data;
+
+		// AppData *app_data = (AppData *) handler_data->data;
+		Packet *packet = handler_data->packet;
+		switch (packet->header->request_type) {
+			case TEST_MSG: {
+				cerver_log_debug ("Got a test message from cerver!");
+			} break;
+
+			default:
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				break;
+		}
+	}
+
+}
+
+static int test_app_msg_send (Client *client, Connection *connection) {
+
+	int retval = 1;
+
+	if ((client->running) && connection->active) {
+		Packet *packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
+		if (packet) {
+			packet_set_network_values (packet, NULL, client, connection, NULL);
+			size_t sent = 0;
+			if (packet_send (packet, 0, &sent, false)) {
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+			}
+
+			else {
+				printf ("PACKET_TYPE_APP sent to cerver: %ld\n", sent);
+				retval = 0;
+			}
+
+			packet_delete (packet);
+		}
+	}
+
+	return retval;
+
+}
+
+static void *cerver_client_connect_and_start (void *args) {
+
+	Client *client = client_create ();
+	if (client) {
+		client_set_name (client, "start-client");
+
+		Handler *app_handler = handler_create (client_app_handler);
+		// handler_set_direct_handle (app_handler, true);
+		client_set_app_handlers (client, app_handler, NULL);
+
+		// wait 2 seconds before connecting to cerver
+		sleep (2);
+		Connection *connection = client_connection_create (client, "127.0.0.1", 7000, PROTOCOL_TCP, false);
+		if (connection) {
+			connection_set_max_sleep (connection, 30);
+
+			if (!client_connect_and_start (client, connection)) {
+				cerver_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+			}
+
+			else {
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+			}
+		}
+
+		// send 1 request message every second
+		for (unsigned int i = 0; i < 5; i++) {
+			test_app_msg_send (client, connection);
+
+			sleep (1);
+		}
+
+		client_connection_end (client, connection);
+
+		// destroy the client and its connection
+		// client_teardown_async (client);
+		// cerver_log_success ("client_teardown ()");
+
+		if (!client_teardown (client)) {
+			cerver_log_success ("client_teardown ()");
+		}
+
+		else {
+			cerver_log_error ("client_teardown () has failed!");
+		}
+	}
+
+	return NULL;
+
+}
+
+#pragma endregion
+
+#pragma region start
+
+int main (void) {
+
+	srand (time (NULL));
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	cerver_init ();
+
+	printf ("\n");
+	cerver_version_print_full ();
+	printf ("\n");
+
+	cerver_log_debug ("Cerver Client Files Example");
+	printf ("\n");
+	cerver_log_debug ("Cerver creates a new client that will use to make files requests to another cerver");
+	printf ("\n");
+
+	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	if (client_cerver) {
+		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Files Example");
+
+		/*** cerver configuration ***/
+		cerver_set_receive_buffer_size (client_cerver, 4096);
+		cerver_set_thpool_n_threads (client_cerver, 4);
+
+		Handler *app_handler = handler_create (cerver_app_handler_direct);
+		handler_set_direct_handle (app_handler, true);
+		cerver_set_app_handlers (client_cerver, app_handler, NULL);
+
+		pthread_t client_thread = 0;
+		thread_create_detachable (&client_thread, cerver_client_connect_and_start, NULL);
+
+		if (cerver_start (client_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				client_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (client_cerver);
+		}
+	}
+
+	else {
+		cerver_log_error ("Failed to create cerver!");
+
+		cerver_delete (client_cerver);
+	}
+
+	cerver_end ();
+
+	return 0;
+
+}
+
+#pragma endregion

--- a/examples/files.c
+++ b/examples/files.c
@@ -1,0 +1,244 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <time.h>
+#include <signal.h>
+
+#include <cerver/version.h>
+#include <cerver/cerver.h>
+#include <cerver/events.h>
+#include <cerver/files.h>
+
+#include <cerver/utils/log.h>
+#include <cerver/utils/utils.h>
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0
+
+} AppRequest;
+
+static Cerver *my_cerver = NULL;
+
+#pragma region end
+
+// correctly closes any on-going server and process when quitting the appplication
+static void end (int dummy) {
+	
+	if (my_cerver) {
+		cerver_stats_print (my_cerver, true, true);
+		cerver_teardown (my_cerver);
+	}
+
+	cerver_end ();
+
+	exit (0);
+
+}
+
+#pragma endregion
+
+#pragma region handler
+
+static void handle_test_request (Packet *packet) {
+
+	if (packet) {
+		// cerver_log_debug ("Got a test message from client. Sending another one back...");
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
+		if (test_packet) {
+			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
+			size_t sent = 0;
+			if (packet_send (test_packet, 0, &sent, false)) 
+				cerver_log_error ("Failed to send test packet to client!");
+
+			else {
+				// printf ("Response packet sent: %ld\n", sent);
+			}
+			
+			packet_delete (test_packet);
+		}
+	}
+
+}
+
+static void handler (void *data) {
+
+	if (data) {
+		Packet *packet = (Packet *) data;
+		
+		switch (packet->header->request_type) {
+			case TEST_MSG: handle_test_request (packet); break;
+
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				break;
+		}
+	}
+
+}
+
+#pragma endregion
+
+#pragma region events
+
+static void on_cever_started (void *event_data_ptr) {
+
+	if (event_data_ptr) {
+		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
+
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
+			"Cerver %s has started!\n", 
+			event_data->cerver->info->name->str
+		);
+	}
+
+}
+
+static void on_cever_teardown (void *event_data_ptr) {
+
+	if (event_data_ptr) {
+		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
+
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
+			"Cerver %s is going to be destroyed!\n", 
+			event_data->cerver->info->name->str
+		);
+	}
+
+}
+
+static void on_client_connected (void *event_data_ptr) {
+
+	if (event_data_ptr) {
+		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
+
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
+			"Client %ld connected with sock fd %d to cerver %s!\n",
+			event_data->client->id,
+			event_data->connection->socket->sock_fd, 
+			event_data->cerver->info->name->str
+		);
+	}
+
+}
+
+static void on_client_close_connection (void *event_data_ptr) {
+
+	if (event_data_ptr) {
+		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
+
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
+			"A client closed a connection to cerver %s!\n",
+			event_data->cerver->info->name->str
+		);
+	}
+
+}
+
+#pragma endregion
+
+#pragma region main
+
+int main (void) {
+
+	srand (time (NULL));
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	cerver_init ();
+
+	printf ("\n");
+	cerver_version_print_full ();
+	printf ("\n");
+
+	cerver_log_debug ("Simple File Cerver Example");
+	printf ("\n");
+	cerver_log_debug ("Cerver is configured to accept & handle files requests");
+	printf ("\n");
+
+	my_cerver = cerver_create (CERVER_TYPE_FILES, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	if (my_cerver) {
+		cerver_set_welcome_msg (my_cerver, "Welcome - Simple file cerver example");
+
+		/*** cerver configuration ***/
+		cerver_set_receive_buffer_size (my_cerver, 4096);
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
+		cerver_set_handle_detachable_threads (my_cerver, true);
+		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		Handler *app_handler = handler_create (handler);
+		// 27/05/2020 - needed for this example!
+		handler_set_direct_handle (app_handler, true);
+		cerver_set_app_handlers (my_cerver, app_handler, NULL);
+
+		cerver_event_register (
+			my_cerver, 
+			CERVER_EVENT_STARTED,
+			on_cever_started, NULL, NULL,
+			false, false
+		);
+
+		cerver_event_register (
+			my_cerver, 
+			CERVER_EVENT_TEARDOWN,
+			on_cever_teardown, NULL, NULL,
+			false, false
+		);
+
+		cerver_event_register (
+			my_cerver, 
+			CERVER_EVENT_CLIENT_CONNECTED,
+			on_client_connected, NULL, NULL,
+			false, false
+		);
+
+		cerver_event_register (
+			my_cerver, 
+			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
+			on_client_close_connection, NULL, NULL,
+			false, false
+		);
+
+		/*** file cerver configuration ***/
+		FileCerver *file_cerver = (FileCerver *) my_cerver->cerver_data;
+
+		file_cerver_add_path (file_cerver, "./data");
+		file_cerver_set_uploads_path (file_cerver, "./uploads");
+
+		if (cerver_start (my_cerver)) {
+			char *s = c_string_create ("Failed to start %s!",
+				my_cerver->info->name->str);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+
+			cerver_delete (my_cerver);
+		}
+	}
+
+	else {
+		cerver_log_error ("Failed to create cerver!");
+
+		cerver_delete (my_cerver);
+	}
+
+	cerver_end ();
+
+	return 0;
+
+}
+
+#pragma endregion

--- a/examples/game.c
+++ b/examples/game.c
@@ -18,7 +18,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void my_game_end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		printf ("\nGame Stats:\n");
@@ -43,7 +43,7 @@ static int my_game_init (void) {
 
 static void my_game_packet_handler (void *data) {
 
-	// method to handle APP_PACKET type packets that are specific for your application
+	// method to handle PACKET_TYPE_APP type packets that are specific for your application 
 
 }
 
@@ -106,7 +106,7 @@ int main (void) {
 			GameCerver *game_cerver = (GameCerver *) my_cerver->cerver_data;
 
 			// register the arcade game type
-			GameType *arcade_game_type = game_type_create ("arcade", NULL, NULL,
+			GameType *arcade_game_type = game_type_create ("arcade", NULL, NULL, 
 				arcade_game_start, arcade_game_end);
 			game_type_add_lobby_config (arcade_game_type, true, NULL, 4);
 			game_type_set_on_lobby_join (arcade_game_type, arcade_game_join);
@@ -134,8 +134,10 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE,
-			"Failed to init my game!");
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_NONE,
+			"Failed to init my game!"
+		);
 	}
 
 	cerver_end ();

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -36,7 +36,7 @@ typedef enum AppRequest {
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -56,18 +56,18 @@ static void handle_test_request (Packet *packet, PacketType packet_type) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
-
+		
 		Packet *test_packet = packet_generate_request (packet_type, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -85,13 +85,13 @@ static void my_app_handler_queue (void *handler_data_ptr) {
 		Packet *packet = handler_data->packet;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_PACKET test request!");
-				handle_test_request (packet, APP_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP test request!");
+				handle_test_request (packet, PACKET_TYPE_APP); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP request.");
 				break;
 		}
 	}
@@ -105,13 +105,13 @@ static void my_app_error_handler_queue (void *handler_data_ptr) {
 		Packet *packet = handler_data->packet;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
-				handle_test_request (packet, APP_ERROR_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP_ERROR test request!");
+				handle_test_request (packet, PACKET_TYPE_APP_ERROR); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_ERROR_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP_ERROR request.");
 				break;
 		}
 	}
@@ -123,15 +123,15 @@ static void my_custom_handler_queue (void *handler_data_ptr) {
 	if (handler_data_ptr) {
 		HandlerData *handler_data = (HandlerData *) handler_data_ptr;
 		Packet *packet = handler_data->packet;
-
+		
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a CUSTOM_PACKET test request!");
-				handle_test_request (packet, CUSTOM_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_CUSTOM test request!");
+				handle_test_request (packet, PACKET_TYPE_CUSTOM); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown CUSTOM_PACKET request.");
+			default: 
+				cerver_log ( LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_CUSTOM request.");
 				break;
 		}
 	}
@@ -148,13 +148,13 @@ static void my_app_handler_direct (void *data) {
 		Packet *packet = (Packet *) data;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_PACKET test request!");
-				handle_test_request (packet, APP_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP test request!");
+				handle_test_request (packet, PACKET_TYPE_APP); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP request.");
 				break;
 		}
 	}
@@ -167,13 +167,13 @@ static void my_app_error_handler_direct (void *data) {
 		Packet *packet = (Packet *) data;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a APP_ERROR_PACKET test request!");
-				handle_test_request (packet, APP_ERROR_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_APP_ERROR test request!");
+				handle_test_request (packet, PACKET_TYPE_APP_ERROR); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown APP_ERROR_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_APP_ERROR request.");
 				break;
 		}
 	}
@@ -184,15 +184,15 @@ static void my_custom_handler_direct (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-
+		
 		switch (packet->header->request_type) {
-			case TEST_MSG:
-				cerver_log_debug ("Got a CUSTOM_PACKET test request!");
-				handle_test_request (packet, CUSTOM_PACKET);
+			case TEST_MSG: 
+				cerver_log_debug ("Got a PACKET_TYPE_CUSTOM test request!");
+				handle_test_request (packet, PACKET_TYPE_CUSTOM); 
 				break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown CUSTOM_PACKET request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown PACKET_TYPE_CUSTOM request.");
 				break;
 		}
 	}
@@ -208,18 +208,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -229,16 +225,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -300,14 +292,14 @@ static void start (HandlersType type) {
 		cerver_set_custom_handler (my_cerver, app_custom_handler);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -326,9 +318,9 @@ static void start (HandlersType type) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
-		cerver_delete (my_cerver);
+        cerver_delete (my_cerver);
 	}
 
 }
@@ -361,7 +353,7 @@ int main (int argc, char **argv) {
 	printf ("\n");
 
 	cerver_log_debug ("App & Custom Handlers Example");
-	cerver_log_debug ("Testing correct handling of APP_PACKET, APP_ERROR_PACKET & CUSTOM_PACKET packet types");
+	cerver_log_debug ("Testing correct handling of PACKET_TYPE_APP, PACKET_TYPE_APP_ERROR & PACKET_TYPE_CUSTOM packet types");
 	printf ("\n");
 
 	char *type = NULL;

--- a/examples/logs.c
+++ b/examples/logs.c
@@ -24,11 +24,19 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
 	}
+
+	cerver_end ();
+
+	exit (0);
+
+}
+
+static void quit (int dummy) {
 
 	cerver_end ();
 
@@ -43,19 +51,19 @@ static void end (int dummy) {
 static void handle_test_request (Packet *packet) {
 
 	// cerver_log_debug ("Got a test message from client. Sending another one back...");
-	cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
-
-	Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+	cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+	
+	Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 	if (test_packet) {
 		packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 		size_t sent = 0;
-		if (packet_send (test_packet, 0, &sent, false))
+		if (packet_send (test_packet, 0, &sent, false)) 
 			cerver_log_error ("Failed to send test packet to client!");
 
 		else {
 			// printf ("Response packet sent: %ld\n", sent);
 		}
-
+		
 		packet_delete (test_packet);
 	}
 
@@ -65,12 +73,12 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-
+		
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -86,18 +94,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -107,16 +111,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -131,6 +131,12 @@ int main (int argc, char **argv) {
 
 	// register to the quit signal
 	signal (SIGINT, end);
+	signal (SIGSEGV, quit);
+
+	cerver_log_set_output_type (LOG_OUTPUT_TYPE_BOTH);
+	cerver_log_set_path ("./logs");
+	cerver_log_set_time_config (LOG_TIME_TYPE_TIME);
+	cerver_log_set_local_time (true);
 
 	cerver_init ();
 
@@ -156,14 +162,14 @@ int main (int argc, char **argv) {
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false

--- a/examples/makefile
+++ b/examples/makefile
@@ -3,8 +3,6 @@ TARGET      := cerver
 PTHREAD 	:= -l pthread
 MATH		:= -lm
 
-CMONGO 		:= `pkg-config --libs --cflags libmongoc-1.0`
-
 # print additional information
 DEFINES = -D CERVER_DEBUG -D CERVER_STATS
 

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -108,7 +108,7 @@ void *app_data_copy (void *app_data_args_ptr) {
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -137,18 +137,18 @@ static void handle_test_request (Packet *packet, unsigned int handler_id) {
 			cerver_log_debug (status);
 			free (status);
 		}
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -158,11 +158,9 @@ static void handle_test_request (Packet *packet, unsigned int handler_id) {
 static void handle_msg_request (Packet *packet, unsigned int handler_id, String *msg) {
 
 	if (packet && msg) {
-		char *status = c_string_create ("Got a request for handler's <%d> message!", handler_id);
-		if (status) {
-			cerver_log_debug (status);
-			free (status);
-		}
+		cerver_log_debug (
+			"Got a request for handler's <%d> message!", handler_id
+		);
 
 		printf ("%s - %d\n", msg->str, msg->len);
 
@@ -170,18 +168,18 @@ static void handle_msg_request (Packet *packet, unsigned int handler_id, String 
 		memset (app_message, 0, sizeof (AppMessage));
 		strncpy (app_message->message, msg->str, 128);
 		app_message->len = msg->len;
-
-		Packet *msg_packet = packet_generate_request (APP_PACKET, GET_MSG, app_message, sizeof (AppMessage));
+		
+		Packet *msg_packet = packet_generate_request (PACKET_TYPE_APP, GET_MSG, app_message, sizeof (AppMessage));
 		if (msg_packet) {
 			packet_set_network_values (msg_packet, packet->cerver, packet->client, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (msg_packet, 0, &sent, false))
+			if (packet_send (msg_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send handler's message to client");
 
 			else {
 				printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (msg_packet);
 		}
 
@@ -203,8 +201,8 @@ static void handler_cero (void *data) {
 
 				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				default: 
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -213,7 +211,7 @@ static void handler_cero (void *data) {
 }
 
 static void handler_one (void *data) {
-
+	
 	if (data) {
 		HandlerData *handler_data = (HandlerData *) data;
 
@@ -225,8 +223,8 @@ static void handler_one (void *data) {
 
 				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				default: 
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -235,7 +233,7 @@ static void handler_one (void *data) {
 }
 
 static void handler_two (void *data) {
-
+	
 	if (data) {
 		HandlerData *handler_data = (HandlerData *) data;
 
@@ -247,8 +245,8 @@ static void handler_two (void *data) {
 
 				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				default: 
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -257,7 +255,7 @@ static void handler_two (void *data) {
 }
 
 static void handler_three (void *data) {
-
+	
 	if (data) {
 		HandlerData *handler_data = (HandlerData *) data;
 
@@ -269,8 +267,8 @@ static void handler_three (void *data) {
 
 				case GET_MSG: handle_msg_request(packet, handler_data->handler_id, app_data->message); break;
 
-				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				default: 
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -287,18 +285,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -308,16 +302,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -380,14 +370,14 @@ int main (void) {
 		handler_set_data_delete (handler_3, app_data_delete);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -406,13 +396,13 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}
 
 	cerver_end ();
-
+	
 	return 0;
 
 }

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -115,9 +115,9 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		// cerver_log_debug ("Got a test message from client. Sending another one back...");
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
 
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
@@ -178,7 +178,7 @@ static void handler (void *data) {
 			case MULTI_MSG: handle_multi_message (packet); break;
 
 			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -103,7 +103,7 @@ AppData *app_data = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -122,17 +122,17 @@ static void handle_test_request (Packet *packet) {
 	if (packet) {
 		cerver_log_debug ("Got a TEST request from client! Sending another one back...");
 
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -150,18 +150,18 @@ static void handle_msg_request (Packet *packet, String *msg) {
 		memset (app_message, 0, sizeof (AppMessage));
 		strncpy (app_message->message, msg->str, 128);
 		app_message->len = msg->len;
-
-		Packet *msg_packet = packet_generate_request (APP_PACKET, GET_MSG, app_message, sizeof (AppMessage));
+		
+		Packet *msg_packet = packet_generate_request (PACKET_TYPE_APP, GET_MSG, app_message, sizeof (AppMessage));
 		if (msg_packet) {
 			packet_set_network_values (msg_packet, packet->cerver, packet->client, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (msg_packet, 0, &sent, false))
+			if (packet_send (msg_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send handler's message to client");
 
 			else {
 				printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (msg_packet);
 		}
 
@@ -183,8 +183,8 @@ static void app_packet_handler (void *data) {
 
 				case GET_MSG: handle_msg_request(packet, app_data->message); break;
 
-				default:
-					cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+				default: 
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 					break;
 			}
 		}
@@ -225,7 +225,7 @@ int main (void) {
 		handler_set_data_delete (app_handler, app_data_delete);
 
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
-
+		
 		if (cerver_start (my_cerver)) {
 			char *s = c_string_create ("Failed to start %s!",
 				my_cerver->info->name->str);
@@ -239,7 +239,7 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -33,7 +33,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -53,18 +53,18 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		cerver_log_debug ("Got a test message from client. Sending another one back...");
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -79,8 +79,8 @@ static void handler (void *data) {
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -118,7 +118,7 @@ static u8 my_auth_method_username (AuthMethod *auth_method, const char *username
 }
 
 static u8 my_auth_method_password (AuthMethod *auth_method, const char *password) {
-
+	
 	u8 retval = 1;
 
 	if (password) {
@@ -192,17 +192,13 @@ static void on_hold_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
 			"Conenction %d is on hold in cerver %s!\n",
 			event_data->connection->socket->sock_fd,
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CERVER, status);
-			free (status);
-		}
 	}
 
 }
@@ -212,16 +208,12 @@ static void on_hold_disconnected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection disconnected in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection disconnected in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -231,16 +223,12 @@ static void on_hold_drop (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"An on hold connection was dropped in cerver %s!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_NONE,
+			"An on hold connection was dropped in cerver %s!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_NONE, status);
-			free (status);
-		}
 	}
 
 }
@@ -250,18 +238,14 @@ static void on_client_success_auth (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld authenticated connection with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -271,17 +255,13 @@ static void on_client_failed_auth (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client failed to authenticate connection with sock fd %d to cerver %s!\n",
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -291,18 +271,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -312,18 +288,14 @@ static void on_client_new_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld new connection with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -333,16 +305,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -387,56 +355,56 @@ int main (void) {
 		cerver_set_sessions (my_cerver, session_default_generate_id);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_CONNECTED,
 			on_hold_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DISCONNECTED,
 			on_hold_disconnected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_ON_HOLD_DROPPED,
 			on_hold_drop, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_SUCCESS_AUTH,
 			on_client_success_auth, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_FAILED_AUTH,
 			on_client_failed_auth, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_NEW_CONNECTION,
 			on_client_new_connection, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false

--- a/examples/test.c
+++ b/examples/test.c
@@ -24,7 +24,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -44,19 +44,19 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		// cerver_log_debug ("Got a test message from client. Sending another one back...");
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -67,12 +67,12 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-
+		
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -88,16 +88,12 @@ static void on_cever_started (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"Cerver %s has started!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
+			"Cerver %s has started!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CERVER, status);
-			free (status);
-		}
 
 		printf ("Test Message: %s\n\n", ((String *) event_data->action_args)->str);
 	}
@@ -109,16 +105,12 @@ static void on_cever_teardown (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
-			"Cerver %s is going to be destroyed!\n",
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CERVER,
+			"Cerver %s is going to be destroyed!\n", 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CERVER, status);
-			free (status);
-		}
 	}
 
 }
@@ -128,18 +120,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -149,16 +137,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -167,7 +151,35 @@ static void on_client_close_connection (void *event_data_ptr) {
 
 #pragma region main
 
-int main (void) {
+static u16 get_port (int argc, char **argv) {
+
+	u16 port = 7000;
+	if (argc > 1) {
+		int j = 0;
+		const char *curr_arg = NULL;
+		for (int i = 1; i < argc; i++) {
+			curr_arg = argv[i];
+
+			// port
+			if (!strcmp (curr_arg, "-p")) {
+				j = i + 1;
+				if (j <= argc) {
+					port = (u16) atoi (argv[j]);
+					i++;
+				}
+			}
+
+			else {
+				cerver_log_warning ("Unknown argument: %s", curr_arg);
+			}
+		}
+	}
+
+	return port;
+
+}
+
+int main (int argc, char **argv) {
 
 	srand (time (NULL));
 
@@ -185,7 +197,7 @@ int main (void) {
 	cerver_log_debug ("Single app handler with direct handle option enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", get_port (argc, argv), PROTOCOL_TCP, false, 2, 2000);
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple Test Message Example");
 
@@ -200,28 +212,28 @@ int main (void) {
 
 		String *test = str_new ("This is a test!");
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_STARTED,
 			on_cever_started, test, str_delete,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_TEARDOWN,
 			on_cever_teardown, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -240,7 +252,7 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -24,7 +24,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -44,19 +44,19 @@ static void handle_test_request (Packet *packet) {
 
 	if (packet) {
 		// cerver_log_debug ("Got a test message from client. Sending another one back...");
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
-
-		Packet *test_packet = packet_generate_request (APP_PACKET, TEST_MSG, NULL, 0);
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from client. Sending another one back...");
+		
+		Packet *test_packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
 		if (test_packet) {
 			packet_set_network_values (test_packet, NULL, NULL, packet->connection, NULL);
 			size_t sent = 0;
-			if (packet_send (test_packet, 0, &sent, false))
+			if (packet_send (test_packet, 0, &sent, false)) 
 				cerver_log_error ("Failed to send test packet to client!");
 
 			else {
 				// printf ("Response packet sent: %ld\n", sent);
 			}
-
+			
 			packet_delete (test_packet);
 		}
 	}
@@ -67,12 +67,12 @@ static void handler (void *data) {
 
 	if (data) {
 		Packet *packet = (Packet *) data;
-
+		
 		switch (packet->header->request_type) {
 			case TEST_MSG: handle_test_request (packet); break;
 
-			default:
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
+			default: 
+				cerver_log ( LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -88,18 +88,14 @@ static void on_client_connected (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"Client %ld connected with sock fd %d to cerver %s!\n",
 			event_data->client->id,
-			event_data->connection->socket->sock_fd,
+			event_data->connection->socket->sock_fd, 
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -109,16 +105,12 @@ static void on_client_close_connection (void *event_data_ptr) {
 	if (event_data_ptr) {
 		CerverEventData *event_data = (CerverEventData *) event_data_ptr;
 
-		char *status = c_string_create (
+		printf ("\n");
+		cerver_log (
+			LOG_TYPE_EVENT, LOG_TYPE_CLIENT,
 			"A client closed a connection to cerver %s!\n",
 			event_data->cerver->info->name->str
 		);
-
-		if (status) {
-			printf ("\n");
-			cerver_log_msg (stdout, LOG_TYPE_EVENT, LOG_TYPE_CLIENT, status);
-			free (status);
-		}
 	}
 
 }
@@ -161,14 +153,14 @@ int main (void) {
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CONNECTED,
 			on_client_connected, NULL, NULL,
 			false, false
 		);
 
 		cerver_event_register (
-			my_cerver,
+			my_cerver, 
 			CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
 			on_client_close_connection, NULL, NULL,
 			false, false
@@ -187,7 +179,7 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
+        cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/web/sockets.c
+++ b/examples/web/sockets.c
@@ -42,6 +42,15 @@ void end (int dummy) {
 
 #pragma region routes
 
+// GET /
+void main_handler (CerverReceive *cr, HttpRequest *request) {
+
+	if (http_response_render_file (cr, "./examples/web/public/echo.html")) {
+		cerver_log_error ("Failed to send ./examples/web/public/echo.html");
+	}
+
+}
+
 void test_handler (CerverReceive *cr, HttpRequest *request) {
 
 	HttpResponse *res = http_response_json_msg ((http_status) 200, "Test route works!");
@@ -132,6 +141,12 @@ int main (int argc, char **argv) {
 
 		/*** web cerver configuration ***/
 		HttpCerver *http_cerver = (HttpCerver *) web_cerver->cerver_data;
+
+		http_cerver_static_path_add (http_cerver, "./examples/web/public");
+
+		// GET /
+		HttpRoute *main_route = http_route_create (REQUEST_METHOD_GET, "/", main_handler);
+		http_cerver_route_register (http_cerver, main_route);
 
 		// /test
 		HttpRoute *test_route = http_route_create (REQUEST_METHOD_GET, "test", test_handler);

--- a/examples/welcome.c
+++ b/examples/welcome.c
@@ -14,7 +14,7 @@ static Cerver *my_cerver = NULL;
 
 // correctly closes any on-going server and process when quitting the appplication
 static void end (int dummy) {
-
+	
 	if (my_cerver) {
 		cerver_stats_print (my_cerver, true, true);
 		cerver_teardown (my_cerver);
@@ -58,8 +58,8 @@ int main (void) {
 	}
 
 	else {
-		cerver_log_error ("Failed to create cerver!");
-
+        cerver_log_error ("Failed to create cerver!");
+		
 		cerver_delete (my_cerver);
 	}
 

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -11,8 +11,8 @@
 
 #include "cerver/collections/dlist.h"
 
-#include "cerver/config.h"
 #include "cerver/cerver.h"
+#include "cerver/config.h"
 #include "cerver/handler.h"
 #include "cerver/packets.h"
 
@@ -49,7 +49,7 @@ struct _AdminCerverStats {
 
 typedef struct _AdminCerverStats AdminCerverStats;
 
-extern void admin_cerver_stats_print (AdminCerverStats *stats);
+CERVER_PUBLIC void admin_cerver_stats_print (AdminCerverStats *stats);
 
 #pragma endregion
 
@@ -205,24 +205,24 @@ CERVER_EXPORT void admin_cerver_set_max_fds (AdminCerver *admin_cerver, u32 max_
 // sets a custom poll time out to use for admins
 CERVER_EXPORT void admin_cerver_set_poll_timeout (AdminCerver *admin_cerver, u32 poll_timeout);
 
-// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
+// sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 CERVER_EXPORT void admin_cerver_set_app_handlers (AdminCerver *admin_cerver, 
 	struct _Handler *app_handler, struct _Handler *app_error_handler);
 
-// sets option to automatically delete APP_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_APP packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_app_handler_delete (AdminCerver *admin_cerver, bool delete_packet);
 
-// sets option to automatically delete APP_ERROR_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_app_error_handler_delete (AdminCerver *admin_cerver, bool delete_packet);
 
-// sets a CUSTOM_PACKET packet type handler
+// sets a PACKET_TYPE_CUSTOM packet type handler
 CERVER_EXPORT void admin_cerver_set_custom_handler (AdminCerver *admin_cerver, struct _Handler *custom_handler);
 
-// sets option to automatically delete CUSTOM_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_custom_handler_delete (AdminCerver *admin_cerver, bool delete_packet);

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -32,7 +32,7 @@ struct _AdminCerverStats {
 	u64 total_n_packets_received;                   // total number of packets received (packet header + data)
 	u64 total_n_receives_done;                      // total amount of actual calls to recv ()
 	u64 total_bytes_received;                       // total amount of bytes received in the cerver
-	
+
 	u64 total_n_packets_sent;                       // total number of packets that were sent
 	u64 total_bytes_sent;                           // total amount of bytes sent by the cerver
 
@@ -108,7 +108,7 @@ CERVER_PUBLIC u8 admin_send_packet_split (Admin *admin, struct _Packet *packet);
 // sends a packet in pieces to the first connection of the specified admin
 // returns 0 on success, 1 on error
 CERVER_PUBLIC u8 admin_send_packet_pieces (Admin *admin, struct _Packet *packet,
-    void **pieces, size_t *sizes, u32 n_pieces);
+	void **pieces, size_t *sizes, u32 n_pieces);
 
 #pragma endregion
 
@@ -149,7 +149,7 @@ struct _AdminCerver {
 	struct _Handler *custom_packet_handler;
 
 	unsigned int num_handlers_alive;       // handlers currently alive
-    unsigned int num_handlers_working;     // handlers currently working
+	unsigned int num_handlers_working;     // handlers currently working
 	pthread_mutex_t *handlers_lock;
 
 	bool app_packet_handler_delete_packet;
@@ -159,17 +159,17 @@ struct _AdminCerver {
 	bool check_packets;                     // enable / disbale packet checking
 
 	pthread_t update_thread_id;
-    Action update;                          // method to be executed every tick
-    void *update_args;                      // args to pass to custom update method
+	Action update;                          // method to be executed every tick
+	void *update_args;                      // args to pass to custom update method
 	void (*delete_update_args)(void *);     // method to delete update args at cerver teardown
-    u8 update_ticks;                        // like fps
+	u8 update_ticks;                        // like fps
 
-    pthread_t update_interval_thread_id;
-    Action update_interval;                 // the actual method to execute every x seconds
-    void *update_interval_args;             // args to pass to the update method
+	pthread_t update_interval_thread_id;
+	Action update_interval;                 // the actual method to execute every x seconds
+	void *update_interval_args;             // args to pass to the update method
 	// method to delete update interval args at cerver teardown
-    void (*delete_update_interval_args)(void *);
-    u32 update_interval_secs;               // the interval in seconds
+	void (*delete_update_interval_args)(void *);
+	u32 update_interval_secs;               // the interval in seconds
 
 	struct _AdminCerverStats *stats;
 
@@ -206,16 +206,16 @@ CERVER_EXPORT void admin_cerver_set_max_fds (AdminCerver *admin_cerver, u32 max_
 CERVER_EXPORT void admin_cerver_set_poll_timeout (AdminCerver *admin_cerver, u32 poll_timeout);
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
-CERVER_EXPORT void admin_cerver_set_app_handlers (AdminCerver *admin_cerver, 
+CERVER_EXPORT void admin_cerver_set_app_handlers (AdminCerver *admin_cerver,
 	struct _Handler *app_handler, struct _Handler *app_error_handler);
 
 // sets option to automatically delete PACKET_TYPE_APP packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_app_handler_delete (AdminCerver *admin_cerver, bool delete_packet);
 
 // sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_app_error_handler_delete (AdminCerver *admin_cerver, bool delete_packet);
 
@@ -223,7 +223,7 @@ CERVER_EXPORT void admin_cerver_set_app_error_handler_delete (AdminCerver *admin
 CERVER_EXPORT void admin_cerver_set_custom_handler (AdminCerver *admin_cerver, struct _Handler *custom_handler);
 
 // sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void admin_cerver_set_custom_handler_delete (AdminCerver *admin_cerver, bool delete_packet);
 
@@ -245,9 +245,9 @@ CERVER_EXPORT void admin_cerver_set_check_packets (AdminCerver *admin_cerver, bo
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void admin_cerver_set_update (
-    AdminCerver *admin_cerver, 
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u8 fps
+	AdminCerver *admin_cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u8 fps
 );
 
 // sets a custom update method to be executed every x seconds (in intervals)
@@ -255,9 +255,9 @@ CERVER_EXPORT void admin_cerver_set_update (
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void admin_cerver_set_update_interval (
-    AdminCerver *admin_cerver, 
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u32 interval
+	AdminCerver *admin_cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u32 interval
 );
 
 // returns the current number of connected admins
@@ -273,8 +273,8 @@ CERVER_EXPORT u8 admin_cerver_broadcast_to_admins_split (AdminCerver *admin_cerv
 
 // broadcasts a packet to all connected admins in an admin cerver using packet_send_pieces ()
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, struct _Packet *packet, 
-    void **pieces, size_t *sizes, u32 n_pieces);
+CERVER_EXPORT u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, struct _Packet *packet,
+	void **pieces, size_t *sizes, u32 n_pieces);
 
 // registers a newly created admin to the admin cerver structures (internal & poll)
 // this will allow the admin cerver to start handling admin's packets

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -20,17 +20,17 @@ struct _Connection;
 // the auth data stripped from the packet
 struct _AuthData {
 
-    String *token;
+	String *token;
 
-    void *auth_data;
-    size_t auth_data_size;
+	void *auth_data;
+	size_t auth_data_size;
 
-    // recover data used for authentication
-    // after a success auth, it will be added to the client
-    // if not, it should be dispossed by user defined auth method
-    // and set to NULL
-    void *data;                 
-    Action delete_data;         // how to delete the data
+	// recover data used for authentication
+	// after a success auth, it will be added to the client
+	// if not, it should be dispossed by user defined auth method
+	// and set to NULL
+	void *data;
+	Action delete_data;         // how to delete the data
 
 };
 
@@ -39,12 +39,12 @@ typedef struct _AuthData AuthData;
 // auxiliary structure passed to the user defined auth method
 struct _AuthMethod {
 
-    struct _Packet *packet;         // the original packet
-    AuthData *auth_data;            // the stripped auth data from the packet
+	struct _Packet *packet;         // the original packet
+	AuthData *auth_data;            // the stripped auth data from the packet
 
-    // a user message that can be sent to the connection when teh auth has failed
-    // in a generated ERR_FAILED_AUTH packet
-    String *error_message;
+	// a user message that can be sent to the connection when teh auth has failed
+	// in a generated ERR_FAILED_AUTH packet
+	String *error_message;
 
 };
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -65,32 +65,32 @@ CERVER_EXPORT void cerver_end (void);
 #pragma region types
 
 #define CERVER_TYPE_MAP(XX)					\
-    XX(0,	NONE, 		None)				\
-    XX(1,	CUSTOM, 	Custom)				\
-    XX(2,	GAME, 		Game)				\
-    XX(3,	WEB, 		Web)				\
-    XX(4,	FILES, 		Files)
+	XX(0,	NONE, 		None)				\
+	XX(1,	CUSTOM, 	Custom)				\
+	XX(2,	GAME, 		Game)				\
+	XX(3,	WEB, 		Web)				\
+	XX(4,	FILES, 		Files)
 
 typedef enum CerverType {
 
-    #define XX(num, name, string) CERVER_TYPE_##name = num,
-    CERVER_TYPE_MAP (XX)
-    #undef XX
+	#define XX(num, name, string) CERVER_TYPE_##name = num,
+	CERVER_TYPE_MAP (XX)
+	#undef XX
 
 } CerverType;
 
 CERVER_EXPORT const char *cerver_type_to_string (CerverType type);
 
 #define CERVER_HANDLER_TYPE_MAP(XX)																\
-    XX(0,	NONE, 		None, 		None)														\
-    XX(1,	POLL, 		Poll, 		Handle connections using a single thread & poll ())			\
-    XX(2,	THREADS, 	Threads, 	Handle each new connection in a dedicated thread)
+	XX(0,	NONE, 		None, 		None)														\
+	XX(1,	POLL, 		Poll, 		Handle connections using a single thread & poll ())			\
+	XX(2,	THREADS, 	Threads, 	Handle each new connection in a dedicated thread)
 
 typedef enum CerverHandlerType {
 
-    #define XX(num, name, string, description) CERVER_HANDLER_TYPE_##name = num,
-    CERVER_HANDLER_TYPE_MAP (XX)
-    #undef XX
+	#define XX(num, name, string, description) CERVER_HANDLER_TYPE_##name = num,
+	CERVER_HANDLER_TYPE_MAP (XX)
+	#undef XX
 
 } CerverHandlerType;
 
@@ -104,12 +104,12 @@ CERVER_EXPORT const char *cerver_handler_type_description (CerverHandlerType typ
 
 typedef struct CerverInfo {
 
-    String *name;
-    String *welcome_msg;                  // this msg is sent to the client when it first connects
-    struct _Packet *cerver_info_packet;    // useful info that we can send to clients
+	String *name;
+	String *welcome_msg;                  // this msg is sent to the client when it first connects
+	struct _Packet *cerver_info_packet;    // useful info that we can send to clients
 
-    time_t time_started;                   // the actual time the cerver was started
-    u64 uptime;                            // the seconds the cerver has been up
+	time_t time_started;                   // the actual time the cerver was started
+	u64 uptime;                            // the seconds the cerver has been up
 
 } CerverInfo;
 
@@ -120,7 +120,7 @@ CERVER_EXPORT u8 cerver_set_welcome_msg (struct _Cerver *cerver, const char *msg
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
 CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
-    struct _Client *client, struct _Connection *connection);
+	struct _Client *client, struct _Connection *connection);
 
 #pragma endregion
 
@@ -128,33 +128,33 @@ CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
 
 typedef struct CerverStats {
 
-    time_t threshold_time;                          // every time we want to reset cerver stats (like packets), defaults 24hrs
+	time_t threshold_time;                          // every time we want to reset cerver stats (like packets), defaults 24hrs
 
-    u64 client_n_packets_received;                  // packets received from clients
-    u64 client_receives_done;                       // receives done to clients
-    u64 client_bytes_received;                      // bytes received from clients
+	u64 client_n_packets_received;                  // packets received from clients
+	u64 client_receives_done;                       // receives done to clients
+	u64 client_bytes_received;                      // bytes received from clients
 
-    u64 on_hold_n_packets_received;                 // packets received from on hold connections
-    u64 on_hold_receives_done;                      // received done to on hold connections
-    u64 on_hold_bytes_received;                     // bytes received from on hold connections
+	u64 on_hold_n_packets_received;                 // packets received from on hold connections
+	u64 on_hold_receives_done;                      // received done to on hold connections
+	u64 on_hold_bytes_received;                     // bytes received from on hold connections
 
-    u64 total_n_packets_received;                   // total number of cerver packets received (packet header + data)
-    u64 total_n_receives_done;                      // total amount of actual calls to recv ()
-    u64 total_bytes_received;                       // total amount of bytes received in the cerver
+	u64 total_n_packets_received;                   // total number of cerver packets received (packet header + data)
+	u64 total_n_receives_done;                      // total amount of actual calls to recv ()
+	u64 total_bytes_received;                       // total amount of bytes received in the cerver
 
-    u64 n_packets_sent;                             // total number of packets that were sent
-    u64 total_bytes_sent;                           // total amount of bytes sent by the cerver
+	u64 n_packets_sent;                             // total number of packets that were sent
+	u64 total_bytes_sent;                           // total amount of bytes sent by the cerver
 
-    u64 current_active_client_connections;          // all of the current active connections for all current clients (active in main poll array)
-    u64 current_n_connected_clients;                // the current number of clients connected
-    u64 current_n_hold_connections;                 // current numbers of on hold connections (only if the cerver requires authentication)
-    u64 total_on_hold_connections;                  // the total amount of on hold connections
-    u64 total_n_clients;                            // the total amount of clients that were registered to the cerver (no auth required)
-    u64 unique_clients;                             // n unique clients connected in a threshold time (check used authentication)
-    u64 total_client_connections;                   // the total amount of client connections that have been done to the cerver
+	u64 current_active_client_connections;          // all of the current active connections for all current clients (active in main poll array)
+	u64 current_n_connected_clients;                // the current number of clients connected
+	u64 current_n_hold_connections;                 // current numbers of on hold connections (only if the cerver requires authentication)
+	u64 total_on_hold_connections;                  // the total amount of on hold connections
+	u64 total_n_clients;                            // the total amount of clients that were registered to the cerver (no auth required)
+	u64 unique_clients;                             // n unique clients connected in a threshold time (check used authentication)
+	u64 total_client_connections;                   // the total amount of client connections that have been done to the cerver
 
-    struct _PacketsPerType *received_packets;
-    struct _PacketsPerType *sent_packets;
+	struct _PacketsPerType *received_packets;
+	struct _PacketsPerType *sent_packets;
 
 } CerverStats;
 
@@ -171,127 +171,127 @@ CERVER_EXPORT void cerver_stats_print (struct _Cerver *cerver, bool received, bo
 // this is the generic cerver struct, used to create different server types
 struct _Cerver {
 
-    CerverType type;
+	CerverType type;
 
-    i32 sock;                           // server socket
-    struct sockaddr_storage address;
+	i32 sock;                           // server socket
+	struct sockaddr_storage address;
 
-    u16 port;
-    Protocol protocol;                  // we only support either tcp or udp
-    bool use_ipv6;
-    u16 connection_queue;               // each server can handle connection differently
-    u32 receive_buffer_size;
+	u16 port;
+	Protocol protocol;                  // we only support either tcp or udp
+	bool use_ipv6;
+	u16 connection_queue;               // each server can handle connection differently
+	u32 receive_buffer_size;
 
-    bool isRunning;                     // the server is recieving and/or sending packetss
-    bool blocking;                      // sokcet fd is blocking?
+	bool isRunning;                     // the server is recieving and/or sending packetss
+	bool blocking;                      // sokcet fd is blocking?
 
-    void *cerver_data;
-    Action delete_cerver_data;
+	void *cerver_data;
+	Action delete_cerver_data;
 
-    u16 n_thpool_threads;
-    Thpool *thpool;
+	u16 n_thpool_threads;
+	Thpool *thpool;
 
-    // 29/05/2020
-    // using this pool to avoid completely destroying connection's sockets
-    // as another thread might be blocked by the socket's mutex
-    unsigned int sockets_pool_init;
-    Pool *sockets_pool;
+	// 29/05/2020
+	// using this pool to avoid completely destroying connection's sockets
+	// as another thread might be blocked by the socket's mutex
+	unsigned int sockets_pool_init;
+	Pool *sockets_pool;
 
-    AVLTree *clients;                   // connected clients
-    Htab *client_sock_fd_map;           // direct indexing by sokcet fd as key
+	AVLTree *clients;                   // connected clients
+	Htab *client_sock_fd_map;           // direct indexing by sokcet fd as key
 
-    // 17/06/2020 - ability to check for inactive clients
-    // clients that have not been sent or received from a packet in x time
-    // will be automatically dropped from the cerver
-    bool inactive_clients;              // enable / disable checking
-    u32 max_inactive_time;              // max secs allowed for a client to be inactive
-    u32 check_inactive_interval;        // how often to check for inactive clients
-    pthread_t inactive_thread_id;
+	// 17/06/2020 - ability to check for inactive clients
+	// clients that have not been sent or received from a packet in x time
+	// will be automatically dropped from the cerver
+	bool inactive_clients;              // enable / disable checking
+	u32 max_inactive_time;              // max secs allowed for a client to be inactive
+	u32 check_inactive_interval;        // how often to check for inactive clients
+	pthread_t inactive_thread_id;
 
-    CerverHandlerType handler_type;
+	CerverHandlerType handler_type;
 
-    // if set & CERVER_HANDLER_TYPE_THREADS, connections will be handled
-    // by creating a new detachable thread each time, if not,
-    // the thpoll will be used instead; if the thpool is full or unavailable,
-    // a detachable thread will be created anyway
-    bool handle_detachable_threads;
+	// if set & CERVER_HANDLER_TYPE_THREADS, connections will be handled
+	// by creating a new detachable thread each time, if not,
+	// the thpoll will be used instead; if the thpool is full or unavailable,
+	// a detachable thread will be created anyway
+	bool handle_detachable_threads;
 
-    struct pollfd *fds;
-    u32 max_n_fds;                      // current max n fds in pollfd
-    u16 current_n_fds;                  // n of active fds in the pollfd array
-    u32 poll_timeout;
-    pthread_mutex_t *poll_lock;
+	struct pollfd *fds;
+	u32 max_n_fds;                      // current max n fds in pollfd
+	u16 current_n_fds;                  // n of active fds in the pollfd array
+	u32 poll_timeout;
+	pthread_mutex_t *poll_lock;
 
-    /*** auth ***/
-    bool auth_required;                 // does the server requires authentication?
-    struct _Packet *auth_packet;        // requests client authentication
-    u8 max_auth_tries;                  // client's chances of auth before being dropped
-    delegate authenticate;              // authentication function
+	/*** auth ***/
+	bool auth_required;                 // does the server requires authentication?
+	struct _Packet *auth_packet;        // requests client authentication
+	u8 max_auth_tries;                  // client's chances of auth before being dropped
+	delegate authenticate;              // authentication function
 
-    AVLTree *on_hold_connections;       // hold on the connections until they authenticate
-    Htab *on_hold_connection_sock_fd_map;
-    struct pollfd *hold_fds;
-    u32 on_hold_poll_timeout;
-    u32 max_on_hold_connections;
-    u16 current_on_hold_nfds;
-    pthread_t on_hold_poll_id;
-    pthread_mutex_t *on_hold_poll_lock;
-    u8 on_hold_max_bad_packets;
-    bool on_hold_check_packets;
+	AVLTree *on_hold_connections;       // hold on the connections until they authenticate
+	Htab *on_hold_connection_sock_fd_map;
+	struct pollfd *hold_fds;
+	u32 on_hold_poll_timeout;
+	u32 max_on_hold_connections;
+	u16 current_on_hold_nfds;
+	pthread_t on_hold_poll_id;
+	pthread_mutex_t *on_hold_poll_lock;
+	u8 on_hold_max_bad_packets;
+	bool on_hold_check_packets;
 
-    // allow the clients to use sessions (have multiple connections)
-    bool use_sessions;
-    // admin defined function to generate session ids, it takes a session data struct
-    void *(*session_id_generator) (const void *);
+	// allow the clients to use sessions (have multiple connections)
+	bool use_sessions;
+	// admin defined function to generate session ids, it takes a session data struct
+	void *(*session_id_generator) (const void *);
 
-    // the admin can define a function to handle the recieve buffer if they are using a custom protocol
-    // otherwise, it will be set to the default one
-    Action handle_received_buffer;
+	// the admin can define a function to handle the recieve buffer if they are using a custom protocol
+	// otherwise, it will be set to the default one
+	Action handle_received_buffer;
 
-    // 27/05/2020 - changed form Action to Handler
-    // custom packet hanlders
-    struct _Handler *app_packet_handler;
-    struct _Handler *app_error_packet_handler;
-    struct _Handler *custom_packet_handler;
+	// 27/05/2020 - changed form Action to Handler
+	// custom packet hanlders
+	struct _Handler *app_packet_handler;
+	struct _Handler *app_error_packet_handler;
+	struct _Handler *custom_packet_handler;
 
-    bool app_packet_handler_delete_packet;
-    bool app_error_packet_handler_delete_packet;
-    bool custom_packet_handler_delete_packet;
+	bool app_packet_handler_delete_packet;
+	bool app_error_packet_handler_delete_packet;
+	bool custom_packet_handler_delete_packet;
 
-    // 10/05/2020
-    bool multiple_handlers;
-    // DoubleList *handlers;
-    struct _Handler **handlers;
-    unsigned int n_handlers;
-    unsigned int num_handlers_alive;       // handlers currently alive
-    unsigned int num_handlers_working;     // handlers currently working
-    pthread_mutex_t *handlers_lock;
-    // TODO: add ability to control handler execution
-    // pthread_cond_t *handlers_wait;
+	// 10/05/2020
+	bool multiple_handlers;
+	// DoubleList *handlers;
+	struct _Handler **handlers;
+	unsigned int n_handlers;
+	unsigned int num_handlers_alive;       // handlers currently alive
+	unsigned int num_handlers_working;     // handlers currently working
+	pthread_mutex_t *handlers_lock;
+	// TODO: add ability to control handler execution
+	// pthread_cond_t *handlers_wait;
 
-    bool check_packets;                     // enable / disbale packet checking
+	bool check_packets;                     // enable / disbale packet checking
 
-    pthread_t update_thread_id;
-    Action update;                          // method to be executed every tick
-    void *update_args;                      // args to pass to custom update method
-    void (*delete_update_args)(void *);     // method to delete update args at cerver teardown
-    u8 update_ticks;                        // like fps
+	pthread_t update_thread_id;
+	Action update;                          // method to be executed every tick
+	void *update_args;                      // args to pass to custom update method
+	void (*delete_update_args)(void *);     // method to delete update args at cerver teardown
+	u8 update_ticks;                        // like fps
 
-    pthread_t update_interval_thread_id;
-    Action update_interval;                 // the actual method to execute every x seconds
-    void *update_interval_args;             // args to pass to the update method
-    // method to delete update interval args at cerver teardown
-    void (*delete_update_interval_args)(void *);
-    u32 update_interval_secs;               // the interval in seconds
+	pthread_t update_interval_thread_id;
+	Action update_interval;                 // the actual method to execute every x seconds
+	void *update_interval_args;             // args to pass to the update method
+	// method to delete update interval args at cerver teardown
+	void (*delete_update_interval_args)(void *);
+	u32 update_interval_secs;               // the interval in seconds
 
-    struct _AdminCerver *admin;
-    pthread_t admin_thread_id;
+	struct _AdminCerver *admin;
+	pthread_t admin_thread_id;
 
-    CerverEvent *events[CERVER_MAX_EVENTS];
-    CerverErrorEvent *errors[CERVER_MAX_ERRORS];
+	CerverEvent *events[CERVER_MAX_EVENTS];
+	CerverErrorEvent *errors[CERVER_MAX_ERRORS];
 
-    CerverInfo *info;
-    CerverStats *stats;
+	CerverInfo *info;
+	CerverStats *stats;
 
 };
 
@@ -303,9 +303,9 @@ CERVER_PRIVATE void cerver_delete (void *ptr);
 
 // sets the cerver main network values
 CERVER_EXPORT void cerver_set_network_values (
-    Cerver *cerver,
-    const u16 port, const Protocol protocol,
-    bool use_ipv6, const u16 connection_queue
+	Cerver *cerver,
+	const u16 port, const Protocol protocol,
+	bool use_ipv6, const u16 connection_queue
 );
 
 // sets the cerver connection queue (how many connections to queue for accept)
@@ -335,8 +335,8 @@ CERVER_EXPORT void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_
 // max_inactive_time - max secs allowed for a client to be inactive, 0 for default
 // check_inactive_interval - how often to check for inactive clients in secs, 0 for default
 CERVER_EXPORT void cerver_set_inactive_clients (
-    Cerver *cerver,
-    u32 max_inactive_time, u32 check_inactive_interval
+	Cerver *cerver,
+	u32 max_inactive_time, u32 check_inactive_interval
 );
 
 // sets the cerver handler type
@@ -396,8 +396,8 @@ CERVER_EXPORT void cerver_set_handle_recieved_buffer (Cerver *cerver, Action han
 // 27/05/2020 - changed form Action to Handler
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 CERVER_EXPORT void cerver_set_app_handlers (
-    Cerver *cerver,
-    struct _Handler *app_handler, struct _Handler *app_error_handler
+	Cerver *cerver,
+	struct _Handler *app_handler, struct _Handler *app_error_handler
 );
 
 // sets option to automatically delete PACKET_TYPE_APP packets after use
@@ -435,9 +435,9 @@ CERVER_EXPORT void cerver_set_check_packets (Cerver *cerver, bool check_packets)
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update (
-    Cerver *cerver,
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u8 fps
+	Cerver *cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u8 fps
 );
 
 // sets a custom cerver update method to be executed every x seconds (in intervals)
@@ -445,9 +445,9 @@ CERVER_EXPORT void cerver_set_update (
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update_interval (
-    Cerver *cerver,
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u32 interval
+	Cerver *cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u32 interval
 );
 
 // enables admin connections to cerver
@@ -489,9 +489,9 @@ CERVER_EXPORT unsigned int cerver_get_n_handlers_working (Cerver *cerver);
 
 // returns a new cerver with the specified parameters
 CERVER_EXPORT Cerver *cerver_create (
-    const CerverType type, const char *name,
-    const u16 port, const Protocol protocol, bool use_ipv6,
-    u16 connection_queue, u32 poll_timeout
+	const CerverType type, const char *name,
+	const u16 port, const Protocol protocol, bool use_ipv6,
+	u16 connection_queue, u32 poll_timeout
 );
 
 #pragma endregion
@@ -511,8 +511,8 @@ CERVER_EXPORT u8 cerver_start (Cerver *cerver);
 // aux structure for cerver update methods
 struct _CerverUpdate {
 
-    Cerver *cerver;
-    void *args;
+	Cerver *cerver;
+	void *args;
 
 };
 
@@ -541,17 +541,17 @@ CERVER_EXPORT u8 cerver_teardown (Cerver *cerver);
 // information that we get from another cerver when connecting to it
 struct _CerverReport {
 
-    CerverType type;
+	CerverType type;
 
-    String *name;
-    String *welcome;
+	String *name;
+	String *welcome;
 
-    bool use_ipv6;
-    Protocol protocol;
-    u16 port;
+	bool use_ipv6;
+	Protocol protocol;
+	u16 port;
 
-    bool auth_required;
-    bool uses_sessions;
+	bool auth_required;
+	bool uses_sessions;
 
 };
 
@@ -560,8 +560,8 @@ typedef struct _CerverReport CerverReport;
 CERVER_PRIVATE void cerver_report_delete (void *ptr);
 
 CERVER_PRIVATE u8 cerver_report_check_info (
-    CerverReport *cerver_report,
-    struct _Client *client, struct _Connection *connection
+	CerverReport *cerver_report,
+	struct _Client *client, struct _Connection *connection
 );
 
 #pragma endregion
@@ -574,17 +574,17 @@ CERVER_PRIVATE u8 cerver_report_check_info (
 // serialized cerver structure
 typedef struct SCerver {
 
-    CerverType type;
+	CerverType type;
 
-    char name[S_CERVER_NAME_LENGTH];
-    char welcome[S_CERVER_WELCOME_LENGTH];
+	char name[S_CERVER_NAME_LENGTH];
+	char welcome[S_CERVER_WELCOME_LENGTH];
 
-    bool use_ipv6;
-    Protocol protocol;
-    u16 port;
+	bool use_ipv6;
+	Protocol protocol;
+	u16 port;
 
-    bool auth_required;
-    bool uses_sessions;
+	bool auth_required;
+	bool uses_sessions;
 
 } SCerver;
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -1,10 +1,6 @@
 #ifndef _CERVER_CERVER_H_
 #define _CERVER_CERVER_H_
 
-#ifndef _GNU_SOURCE
-    #define _GNU_SOURCE
-#endif
-
 #include <stdlib.h>
 
 #include <poll.h>

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -1,5 +1,5 @@
-#ifndef _CERVER_CERVER_H_
-#define _CERVER_CERVER_H_
+#ifndef _CERVER_H_
+#define _CERVER_H_
 
 #include <stdlib.h>
 
@@ -12,11 +12,13 @@
 #include "cerver/collections/htab.h"
 #include "cerver/collections/pool.h"
 
-#include "cerver/config.h"
 #include "cerver/admin.h"
+#include "cerver/config.h"
+#include "cerver/events.h"
+#include "cerver/errors.h"
+#include "cerver/handler.h"
 #include "cerver/network.h"
 #include "cerver/packets.h"
-#include "cerver/handler.h"
 
 #include "cerver/threads/thpool.h"
 
@@ -62,30 +64,39 @@ CERVER_EXPORT void cerver_end (void);
 
 #pragma region types
 
+#define CERVER_TYPE_MAP(XX)					\
+    XX(0,	NONE, 		None)				\
+    XX(1,	CUSTOM, 	Custom)				\
+    XX(2,	GAME, 		Game)				\
+    XX(3,	WEB, 		Web)				\
+    XX(4,	FILES, 		Files)
+
 typedef enum CerverType {
 
-    CERVER_TYPE_NONE            = 0,
-
-    CERVER_TYPE_CUSTOM          = 1,
-
-    CERVER_TYPE_GAME            = 2,
-    CERVER_TYPE_WEB             = 3,
-    CERVER_TYPE_FILE            = 4,
+    #define XX(num, name, string) CERVER_TYPE_##name = num,
+    CERVER_TYPE_MAP (XX)
+    #undef XX
 
 } CerverType;
 
-CERVER_EXPORT String *cerver_type_to_string (CerverType type);
+CERVER_EXPORT const char *cerver_type_to_string (CerverType type);
+
+#define CERVER_HANDLER_TYPE_MAP(XX)																\
+    XX(0,	NONE, 		None, 		None)														\
+    XX(1,	POLL, 		Poll, 		Handle connections using a single thread & poll ())			\
+    XX(2,	THREADS, 	Threads, 	Handle each new connection in a dedicated thread)
 
 typedef enum CerverHandlerType {
 
-    CERVER_HANDLER_TYPE_NONE            = 0,
-
-    CERVER_HANDLER_TYPE_POLL            = 1, // handle connections using a single thread & poll ()
-    CERVER_HANDLER_TYPE_THREADS         = 2, // handle each new connection in a dedicated thread
+    #define XX(num, name, string, description) CERVER_HANDLER_TYPE_##name = num,
+    CERVER_HANDLER_TYPE_MAP (XX)
+    #undef XX
 
 } CerverHandlerType;
 
-CERVER_EXPORT String *cerver_handler_type_to_string (CerverHandlerType type);
+CERVER_EXPORT const char *cerver_handler_type_to_string (CerverHandlerType type);
+
+CERVER_EXPORT const char *cerver_handler_type_description (CerverHandlerType type);
 
 #pragma endregion
 
@@ -108,7 +119,7 @@ CERVER_EXPORT u8 cerver_set_welcome_msg (struct _Cerver *cerver, const char *msg
 
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
-CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver, 
+CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
     struct _Client *client, struct _Connection *connection);
 
 #pragma endregion
@@ -118,7 +129,7 @@ CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
 typedef struct CerverStats {
 
     time_t threshold_time;                          // every time we want to reset cerver stats (like packets), defaults 24hrs
-    
+
     u64 client_n_packets_received;                  // packets received from clients
     u64 client_receives_done;                       // receives done to clients
     u64 client_bytes_received;                      // bytes received from clients
@@ -130,12 +141,12 @@ typedef struct CerverStats {
     u64 total_n_packets_received;                   // total number of cerver packets received (packet header + data)
     u64 total_n_receives_done;                      // total amount of actual calls to recv ()
     u64 total_bytes_received;                       // total amount of bytes received in the cerver
-    
+
     u64 n_packets_sent;                             // total number of packets that were sent
     u64 total_bytes_sent;                           // total amount of bytes sent by the cerver
 
     u64 current_active_client_connections;          // all of the current active connections for all current clients (active in main poll array)
-    u64 current_n_connected_clients;                // the current number of clients connected 
+    u64 current_n_connected_clients;                // the current number of clients connected
     u64 current_n_hold_connections;                 // current numbers of on hold connections (only if the cerver requires authentication)
     u64 total_on_hold_connections;                  // the total amount of on hold connections
     u64 total_n_clients;                            // the total amount of clients that were registered to the cerver (no auth required)
@@ -165,9 +176,9 @@ struct _Cerver {
     i32 sock;                           // server socket
     struct sockaddr_storage address;
 
-    u16 port; 
+    u16 port;
     Protocol protocol;                  // we only support either tcp or udp
-    bool use_ipv6;  
+    bool use_ipv6;
     u16 connection_queue;               // each server can handle connection differently
     u32 receive_buffer_size;
 
@@ -186,7 +197,7 @@ struct _Cerver {
     unsigned int sockets_pool_init;
     Pool *sockets_pool;
 
-    AVLTree *clients;                   // connected clients 
+    AVLTree *clients;                   // connected clients
     Htab *client_sock_fd_map;           // direct indexing by sokcet fd as key
 
     // 17/06/2020 - ability to check for inactive clients
@@ -201,22 +212,22 @@ struct _Cerver {
 
     // if set & CERVER_HANDLER_TYPE_THREADS, connections will be handled
     // by creating a new detachable thread each time, if not,
-    // the thpoll will be used instead; if the thpool is full or unavailable, 
+    // the thpoll will be used instead; if the thpool is full or unavailable,
     // a detachable thread will be created anyway
     bool handle_detachable_threads;
 
     struct pollfd *fds;
     u32 max_n_fds;                      // current max n fds in pollfd
     u16 current_n_fds;                  // n of active fds in the pollfd array
-    u32 poll_timeout;   
-    pthread_mutex_t *poll_lock;        
+    u32 poll_timeout;
+    pthread_mutex_t *poll_lock;
 
     /*** auth ***/
     bool auth_required;                 // does the server requires authentication?
     struct _Packet *auth_packet;        // requests client authentication
     u8 max_auth_tries;                  // client's chances of auth before being dropped
     delegate authenticate;              // authentication function
-     
+
     AVLTree *on_hold_connections;       // hold on the connections until they authenticate
     Htab *on_hold_connection_sock_fd_map;
     struct pollfd *hold_fds;
@@ -229,8 +240,8 @@ struct _Cerver {
     bool on_hold_check_packets;
 
     // allow the clients to use sessions (have multiple connections)
-    bool use_sessions;  
-    // admin defined function to generate session ids, it takes a session data struct            
+    bool use_sessions;
+    // admin defined function to generate session ids, it takes a session data struct
     void *(*session_id_generator) (const void *);
 
     // the admin can define a function to handle the recieve buffer if they are using a custom protocol
@@ -271,13 +282,13 @@ struct _Cerver {
     void *update_interval_args;             // args to pass to the update method
     // method to delete update interval args at cerver teardown
     void (*delete_update_interval_args)(void *);
-    u32 update_interval_secs;               // the interval in seconds          
+    u32 update_interval_secs;               // the interval in seconds
 
     struct _AdminCerver *admin;
     pthread_t admin_thread_id;
 
-    DoubleList *events;
-    DoubleList *errors;
+    CerverEvent *events[CERVER_MAX_EVENTS];
+    CerverErrorEvent *errors[CERVER_MAX_ERRORS];
 
     CerverInfo *info;
     CerverStats *stats;
@@ -291,8 +302,11 @@ CERVER_PRIVATE Cerver *cerver_new (void);
 CERVER_PRIVATE void cerver_delete (void *ptr);
 
 // sets the cerver main network values
-CERVER_EXPORT void cerver_set_network_values (Cerver *cerver, const u16 port, const Protocol protocol,
-    bool use_ipv6, const u16 connection_queue);
+CERVER_EXPORT void cerver_set_network_values (
+    Cerver *cerver,
+    const u16 port, const Protocol protocol,
+    bool use_ipv6, const u16 connection_queue
+);
 
 // sets the cerver connection queue (how many connections to queue for accept)
 CERVER_EXPORT void cerver_set_connection_queue (Cerver *cerver, const u16 connection_queue);
@@ -306,7 +320,7 @@ CERVER_EXPORT void cerver_set_cerver_data (Cerver *cerver, void *data, Action de
 // sets the cerver's thpool number of threads
 // this will enable the cerver's ability to handle received packets using multiple threads
 // usefull if you want the best concurrency and effiency
-// but we aware that you need to make your structures and data thread safe, as they might be accessed 
+// but we aware that you need to make your structures and data thread safe, as they might be accessed
 // from multiple threads at the same time
 // by default, all received packets will be handle only in one thread
 CERVER_EXPORT void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads);
@@ -320,8 +334,10 @@ CERVER_EXPORT void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_
 // will be automatically dropped from the cerver
 // max_inactive_time - max secs allowed for a client to be inactive, 0 for default
 // check_inactive_interval - how often to check for inactive clients in secs, 0 for default
-CERVER_EXPORT void cerver_set_inactive_clients (Cerver *cerver, 
-    u32 max_inactive_time, u32 check_inactive_interval);
+CERVER_EXPORT void cerver_set_inactive_clients (
+    Cerver *cerver,
+    u32 max_inactive_time, u32 check_inactive_interval
+);
 
 // sets the cerver handler type
 // the default type is to handle connections using the poll () which requires only one thread
@@ -355,9 +371,9 @@ CERVER_EXPORT void cerver_set_auth_method (Cerver *cerver, delegate authenticate
 // sets the cerver on poll timeout in ms
 CERVER_EXPORT void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout);
 
-// sets the max number of bad packets to tolerate from an ON HOLD connection before being dropped, 
+// sets the max number of bad packets to tolerate from an ON HOLD connection before being dropped,
 // the default is DEFAULT_ON_HOLD_MAX_BAD_PACKETS
-// a bad packet is anyone which can't be handle by the cerver because there is no handle, 
+// a bad packet is anyone which can't be handle by the cerver because there is no handle,
 // or because it failed the packet_check () method
 CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_packets);
 
@@ -366,7 +382,7 @@ CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hol
 CERVER_EXPORT void cerver_set_on_hold_check_packets (Cerver *cerver, bool check);
 
 // configures the cerver to use client sessions
-// This will allow for multiple connections from the same client, 
+// This will allow for multiple connections from the same client,
 // or you can use it to allow different connections from different devices using a token
 // you can pass your own session generator method that must take a SessionData as the argument
 // and must return a char * representing the session id (token) for the client
@@ -378,26 +394,28 @@ CERVER_EXPORT u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generat
 CERVER_EXPORT void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer);
 
 // 27/05/2020 - changed form Action to Handler
-// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
-CERVER_EXPORT void cerver_set_app_handlers (Cerver *cerver, 
-    struct _Handler *app_handler, struct _Handler *app_error_handler);
+// sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
+CERVER_EXPORT void cerver_set_app_handlers (
+    Cerver *cerver,
+    struct _Handler *app_handler, struct _Handler *app_error_handler
+);
 
-// sets option to automatically delete APP_PACKET packets after use
-// if set to false, user must delete the packets manualy 
+// sets option to automatically delete PACKET_TYPE_APP packets after use
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet);
 
-// sets option to automatically delete APP_ERROR_PACKET packets after use
-// if set to false, user must delete the packets manualy 
+// sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void cerver_set_app_error_handler_delete (Cerver *cerver, bool delete_packet);
 
 // 27/05/2020 - changed form Action to Handler
-// sets a CUSTOM_PACKET packet type handler
+// sets a PACKET_TYPE_CUSTOM packet type handler
 CERVER_EXPORT void cerver_set_custom_handler (Cerver *cerver, struct _Handler *custom_handler);
 
-// sets option to automatically delete CUSTOM_PACKET packets after use
-// if set to false, user must delete the packets manualy 
+// sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 CERVER_EXPORT void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet);
 
@@ -417,7 +435,7 @@ CERVER_EXPORT void cerver_set_check_packets (Cerver *cerver, bool check_packets)
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update (
-    Cerver *cerver, 
+    Cerver *cerver,
     Action update, void *update_args, void (*delete_update_args)(void *),
     const u8 fps
 );
@@ -427,7 +445,7 @@ CERVER_EXPORT void cerver_set_update (
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update_interval (
-    Cerver *cerver, 
+    Cerver *cerver,
     Action update, void *update_args, void (*delete_update_args)(void *),
     const u32 interval
 );
@@ -471,7 +489,7 @@ CERVER_EXPORT unsigned int cerver_get_n_handlers_working (Cerver *cerver);
 
 // returns a new cerver with the specified parameters
 CERVER_EXPORT Cerver *cerver_create (
-    const CerverType type, const char *name, 
+    const CerverType type, const char *name,
     const u16 port, const Protocol protocol, bool use_ipv6,
     u16 connection_queue, u32 poll_timeout
 );
@@ -481,7 +499,7 @@ CERVER_EXPORT Cerver *cerver_create (
 #pragma region start
 
 // tell the cerver to start listening for connections and packets
-// initializes cerver's structures like thpool (if any) 
+// initializes cerver's structures like thpool (if any)
 // and any other processes that have been configured before
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 cerver_start (Cerver *cerver);
@@ -522,7 +540,7 @@ CERVER_EXPORT u8 cerver_teardown (Cerver *cerver);
 
 // information that we get from another cerver when connecting to it
 struct _CerverReport {
-    
+
     CerverType type;
 
     String *name;
@@ -542,7 +560,7 @@ typedef struct _CerverReport CerverReport;
 CERVER_PRIVATE void cerver_report_delete (void *ptr);
 
 CERVER_PRIVATE u8 cerver_report_check_info (
-    CerverReport *cerver_report, 
+    CerverReport *cerver_report,
     struct _Client *client, struct _Connection *connection
 );
 
@@ -561,9 +579,9 @@ typedef struct SCerver {
     char name[S_CERVER_NAME_LENGTH];
     char welcome[S_CERVER_WELCOME_LENGTH];
 
-    bool use_ipv6;  
+    bool use_ipv6;
     Protocol protocol;
-    u16 port; 
+    u16 port;
 
     bool auth_required;
     bool uses_sessions;

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -19,29 +19,36 @@
 
 #include "cerver/utils/log.h"
 
+#define CLIENT_FILES_MAX_PATHS           32
+
 struct _Cerver;
 struct _Client;
+struct _Connection;
 struct _Packet;
 struct _PacketsPerType;
-struct _Connection;
 struct _Handler;
+
+struct _FileHeader;
+
+struct _ClientEvent;
+struct _ClientError;
 
 #pragma region stats
 
 struct _ClientStats {
 
-	time_t threshold_time;                  // every time we want to reset the client's stats
+    time_t threshold_time;                  // every time we want to reset the client's stats
 
-	u64 n_receives_done;                    // n calls to recv ()
+    u64 n_receives_done;                    // n calls to recv ()
 
-	u64 total_bytes_received;               // total amount of bytes received from this client
-	u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
+    u64 total_bytes_received;               // total amount of bytes received from this client
+    u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
 
-	u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
-	u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
+    u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
+    u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
 
-	struct _PacketsPerType *received_packets;
-	struct _PacketsPerType *sent_packets;
+    struct _PacketsPerType *received_packets;
+    struct _PacketsPerType *sent_packets;
 
 };
 
@@ -49,54 +56,99 @@ typedef struct _ClientStats ClientStats;
 
 CERVER_PUBLIC void client_stats_print (struct _Client *client);
 
+struct _ClientFileStats {
+
+    u64 n_files_requests;				// n requests to get a file
+    u64 n_success_files_requests;		// fulfilled requests
+    u64 n_bad_files_requests;			// bad requests
+    u64 n_files_sent;					// n files sent
+    u64 n_bad_files_sent;				// n files that failed to send
+    u64 n_bytes_sent;					// total bytes sent
+
+    u64 n_files_upload_requests;		// n requests to upload a file
+    u64 n_success_files_uploaded;		// n files received
+    u64 n_bad_files_upload_requests;	// bad requests to upload files
+    u64 n_bad_files_received;			// files that failed to be received
+    u64 n_bytes_received;				// total bytes received
+
+};
+
+typedef struct _ClientFileStats ClientFileStats;
+
+CERVER_PUBLIC void client_file_stats_print (struct _Client *client);
+
 #pragma endregion
 
 #pragma region main
 
+#define CLIENT_MAX_EVENTS				32
+#define CLIENT_MAX_ERRORS				32
+
 // anyone that connects to the cerver
 struct _Client {
 
-	// generated using connection values
-	u64 id;
-	time_t connected_timestamp;
-	
-	// 16/06/2020 - abiility to add a name to a client
-	String *name;
+    // generated using connection values
+    u64 id;
+    time_t connected_timestamp;
 
-	DoubleList *connections;
+    // 16/06/2020 - abiility to add a name to a client
+    String *name;
 
-	// multiple connections can be associated with the same client using the same session id
-	String *session_id;
+    DoubleList *connections;
 
-	time_t last_activity;   // the last time the client sent / receive data
+    // multiple connections can be associated with the same client using the same session id
+    String *session_id;
 
-	bool drop_client;        // client failed to authenticate
+    time_t last_activity;   // the last time the client sent / receive data
 
-	void *data;
-	Action delete_data;
+    bool drop_client;        // client failed to authenticate
 
-	// used when the client connects to another server
-	bool running;
-	time_t time_started;
-	u64 uptime;
+    void *data;
+    Action delete_data;
 
-	// 16/06/2020 - custom packet handlers
-	unsigned int num_handlers_alive;       // handlers currently alive
-	unsigned int num_handlers_working;     // handlers currently working
-	pthread_mutex_t *handlers_lock;
-	struct _Handler *app_packet_handler;
-	struct _Handler *app_error_packet_handler;
-	struct _Handler *custom_packet_handler;
+    // used when the client connects to another server
+    bool running;
+    time_t time_started;
+    u64 uptime;
 
-	bool check_packets;              // enable / disbale packet checking
+    // 16/06/2020 - custom packet handlers
+    unsigned int num_handlers_alive;       // handlers currently alive
+    unsigned int num_handlers_working;     // handlers currently working
+    pthread_mutex_t *handlers_lock;
+    struct _Handler *app_packet_handler;
+    struct _Handler *app_error_packet_handler;
+    struct _Handler *custom_packet_handler;
 
-	// 17/06/2020 - general client lock
-	pthread_mutex_t *lock;
+    bool check_packets;              // enable / disbale packet checking
 
-	DoubleList *events;
-	DoubleList *errors;
+    // 17/06/2020 - general client lock
+    pthread_mutex_t *lock;
 
-	ClientStats *stats;
+    struct _ClientEvent *events[CLIENT_MAX_EVENTS];
+    struct _ClientError *errors[CLIENT_MAX_ERRORS];
+
+    // files
+    unsigned int n_paths;
+    String *paths[CLIENT_FILES_MAX_PATHS];
+
+    // default path where received files will be placed
+    String *uploads_path;
+
+    u8 (*file_upload_handler) (
+        struct _Client *, struct _Connection *,
+        struct _FileHeader *,
+        const char *file_data, size_t file_data_len,
+        char **saved_filename
+    );
+
+    void (*file_upload_cb) (
+        struct _Client *, struct _Connection *,
+        const char *saved_filename
+    );
+
+    ClientFileStats *file_stats;
+
+    ClientStats *stats;
 
 };
 
@@ -114,8 +166,10 @@ CERVER_PUBLIC void client_delete_dummy (void *ptr);
 CERVER_PUBLIC Client *client_create (void);
 
 // creates a new client and registers a new connection
-CERVER_PUBLIC Client *client_create_with_connection (struct _Cerver *cerver, 
-	const i32 sock_fd, const struct sockaddr_storage address);
+CERVER_PUBLIC Client *client_create_with_connection (
+    struct _Cerver *cerver,
+    const i32 sock_fd, const struct sockaddr_storage address
+);
 
 // sets the client's name
 CERVER_EXPORT void client_set_name (Client *client, const char *name);
@@ -135,11 +189,13 @@ CERVER_EXPORT void *client_get_data (Client *client);
 // deletes the previous data of the client
 CERVER_EXPORT void client_set_data (Client *client, void *data, Action delete_data);
 
-// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
-CERVER_EXPORT void client_set_app_handlers (Client *client, 
-	struct _Handler *app_handler, struct _Handler *app_error_handler);
+// sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
+CERVER_EXPORT void client_set_app_handlers (
+    Client *client,
+    struct _Handler *app_handler, struct _Handler *app_error_handler
+);
 
-// sets a CUSTOM_PACKET packet type handler
+// sets a PACKET_TYPE_CUSTOM packet type handler
 CERVER_EXPORT void client_set_custom_handler (Client *client, struct _Handler *custom_handler);
 
 // set whether to check or not incoming packets
@@ -198,7 +254,7 @@ CERVER_PRIVATE u8 client_unregister_connections_from_cerver (struct _Cerver *cer
 // returns 0 on success registering at least one, 1 if all connections failed
 CERVER_PRIVATE u8 client_register_connections_to_cerver_poll (struct _Cerver *cerver, Client *client);
 
-// unregisters all the active connections from a client from the cerver's poll 
+// unregisters all the active connections from a client from the cerver's poll
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
 CERVER_PRIVATE u8 client_unregister_connections_from_cerver_poll (struct _Cerver *cerver, Client *client);
 
@@ -221,98 +277,107 @@ CERVER_PUBLIC Client *client_get_by_sock_fd (struct _Cerver *cerver, i32 sock_fd
 CERVER_PUBLIC Client *client_get_by_session_id (struct _Cerver *cerver, const char *session_id);
 
 // broadcast a packet to all clients inside an avl structure
-CERVER_PUBLIC void client_broadcast_to_all_avl (AVLNode *node, struct _Cerver *cerver, 
-	struct _Packet *packet);
+CERVER_PUBLIC void client_broadcast_to_all_avl (
+    AVLNode *node,
+    struct _Cerver *cerver,
+    struct _Packet *packet
+);
 
 #pragma endregion
 
 #pragma region events
 
+#define CLIENT_EVENT_MAP(XX)																													\
+    XX(0,	NONE, 				No event)																										\
+    XX(1,	CONNECTED, 			Connected to cerver)																							\
+    XX(2,	DISCONNECTED, 		Disconnected from the cerver; either by the cerver or by losing connection)										\
+    XX(3,	CONNECTION_FAILED, 	Failed to connect to cerver)																					\
+    XX(4,	CONNECTION_CLOSE, 	The connection was clossed directly by client. This happens when a call to a recv () methods returns <= 0)		\
+    XX(5,	CONNECTION_DATA, 	Data has been received; only triggered from client request methods)												\
+    XX(6,	CERVER_INFO, 		Received cerver info from the cerver)																			\
+    XX(7,	CERVER_TEARDOWN, 	The cerver is going to teardown & the client will disconnect)													\
+    XX(8,	CERVER_STATS, 		Received cerver stats)																							\
+    XX(9,	CERVER_GAME_STATS, 	Received cerver game stats)																						\
+    XX(10,	AUTH_SENT, 			Auth data has been sent to the cerver)																			\
+    XX(11,	SUCCESS_AUTH, 		Auth with cerver has been successfull)																			\
+    XX(12,	MAX_AUTH_TRIES, 	Maxed out attempts to authenticate to cerver; need to try again)												\
+    XX(13,	LOBBY_CREATE, 		A new lobby was successfully created)																			\
+    XX(14,	LOBBY_JOIN, 		Correctly joined a new lobby)																					\
+    XX(15,	LOBBY_LEAVE, 		Successfully exited a lobby)																					\
+    XX(16,	LOBBY_START, 		The game in the lobby has started)																				\
+    XX(17,	UNKNOWN, 			Unknown event)
+
 typedef enum ClientEventType {
 
-	CLIENT_EVENT_NONE                  = 0, 
-
-	CLIENT_EVENT_CONNECTED,            // connected to cerver
-	CLIENT_EVENT_DISCONNECTED,         // disconnected from the cerver, either by the cerver or by losing connection
-
-	CLIENT_EVENT_CONNECTION_FAILED,    // failed to connect to cerver
-	CLIENT_EVENT_CONNECTION_CLOSE,     // this happens when a call to a recv () methods returns <= 0, the connection is clossed directly by client
-
-	CLIENT_EVENT_CONNECTION_DATA,      // data has been received, only triggered from client request methods
-
-	CLIENT_EVENT_CERVER_INFO,          // received cerver info from the cerver
-	CLIENT_EVENT_CERVER_TEARDOWN,      // the cerver is going to teardown (disconnect happens automatically)
-	CLIENT_EVENT_CERVER_STATS,         // received cerver stats
-	CLIENT_EVENT_CERVER_GAME_STATS,    // received cerver game stats
-
-	CLIENT_EVENT_AUTH_SENT,            // auth data has been sent to the cerver
-	CLIENT_EVENT_SUCCESS_AUTH,         // auth with cerver has been successfull
-	CLIENT_EVENT_MAX_AUTH_TRIES,       // maxed out attempts to authenticate to cerver, so try again
-
-	CLIENT_EVENT_LOBBY_CREATE,         // a new lobby was successfully created
-	CLIENT_EVENT_LOBBY_JOIN,           // correctly joined a new lobby
-	CLIENT_EVENT_LOBBY_LEAVE,          // successfully exited a lobby
-
-	CLIENT_EVENT_LOBBY_START,          // the game in the lobby has started
+    #define XX(num, name, description) CLIENT_EVENT_##name = num,
+    CLIENT_EVENT_MAP (XX)
+    #undef XX
 
 } ClientEventType;
 
-typedef struct ClientEvent {
+// get the description for the current error type
+CERVER_EXPORT const char *client_event_type_description (ClientEventType type);
 
-	ClientEventType type;         // the event we are waiting to happen
-	bool create_thread;                 // create a detachable thread to run action
-	bool drop_after_trigger;            // if we only want to trigger the event once
+struct _ClientEvent {
 
-	// the request that triggered the event
-	// this is usefull for custom events
-	u32 request_type; 
-	void *response_data;                // data that came with the response   
-	Action delete_response_data;       
+    ClientEventType type;         // the event we are waiting to happen
+    bool create_thread;                 // create a detachable thread to run action
+    bool drop_after_trigger;            // if we only want to trigger the event once
 
-	Action action;                      // the action to be triggered
-	void *action_args;                  // the action arguments
-	Action delete_action_args;          // how to get rid of the data
+    // the request that triggered the event
+    // this is usefull for custom events
+    u32 request_type;
+    void *response_data;                // data that came with the response
+    Action delete_response_data;
 
-} ClientEvent;
+    Action action;                      // the action to be triggered
+    void *action_args;                  // the action arguments
+    Action delete_action_args;          // how to get rid of the data
+
+};
+
+typedef struct _ClientEvent ClientEvent;
 
 // registers an action to be triggered when the specified event occurs
 // if there is an existing action registered to an event, it will be overrided
-// a newly allocated ClientEventData structure will be passed to your method 
+// a newly allocated ClientEventData structure will be passed to your method
 // that should be free using the client_event_data_delete () method
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 client_event_register (
-	struct _Client *client, const ClientEventType event_type, 
-	Action action, void *action_args, Action delete_action_args, 
-	bool create_thread, bool drop_after_trigger
+    struct _Client *client,
+    const ClientEventType event_type,
+    Action action, void *action_args, Action delete_action_args,
+    bool create_thread, bool drop_after_trigger
 );
 
 // unregister the action associated with an event
 // deletes the action args using the delete_action_args () if NOT NULL
-// returns 0 on success, 1 on error
+// returns 0 on success, 1 on error or if event is NOT registered
 CERVER_EXPORT u8 client_event_unregister (struct _Client *client, const ClientEventType event_type);
 
 CERVER_PRIVATE void client_event_set_response (
-	struct _Client *client, const ClientEventType event_type,
-	void *response_data, Action delete_response_data
+    struct _Client *client,
+    const ClientEventType event_type,
+    void *response_data, Action delete_response_data
 );
 
 // triggers all the actions that are registred to an event
 CERVER_PRIVATE void client_event_trigger (
-	const ClientEventType event_type,
-	const struct _Client *client, const struct _Connection *connection
+    const ClientEventType event_type,
+    const struct _Client *client, const struct _Connection *connection
 );
 
 // structure that is passed to the user registered method
 typedef struct ClientEventData {
 
-	const struct _Client *client;
-	const struct _Connection *connection;
+    const struct _Client *client;
+    const struct _Connection *connection;
 
-	void *response_data;                // data that came with the response   
-	Action delete_response_data;  
+    void *response_data;                // data that came with the response
+    Action delete_response_data;
 
-	void *action_args;                  // the action arguments
-	Action delete_action_args;
+    void *action_args;                  // the action arguments
+    Action delete_action_args;
 
 } ClientEventData;
 
@@ -322,71 +387,81 @@ CERVER_PUBLIC void client_event_data_delete (ClientEventData *event_data);
 
 #pragma region errors
 
+#define CLIENT_ERROR_MAP(XX)													\
+    XX(0,	NONE, 				No error)										\
+    XX(1,	CERVER_ERROR, 		The cerver had an internal error)				\
+    XX(2,	PACKET_ERROR, 		The cerver was unable to handle the packet)		\
+    XX(3,	FAILED_AUTH, 		Client failed to authenticate)					\
+    XX(4,	GET_FILE, 			Bad get file request)							\
+    XX(5,	SEND_FILE, 			Bad upload file request)						\
+    XX(6,	FILE_NOT_FOUND, 	The request file was not found)					\
+    XX(7,	CREATE_LOBBY, 		Failed to create a new game lobby)				\
+    XX(8,	JOIN_LOBBY, 		The player failed to join an existing lobby)	\
+    XX(9,	LEAVE_LOBBY, 		The player failed to exit the lobby)			\
+    XX(10,	FIND_LOBBY, 		Failed to find a suitable game lobby)			\
+    XX(11,	GAME_INIT, 			The game failed to init)						\
+    XX(12,	GAME_START, 		The game failed to start)						\
+    XX(13,	UNKNOWN, 			Unknown error)
+
 typedef enum ClientErrorType {
 
-	CLIENT_ERROR_NONE                    = 0,
-
-	CLIENT_ERROR_CERVER_ERROR            = 1, // internal server error, like no memory
-
-	CLIENT_ERROR_FAILED_AUTH             = 2, // we failed to authenticate with the cerver
-
-	CLIENT_ERROR_CREATE_LOBBY            = 3, // failed to create a new game lobby
-	CLIENT_ERROR_JOIN_LOBBY              = 4, // a client / player failed to join an existin lobby
-	CLIENT_ERROR_LEAVE_LOBBY             = 5, // a player failed to leave from a lobby
-	CLIENT_ERROR_FIND_LOBBY              = 6, // failed to find a game lobby for a player
-
-	CLIENT_ERROR_GAME_INIT               = 7, // the game failed to init properly
-	CLIENT_ERROR_GAME_START              = 8, // the game failed to start
+    #define XX(num, name, description) CLIENT_ERROR_##name = num,
+    CLIENT_ERROR_MAP (XX)
+    #undef XX
 
 } ClientErrorType;
 
-typedef struct ClientError {
+// get the description for the current error type
+CERVER_EXPORT const char *client_error_type_description (ClientErrorType type);
 
-	ClientErrorType type;
-	bool create_thread;                 // create a detachable thread to run action
-	bool drop_after_trigger;            // if we only want to trigger the event once
+struct _ClientError {
 
-	Action action;                      // the action to be triggered
-	void *action_args;                  // the action arguments
-	Action delete_action_args;          // how to get rid of the data
+    ClientErrorType type;
+    bool create_thread;                 // create a detachable thread to run action
+    bool drop_after_trigger;            // if we only want to trigger the event once
 
-} ClientError;
+    Action action;                      // the action to be triggered
+    void *action_args;                  // the action arguments
+    Action delete_action_args;          // how to get rid of the data
+
+};
+
+typedef struct _ClientError ClientError;
 
 // registers an action to be triggered when the specified error occurs
 // if there is an existing action registered to an error, it will be overrided
-// a newly allocated ClientErrorData structure will be passed to your method 
+// a newly allocated ClientErrorData structure will be passed to your method
 // that should be free using the client_error_data_delete () method
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 client_error_register (
-	struct _Client *client, const ClientErrorType error_type,
-	Action action, void *action_args, Action delete_action_args, 
-	bool create_thread, bool drop_after_trigger
+    struct _Client *client,
+    const ClientErrorType error_type,
+    Action action, void *action_args, Action delete_action_args,
+    bool create_thread, bool drop_after_trigger
 );
 
 // unregisters the action associated with the error types
 // deletes the action args using the delete_action_args () if NOT NULL
-// returns 0 on success, 1 on error
+// returns 0 on success, 1 on error or if error is NOT registered
 CERVER_EXPORT u8 client_error_unregister (struct _Client *client, const ClientErrorType error_type);
 
 // triggers all the actions that are registred to an error
 // returns 0 on success, 1 on error
 CERVER_PRIVATE u8 client_error_trigger (
-	const ClientErrorType error_type, 
-	const struct _Client *client, const struct _Connection *connection, 
-	const char *error_message
+    const ClientErrorType error_type,
+    const struct _Client *client, const struct _Connection *connection,
+    const char *error_message
 );
-
-#pragma region data
 
 // structure that is passed to the user registered method
 typedef struct ClientErrorData {
 
-	const struct _Client *client;
-	const struct _Connection *connection;
+    const struct _Client *client;
+    const struct _Connection *connection;
 
-	void *action_args;                  // the action arguments set by the user
+    void *action_args;                  // the action arguments set by the user
 
-	String *error_message;
+    String *error_message;
 
 } ClientErrorData;
 
@@ -400,9 +475,9 @@ CERVER_PUBLIC void client_error_data_delete (ClientErrorData *error_data);
 
 typedef struct ClientConnection {
 
-	pthread_t connection_thread_id;
-	struct _Client *client;
-	struct _Connection *connection;
+    pthread_t connection_thread_id;
+    struct _Client *client;
+    struct _Connection *connection;
 
 } ClientConnection;
 
@@ -410,9 +485,9 @@ CERVER_PRIVATE void client_connection_aux_delete (ClientConnection *cc);
 
 // creates a new connection that is ready to connect and registers it to the client
 CERVER_EXPORT struct _Connection *client_connection_create (
-	Client *client,
-	const char *ip_address, u16 port, 
-	Protocol protocol, bool use_ipv6
+    Client *client,
+    const char *ip_address, u16 port,
+    Protocol protocol, bool use_ipv6
 );
 
 // registers an existing connection to a client
@@ -436,7 +511,7 @@ CERVER_EXPORT void client_connection_get_next_packet (Client *client, struct _Co
 CERVER_EXPORT unsigned int client_connect (Client *client, struct _Connection *connection);
 
 // connects a client to the host with the specified values in the connection
-// performs a first read to get the cerver info packet 
+// performs a first read to get the cerver info packet
 // this is a blocking method, and works exactly the same as if only calling client_connect ()
 // returns 0 when the connection has been established, 1 on error or failed to connect
 CERVER_EXPORT unsigned int client_connect_to_cerver (Client *client, struct _Connection *connection);
@@ -447,6 +522,25 @@ CERVER_EXPORT unsigned int client_connect_to_cerver (Client *client, struct _Con
 // user must manually handle how he wants to receive / handle incomming packets and also send requests
 // returns 0 on success connection thread creation, 1 on error
 CERVER_EXPORT unsigned int client_connect_async (Client *client, struct _Connection *connection);
+
+/*** start ***/
+
+// after a client connection successfully connects to a server,
+// it will start the connection's update thread to enable the connection to
+// receive & handle packets in a dedicated thread
+// returns 0 on success, 1 on error
+CERVER_EXPORT int client_connection_start (Client *client, struct _Connection *connection);
+
+// connects a client connection to a server
+// and after a success connection, it will start the connection (create update thread for receiving messages)
+// this is a blocking method, returns only after a success or failed connection
+// returns 0 on success, 1 on error
+CERVER_EXPORT int client_connect_and_start (Client *client, struct _Connection *connection);
+
+// connects a client connection to a server in a new thread to avoid blocking the calling thread,
+// and after a success connection, it will start the connection (create update thread for receiving messages)
+// returns 0 on success creating connection thread, 1 on error
+CERVER_EXPORT u8 client_connect_and_start_async (Client *client, struct _Connection *connection);
 
 /*** requests ***/
 
@@ -467,36 +561,72 @@ CERVER_EXPORT unsigned int client_request_to_cerver (Client *client, struct _Con
 // returns 0 on success request, 1 on error
 CERVER_EXPORT unsigned int client_request_to_cerver_async (Client *client, struct _Connection *connection, struct _Packet *request);
 
-/*** start ***/
+/*** files ***/
 
-// after a client connection successfully connects to a server, 
-// it will start the connection's update thread to enable the connection to
-// receive & handle packets in a dedicated thread
+// adds a new file path to take into account when getting a request for a file
 // returns 0 on success, 1 on error
-CERVER_EXPORT int client_connection_start (Client *client, struct _Connection *connection);
+CERVER_EXPORT u8 client_files_add_path (Client *client, const char *path);
 
-// connects a client connection to a server
-// and after a success connection, it will start the connection (create update thread for receiving messages)
-// this is a blocking method, returns only after a success or failed connection
-// returns 0 on success, 1 on error
-CERVER_EXPORT int client_connect_and_start (Client *client, struct _Connection *connection);
+// sets the default uploads path to be used when receiving a file
+CERVER_EXPORT void client_files_set_uploads_path (Client *client, const char *uploads_path);
 
-// connects a client connection to a server in a new thread to avoid blocking the calling thread,
-// and after a success connection, it will start the connection (create update thread for receiving messages)
-// returns 0 on success creating connection thread, 1 on error
-CERVER_EXPORT u8 client_connect_and_start_async (Client *client, struct _Connection *connection);
+// sets a custom method to be used to handle a file upload (receive)
+// in this method, file contents must be consumed from the sock fd
+// and return 0 on success and 1 on error
+CERVER_EXPORT void client_files_set_file_upload_handler (
+    Client *client,
+    u8 (*file_upload_handler) (
+        struct _Client *, struct _Connection *,
+        struct _FileHeader *,
+        const char *file_data, size_t file_data_len,
+        char **saved_filename
+    )
+);
+
+// sets a callback to be executed after a file has been successfully received
+CERVER_EXPORT void client_files_set_file_upload_cb (
+    Client *client,
+    void (*file_upload_cb) (
+        struct _Client *, struct _Connection *,
+        const char *saved_filename
+    )
+);
+
+// search for the requested file in the configured paths
+// returns the actual filename (path + directory) where it was found, NULL on error
+CERVER_PUBLIC String *client_files_search_file (Client *client, const char *filename);
+
+// requests a file from the cerver
+// the client's uploads_path should have been configured before calling this method
+// returns 0 on success sending request, 1 on failed to send request
+CERVER_EXPORT u8 client_file_get (Client *client, struct _Connection *connection, const char *filename);
+
+// sends a file to the cerver
+// returns 0 on success sending request, 1 on failed to send request
+CERVER_EXPORT u8 client_file_send (Client *client, struct _Connection *connection, const char *filename);
+
+/*** update ***/
+
+// receives incoming data from the socket
+// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
+CERVER_PUBLIC unsigned int client_receive (Client *client, struct _Connection *connection);
 
 /*** end ***/
+
+// closes the connection's socket & set it to be inactive
+// does not send a close connection packet to the cerver
+// returns 0 on success, 1 on error
+CERVER_PUBLIC int client_connection_stop (Client *client, Connection *connection);
 
 // terminates the connection & closes the socket
 // but does NOT destroy the current connection
 // returns 0 on success, 1 on error
-CERVER_EXPORT int client_connection_close (Client *client, struct _Connection *connection);
+CERVER_PUBLIC int client_connection_close (Client *client, struct _Connection *connection);
 
 // terminates and destroys a connection registered to a client
 // that is connected to a cerver
 // returns 0 on success, 1 on error
-CERVER_EXPORT int client_connection_end (Client *client, struct _Connection *connection);
+CERVER_PUBLIC int client_connection_end (Client *client, struct _Connection *connection);
 
 // stop any on going connection and process and destroys the client
 // returns 0 on success, 1 on error
@@ -506,12 +636,6 @@ CERVER_EXPORT u8 client_teardown (Client *client);
 // that will cause the calling thread to wait at least a second
 // returns 0 on success creating thread, 1 on error
 CERVER_EXPORT u8 client_teardown_async (Client *client);
-
-/*** update ***/
-
-// receives incoming data from the socket
-// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
-CERVER_PUBLIC unsigned int client_receive (Client *client, struct _Connection *connection);
 
 #pragma endregion
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -37,18 +37,18 @@ struct _ClientError;
 
 struct _ClientStats {
 
-    time_t threshold_time;                  // every time we want to reset the client's stats
+	time_t threshold_time;                  // every time we want to reset the client's stats
 
-    u64 n_receives_done;                    // n calls to recv ()
+	u64 n_receives_done;                    // n calls to recv ()
 
-    u64 total_bytes_received;               // total amount of bytes received from this client
-    u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
+	u64 total_bytes_received;               // total amount of bytes received from this client
+	u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
 
-    u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
-    u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
+	u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
+	u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
 
-    struct _PacketsPerType *received_packets;
-    struct _PacketsPerType *sent_packets;
+	struct _PacketsPerType *received_packets;
+	struct _PacketsPerType *sent_packets;
 
 };
 
@@ -58,18 +58,18 @@ CERVER_PUBLIC void client_stats_print (struct _Client *client);
 
 struct _ClientFileStats {
 
-    u64 n_files_requests;				// n requests to get a file
-    u64 n_success_files_requests;		// fulfilled requests
-    u64 n_bad_files_requests;			// bad requests
-    u64 n_files_sent;					// n files sent
-    u64 n_bad_files_sent;				// n files that failed to send
-    u64 n_bytes_sent;					// total bytes sent
+	u64 n_files_requests;				// n requests to get a file
+	u64 n_success_files_requests;		// fulfilled requests
+	u64 n_bad_files_requests;			// bad requests
+	u64 n_files_sent;					// n files sent
+	u64 n_bad_files_sent;				// n files that failed to send
+	u64 n_bytes_sent;					// total bytes sent
 
-    u64 n_files_upload_requests;		// n requests to upload a file
-    u64 n_success_files_uploaded;		// n files received
-    u64 n_bad_files_upload_requests;	// bad requests to upload files
-    u64 n_bad_files_received;			// files that failed to be received
-    u64 n_bytes_received;				// total bytes received
+	u64 n_files_upload_requests;		// n requests to upload a file
+	u64 n_success_files_uploaded;		// n files received
+	u64 n_bad_files_upload_requests;	// bad requests to upload files
+	u64 n_bad_files_received;			// files that failed to be received
+	u64 n_bytes_received;				// total bytes received
 
 };
 
@@ -87,68 +87,68 @@ CERVER_PUBLIC void client_file_stats_print (struct _Client *client);
 // anyone that connects to the cerver
 struct _Client {
 
-    // generated using connection values
-    u64 id;
-    time_t connected_timestamp;
+	// generated using connection values
+	u64 id;
+	time_t connected_timestamp;
 
-    // 16/06/2020 - abiility to add a name to a client
-    String *name;
+	// 16/06/2020 - abiility to add a name to a client
+	String *name;
 
-    DoubleList *connections;
+	DoubleList *connections;
 
-    // multiple connections can be associated with the same client using the same session id
-    String *session_id;
+	// multiple connections can be associated with the same client using the same session id
+	String *session_id;
 
-    time_t last_activity;   // the last time the client sent / receive data
+	time_t last_activity;   // the last time the client sent / receive data
 
-    bool drop_client;        // client failed to authenticate
+	bool drop_client;        // client failed to authenticate
 
-    void *data;
-    Action delete_data;
+	void *data;
+	Action delete_data;
 
-    // used when the client connects to another server
-    bool running;
-    time_t time_started;
-    u64 uptime;
+	// used when the client connects to another server
+	bool running;
+	time_t time_started;
+	u64 uptime;
 
-    // 16/06/2020 - custom packet handlers
-    unsigned int num_handlers_alive;       // handlers currently alive
-    unsigned int num_handlers_working;     // handlers currently working
-    pthread_mutex_t *handlers_lock;
-    struct _Handler *app_packet_handler;
-    struct _Handler *app_error_packet_handler;
-    struct _Handler *custom_packet_handler;
+	// 16/06/2020 - custom packet handlers
+	unsigned int num_handlers_alive;       // handlers currently alive
+	unsigned int num_handlers_working;     // handlers currently working
+	pthread_mutex_t *handlers_lock;
+	struct _Handler *app_packet_handler;
+	struct _Handler *app_error_packet_handler;
+	struct _Handler *custom_packet_handler;
 
-    bool check_packets;              // enable / disbale packet checking
+	bool check_packets;              // enable / disbale packet checking
 
-    // 17/06/2020 - general client lock
-    pthread_mutex_t *lock;
+	// 17/06/2020 - general client lock
+	pthread_mutex_t *lock;
 
-    struct _ClientEvent *events[CLIENT_MAX_EVENTS];
-    struct _ClientError *errors[CLIENT_MAX_ERRORS];
+	struct _ClientEvent *events[CLIENT_MAX_EVENTS];
+	struct _ClientError *errors[CLIENT_MAX_ERRORS];
 
-    // files
-    unsigned int n_paths;
-    String *paths[CLIENT_FILES_MAX_PATHS];
+	// files
+	unsigned int n_paths;
+	String *paths[CLIENT_FILES_MAX_PATHS];
 
-    // default path where received files will be placed
-    String *uploads_path;
+	// default path where received files will be placed
+	String *uploads_path;
 
-    u8 (*file_upload_handler) (
-        struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    );
+	u8 (*file_upload_handler) (
+		struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	);
 
-    void (*file_upload_cb) (
-        struct _Client *, struct _Connection *,
-        const char *saved_filename
-    );
+	void (*file_upload_cb) (
+		struct _Client *, struct _Connection *,
+		const char *saved_filename
+	);
 
-    ClientFileStats *file_stats;
+	ClientFileStats *file_stats;
 
-    ClientStats *stats;
+	ClientStats *stats;
 
 };
 
@@ -167,8 +167,8 @@ CERVER_PUBLIC Client *client_create (void);
 
 // creates a new client and registers a new connection
 CERVER_PUBLIC Client *client_create_with_connection (
-    struct _Cerver *cerver,
-    const i32 sock_fd, const struct sockaddr_storage address
+	struct _Cerver *cerver,
+	const i32 sock_fd, const struct sockaddr_storage address
 );
 
 // sets the client's name
@@ -191,8 +191,8 @@ CERVER_EXPORT void client_set_data (Client *client, void *data, Action delete_da
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 CERVER_EXPORT void client_set_app_handlers (
-    Client *client,
-    struct _Handler *app_handler, struct _Handler *app_error_handler
+	Client *client,
+	struct _Handler *app_handler, struct _Handler *app_error_handler
 );
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
@@ -278,9 +278,9 @@ CERVER_PUBLIC Client *client_get_by_session_id (struct _Cerver *cerver, const ch
 
 // broadcast a packet to all clients inside an avl structure
 CERVER_PUBLIC void client_broadcast_to_all_avl (
-    AVLNode *node,
-    struct _Cerver *cerver,
-    struct _Packet *packet
+	AVLNode *node,
+	struct _Cerver *cerver,
+	struct _Packet *packet
 );
 
 #pragma endregion
@@ -288,30 +288,30 @@ CERVER_PUBLIC void client_broadcast_to_all_avl (
 #pragma region events
 
 #define CLIENT_EVENT_MAP(XX)																													\
-    XX(0,	NONE, 				No event)																										\
-    XX(1,	CONNECTED, 			Connected to cerver)																							\
-    XX(2,	DISCONNECTED, 		Disconnected from the cerver; either by the cerver or by losing connection)										\
-    XX(3,	CONNECTION_FAILED, 	Failed to connect to cerver)																					\
-    XX(4,	CONNECTION_CLOSE, 	The connection was clossed directly by client. This happens when a call to a recv () methods returns <= 0)		\
-    XX(5,	CONNECTION_DATA, 	Data has been received; only triggered from client request methods)												\
-    XX(6,	CERVER_INFO, 		Received cerver info from the cerver)																			\
-    XX(7,	CERVER_TEARDOWN, 	The cerver is going to teardown & the client will disconnect)													\
-    XX(8,	CERVER_STATS, 		Received cerver stats)																							\
-    XX(9,	CERVER_GAME_STATS, 	Received cerver game stats)																						\
-    XX(10,	AUTH_SENT, 			Auth data has been sent to the cerver)																			\
-    XX(11,	SUCCESS_AUTH, 		Auth with cerver has been successfull)																			\
-    XX(12,	MAX_AUTH_TRIES, 	Maxed out attempts to authenticate to cerver; need to try again)												\
-    XX(13,	LOBBY_CREATE, 		A new lobby was successfully created)																			\
-    XX(14,	LOBBY_JOIN, 		Correctly joined a new lobby)																					\
-    XX(15,	LOBBY_LEAVE, 		Successfully exited a lobby)																					\
-    XX(16,	LOBBY_START, 		The game in the lobby has started)																				\
-    XX(17,	UNKNOWN, 			Unknown event)
+	XX(0,	NONE, 				No event)																										\
+	XX(1,	CONNECTED, 			Connected to cerver)																							\
+	XX(2,	DISCONNECTED, 		Disconnected from the cerver; either by the cerver or by losing connection)										\
+	XX(3,	CONNECTION_FAILED, 	Failed to connect to cerver)																					\
+	XX(4,	CONNECTION_CLOSE, 	The connection was clossed directly by client. This happens when a call to a recv () methods returns <= 0)		\
+	XX(5,	CONNECTION_DATA, 	Data has been received; only triggered from client request methods)												\
+	XX(6,	CERVER_INFO, 		Received cerver info from the cerver)																			\
+	XX(7,	CERVER_TEARDOWN, 	The cerver is going to teardown & the client will disconnect)													\
+	XX(8,	CERVER_STATS, 		Received cerver stats)																							\
+	XX(9,	CERVER_GAME_STATS, 	Received cerver game stats)																						\
+	XX(10,	AUTH_SENT, 			Auth data has been sent to the cerver)																			\
+	XX(11,	SUCCESS_AUTH, 		Auth with cerver has been successfull)																			\
+	XX(12,	MAX_AUTH_TRIES, 	Maxed out attempts to authenticate to cerver; need to try again)												\
+	XX(13,	LOBBY_CREATE, 		A new lobby was successfully created)																			\
+	XX(14,	LOBBY_JOIN, 		Correctly joined a new lobby)																					\
+	XX(15,	LOBBY_LEAVE, 		Successfully exited a lobby)																					\
+	XX(16,	LOBBY_START, 		The game in the lobby has started)																				\
+	XX(17,	UNKNOWN, 			Unknown event)
 
 typedef enum ClientEventType {
 
-    #define XX(num, name, description) CLIENT_EVENT_##name = num,
-    CLIENT_EVENT_MAP (XX)
-    #undef XX
+	#define XX(num, name, description) CLIENT_EVENT_##name = num,
+	CLIENT_EVENT_MAP (XX)
+	#undef XX
 
 } ClientEventType;
 
@@ -320,19 +320,19 @@ CERVER_EXPORT const char *client_event_type_description (ClientEventType type);
 
 struct _ClientEvent {
 
-    ClientEventType type;         // the event we are waiting to happen
-    bool create_thread;                 // create a detachable thread to run action
-    bool drop_after_trigger;            // if we only want to trigger the event once
+	ClientEventType type;         // the event we are waiting to happen
+	bool create_thread;                 // create a detachable thread to run action
+	bool drop_after_trigger;            // if we only want to trigger the event once
 
-    // the request that triggered the event
-    // this is usefull for custom events
-    u32 request_type;
-    void *response_data;                // data that came with the response
-    Action delete_response_data;
+	// the request that triggered the event
+	// this is usefull for custom events
+	u32 request_type;
+	void *response_data;                // data that came with the response
+	Action delete_response_data;
 
-    Action action;                      // the action to be triggered
-    void *action_args;                  // the action arguments
-    Action delete_action_args;          // how to get rid of the data
+	Action action;                      // the action to be triggered
+	void *action_args;                  // the action arguments
+	Action delete_action_args;          // how to get rid of the data
 
 };
 
@@ -344,10 +344,10 @@ typedef struct _ClientEvent ClientEvent;
 // that should be free using the client_event_data_delete () method
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 client_event_register (
-    struct _Client *client,
-    const ClientEventType event_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	struct _Client *client,
+	const ClientEventType event_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 );
 
 // unregister the action associated with an event
@@ -356,28 +356,28 @@ CERVER_EXPORT u8 client_event_register (
 CERVER_EXPORT u8 client_event_unregister (struct _Client *client, const ClientEventType event_type);
 
 CERVER_PRIVATE void client_event_set_response (
-    struct _Client *client,
-    const ClientEventType event_type,
-    void *response_data, Action delete_response_data
+	struct _Client *client,
+	const ClientEventType event_type,
+	void *response_data, Action delete_response_data
 );
 
 // triggers all the actions that are registred to an event
 CERVER_PRIVATE void client_event_trigger (
-    const ClientEventType event_type,
-    const struct _Client *client, const struct _Connection *connection
+	const ClientEventType event_type,
+	const struct _Client *client, const struct _Connection *connection
 );
 
 // structure that is passed to the user registered method
 typedef struct ClientEventData {
 
-    const struct _Client *client;
-    const struct _Connection *connection;
+	const struct _Client *client;
+	const struct _Connection *connection;
 
-    void *response_data;                // data that came with the response
-    Action delete_response_data;
+	void *response_data;                // data that came with the response
+	Action delete_response_data;
 
-    void *action_args;                  // the action arguments
-    Action delete_action_args;
+	void *action_args;                  // the action arguments
+	Action delete_action_args;
 
 } ClientEventData;
 
@@ -388,26 +388,26 @@ CERVER_PUBLIC void client_event_data_delete (ClientEventData *event_data);
 #pragma region errors
 
 #define CLIENT_ERROR_MAP(XX)													\
-    XX(0,	NONE, 				No error)										\
-    XX(1,	CERVER_ERROR, 		The cerver had an internal error)				\
-    XX(2,	PACKET_ERROR, 		The cerver was unable to handle the packet)		\
-    XX(3,	FAILED_AUTH, 		Client failed to authenticate)					\
-    XX(4,	GET_FILE, 			Bad get file request)							\
-    XX(5,	SEND_FILE, 			Bad upload file request)						\
-    XX(6,	FILE_NOT_FOUND, 	The request file was not found)					\
-    XX(7,	CREATE_LOBBY, 		Failed to create a new game lobby)				\
-    XX(8,	JOIN_LOBBY, 		The player failed to join an existing lobby)	\
-    XX(9,	LEAVE_LOBBY, 		The player failed to exit the lobby)			\
-    XX(10,	FIND_LOBBY, 		Failed to find a suitable game lobby)			\
-    XX(11,	GAME_INIT, 			The game failed to init)						\
-    XX(12,	GAME_START, 		The game failed to start)						\
-    XX(13,	UNKNOWN, 			Unknown error)
+	XX(0,	NONE, 				No error)										\
+	XX(1,	CERVER_ERROR, 		The cerver had an internal error)				\
+	XX(2,	PACKET_ERROR, 		The cerver was unable to handle the packet)		\
+	XX(3,	FAILED_AUTH, 		Client failed to authenticate)					\
+	XX(4,	GET_FILE, 			Bad get file request)							\
+	XX(5,	SEND_FILE, 			Bad upload file request)						\
+	XX(6,	FILE_NOT_FOUND, 	The request file was not found)					\
+	XX(7,	CREATE_LOBBY, 		Failed to create a new game lobby)				\
+	XX(8,	JOIN_LOBBY, 		The player failed to join an existing lobby)	\
+	XX(9,	LEAVE_LOBBY, 		The player failed to exit the lobby)			\
+	XX(10,	FIND_LOBBY, 		Failed to find a suitable game lobby)			\
+	XX(11,	GAME_INIT, 			The game failed to init)						\
+	XX(12,	GAME_START, 		The game failed to start)						\
+	XX(13,	UNKNOWN, 			Unknown error)
 
 typedef enum ClientErrorType {
 
-    #define XX(num, name, description) CLIENT_ERROR_##name = num,
-    CLIENT_ERROR_MAP (XX)
-    #undef XX
+	#define XX(num, name, description) CLIENT_ERROR_##name = num,
+	CLIENT_ERROR_MAP (XX)
+	#undef XX
 
 } ClientErrorType;
 
@@ -416,13 +416,13 @@ CERVER_EXPORT const char *client_error_type_description (ClientErrorType type);
 
 struct _ClientError {
 
-    ClientErrorType type;
-    bool create_thread;                 // create a detachable thread to run action
-    bool drop_after_trigger;            // if we only want to trigger the event once
+	ClientErrorType type;
+	bool create_thread;                 // create a detachable thread to run action
+	bool drop_after_trigger;            // if we only want to trigger the event once
 
-    Action action;                      // the action to be triggered
-    void *action_args;                  // the action arguments
-    Action delete_action_args;          // how to get rid of the data
+	Action action;                      // the action to be triggered
+	void *action_args;                  // the action arguments
+	Action delete_action_args;          // how to get rid of the data
 
 };
 
@@ -434,10 +434,10 @@ typedef struct _ClientError ClientError;
 // that should be free using the client_error_data_delete () method
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 client_error_register (
-    struct _Client *client,
-    const ClientErrorType error_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	struct _Client *client,
+	const ClientErrorType error_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 );
 
 // unregisters the action associated with the error types
@@ -448,20 +448,20 @@ CERVER_EXPORT u8 client_error_unregister (struct _Client *client, const ClientEr
 // triggers all the actions that are registred to an error
 // returns 0 on success, 1 on error
 CERVER_PRIVATE u8 client_error_trigger (
-    const ClientErrorType error_type,
-    const struct _Client *client, const struct _Connection *connection,
-    const char *error_message
+	const ClientErrorType error_type,
+	const struct _Client *client, const struct _Connection *connection,
+	const char *error_message
 );
 
 // structure that is passed to the user registered method
 typedef struct ClientErrorData {
 
-    const struct _Client *client;
-    const struct _Connection *connection;
+	const struct _Client *client;
+	const struct _Connection *connection;
 
-    void *action_args;                  // the action arguments set by the user
+	void *action_args;                  // the action arguments set by the user
 
-    String *error_message;
+	String *error_message;
 
 } ClientErrorData;
 
@@ -475,9 +475,9 @@ CERVER_PUBLIC void client_error_data_delete (ClientErrorData *error_data);
 
 typedef struct ClientConnection {
 
-    pthread_t connection_thread_id;
-    struct _Client *client;
-    struct _Connection *connection;
+	pthread_t connection_thread_id;
+	struct _Client *client;
+	struct _Connection *connection;
 
 } ClientConnection;
 
@@ -485,9 +485,9 @@ CERVER_PRIVATE void client_connection_aux_delete (ClientConnection *cc);
 
 // creates a new connection that is ready to connect and registers it to the client
 CERVER_EXPORT struct _Connection *client_connection_create (
-    Client *client,
-    const char *ip_address, u16 port,
-    Protocol protocol, bool use_ipv6
+	Client *client,
+	const char *ip_address, u16 port,
+	Protocol protocol, bool use_ipv6
 );
 
 // registers an existing connection to a client
@@ -574,22 +574,22 @@ CERVER_EXPORT void client_files_set_uploads_path (Client *client, const char *up
 // in this method, file contents must be consumed from the sock fd
 // and return 0 on success and 1 on error
 CERVER_EXPORT void client_files_set_file_upload_handler (
-    Client *client,
-    u8 (*file_upload_handler) (
-        struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    )
+	Client *client,
+	u8 (*file_upload_handler) (
+		struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	)
 );
 
 // sets a callback to be executed after a file has been successfully received
 CERVER_EXPORT void client_files_set_file_upload_cb (
-    Client *client,
-    void (*file_upload_cb) (
-        struct _Client *, struct _Connection *,
-        const char *saved_filename
-    )
+	Client *client,
+	void (*file_upload_cb) (
+		struct _Client *, struct _Connection *,
+		const char *saved_filename
+	)
 );
 
 // search for the requested file in the configured paths

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -32,18 +32,18 @@ struct _AdminCerver;
 
 struct _ConnectionStats {
 
-    time_t threshold_time;                  // every time we want to reset the connection's stats
+	time_t threshold_time;                  // every time we want to reset the connection's stats
 
-    u64 n_receives_done;                    // n calls to recv ()
+	u64 n_receives_done;                    // n calls to recv ()
 
-    u64 total_bytes_received;               // total amount of bytes received from this connection
-    u64 total_bytes_sent;                   // total amount of bytes that have been sent to the connection
+	u64 total_bytes_received;               // total amount of bytes received from this connection
+	u64 total_bytes_sent;                   // total amount of bytes that have been sent to the connection
 
-    u64 n_packets_received;                 // total number of packets received from this connection (packet header + data)
-    u64 n_packets_sent;                     // total number of packets sent to this connection
+	u64 n_packets_received;                 // total number of packets received from this connection (packet header + data)
+	u64 n_packets_sent;                     // total number of packets sent to this connection
 
-    struct _PacketsPerType *received_packets;
-    struct _PacketsPerType *sent_packets;
+	struct _PacketsPerType *received_packets;
+	struct _PacketsPerType *sent_packets;
 
 };
 
@@ -56,57 +56,57 @@ CERVER_PUBLIC void connection_stats_print (struct _Connection *connection);
 // a connection from a client
 struct _Connection {
 
-    String *name;
+	String *name;
 
-    struct _Socket *socket;
-    u16 port;
-    Protocol protocol;
-    bool use_ipv6;
+	struct _Socket *socket;
+	u16 port;
+	Protocol protocol;
+	bool use_ipv6;
 
-    String *ip;
-    struct sockaddr_storage address;
+	String *ip;
+	struct sockaddr_storage address;
 
-    time_t connected_timestamp;             // when the connection started
+	time_t connected_timestamp;             // when the connection started
 
-    struct _CerverReport *cerver_report;    // info about the cerver we are connecting to
+	struct _CerverReport *cerver_report;    // info about the cerver we are connecting to
 
-    u32 max_sleep;
-    bool active;
-    bool updating;
+	u32 max_sleep;
+	bool active;
+	bool updating;
 
-    u8 auth_tries;                          // remaining attempts to authenticate
-    u8 bad_packets;                         // number of bad packets before being disconnected
+	u8 auth_tries;                          // remaining attempts to authenticate
+	u8 bad_packets;                         // number of bad packets before being disconnected
 
-    u32 receive_packet_buffer_size;         // 01/01/2020 - read packets into a buffer of this size in client_receive ()
-    struct _SockReceive *sock_receive;      // 01/01/2020 - used for inter-cerver communications
+	u32 receive_packet_buffer_size;         // 01/01/2020 - read packets into a buffer of this size in client_receive ()
+	struct _SockReceive *sock_receive;      // 01/01/2020 - used for inter-cerver communications
 
-    pthread_t update_thread_id;
-    u32 update_timeout;
+	pthread_t update_thread_id;
+	u32 update_timeout;
 
-    // 16/06/2020 - used for direct requests to cerver
-    bool full_packet;
+	// 16/06/2020 - used for direct requests to cerver
+	bool full_packet;
 
-    // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
-    void *received_data;
-    size_t received_data_size;
-    Action received_data_delete;
+	// 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
+	void *received_data;
+	size_t received_data_size;
+	Action received_data_delete;
 
-    bool receive_packets;                   		// set if the connection will receive packets or not (default true)
-    delegate custom_receive;                		// custom receive method to handle incomming packets in the connection
-    void *custom_receive_args;              		// arguments to be passed to the custom receive method
-    void (*custom_receive_args_delete)(void *);		// method to delete the arguments when the connection gets deleted
+	bool receive_packets;                   		// set if the connection will receive packets or not (default true)
+	delegate custom_receive;                		// custom receive method to handle incomming packets in the connection
+	void *custom_receive_args;              		// arguments to be passed to the custom receive method
+	void (*custom_receive_args_delete)(void *);		// method to delete the arguments when the connection gets deleted
 
-    bool authenticated;                     // the connection has been authenticated to the cerver
-    void *auth_data;                        // maybe auth credentials
-    size_t auth_data_size;
-    Action delete_auth_data;                // destroys the auth data when the connection ends
-    bool admin_auth;                        // attempt to connect as an admin
-    struct _Packet *auth_packet;
+	bool authenticated;                     // the connection has been authenticated to the cerver
+	void *auth_data;                        // maybe auth credentials
+	size_t auth_data_size;
+	Action delete_auth_data;                // destroys the auth data when the connection ends
+	bool admin_auth;                        // attempt to connect as an admin
+	struct _Packet *auth_packet;
 
-    ConnectionStats *stats;
+	ConnectionStats *stats;
 
-    pthread_cond_t *cond;
-    pthread_mutex_t *mutex;
+	pthread_cond_t *cond;
+	pthread_mutex_t *mutex;
 
 };
 
@@ -120,8 +120,8 @@ CERVER_PUBLIC Connection *connection_create_empty (void);
 
 // creates a new client connection with the specified values
 CERVER_PUBLIC Connection *connection_create (
-    const i32 sock_fd, const struct sockaddr_storage address,
-    Protocol protocol
+	const i32 sock_fd, const struct sockaddr_storage address,
+	Protocol protocol
 );
 
 // compare two connections by their socket fds
@@ -135,8 +135,8 @@ CERVER_PUBLIC void connection_get_values (Connection *connection);
 
 // sets the connection's newtwork values
 CERVER_PUBLIC void connection_set_values (
-    Connection *connection,
-    const char *ip_address, u16 port, Protocol protocol, bool use_ipv6
+	Connection *connection,
+	const char *ip_address, u16 port, Protocol protocol, bool use_ipv6
 );
 
 // sets the connection max sleep (wait time) to try to connect to the cerver
@@ -161,9 +161,9 @@ CERVER_EXPORT void connection_set_update_timeout (Connection *connection, u32 ti
 
 typedef struct ConnectionCustomReceiveData {
 
-    struct _Client *client;
-    struct _Connection *connection;
-    void *args;
+	struct _Client *client;
+	struct _Connection *connection;
+	void *args;
 
 } ConnectionCustomReceiveData;
 
@@ -172,18 +172,18 @@ typedef struct ConnectionCustomReceiveData {
 // alongside the arguments passed to this method
 // the method must return 0 on success & 1 on error
 CERVER_PUBLIC void connection_set_custom_receive (
-    Connection *connection,
-    delegate custom_receive,
-    void *args, void (*args_delete)(void *)
+	Connection *connection,
+	delegate custom_receive,
+	void *args, void (*args_delete)(void *)
 );
 
 // sets the connection auth data to send whenever the cerver requires authentication
 // and a method to destroy it once the connection has ended,
 // if delete_auth_data is NULL, the auth data won't be deleted
 CERVER_PUBLIC void connection_set_auth_data (
-    Connection *connection,
-    void *auth_data, size_t auth_data_size, Action delete_auth_data,
-    bool admin_auth
+	Connection *connection,
+	void *auth_data, size_t auth_data_size, Action delete_auth_data,
+	bool admin_auth
 );
 
 // removes the connection auth data using the connection's delete_auth_data method
@@ -227,8 +227,8 @@ CERVER_PRIVATE u8 connection_register_to_client (struct _Client *client, Connect
 // registers the client connection to the cerver's strcutures (like maps)
 // returns 0 on success, 1 on error
 CERVER_PRIVATE u8 connection_register_to_cerver (
-    struct _Cerver *cerver,
-    struct _Client *client, Connection *connection
+	struct _Cerver *cerver,
+	struct _Client *client, Connection *connection
 );
 
 // unregister the client connection from the cerver's structures (like maps)

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -19,7 +19,7 @@
 #define DEFAULT_CONNECTION_MAX_SLEEP                60
 #define DEFAULT_CONNECTION_PROTOCOL                 PROTOCOL_TCP
 
-#define DEFAULT_CONNECTION_UPDATE_SLEEP             200000
+#define DEFAULT_CONNECTION_TIMEOUT					2
 
 struct _Socket;
 struct _Cerver;
@@ -31,7 +31,7 @@ struct _SockReceive;
 struct _AdminCerver;
 
 struct _ConnectionStats {
-    
+
     time_t threshold_time;                  // every time we want to reset the connection's stats
 
     u64 n_receives_done;                    // n calls to recv ()
@@ -67,12 +67,13 @@ struct _Connection {
     struct sockaddr_storage address;
 
     time_t connected_timestamp;             // when the connection started
-    
+
     struct _CerverReport *cerver_report;    // info about the cerver we are connecting to
 
     u32 max_sleep;
     bool active;
-    
+    bool updating;
+
     u8 auth_tries;                          // remaining attempts to authenticate
     u8 bad_packets;                         // number of bad packets before being disconnected
 
@@ -80,19 +81,20 @@ struct _Connection {
     struct _SockReceive *sock_receive;      // 01/01/2020 - used for inter-cerver communications
 
     pthread_t update_thread_id;
-    u32 update_sleep;
+    u32 update_timeout;
 
     // 16/06/2020 - used for direct requests to cerver
     bool full_packet;
 
     // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
-    void *received_data;                    
+    void *received_data;
     size_t received_data_size;
     Action received_data_delete;
 
-    bool receive_packets;                   // set if the connection will receive packets or not (default true)
-    delegate custom_receive;                // custom receive method to handle incomming packets in the connection
-    void *custom_receive_args;              // arguments to be passed to the custom receive method
+    bool receive_packets;                   		// set if the connection will receive packets or not (default true)
+    delegate custom_receive;                		// custom receive method to handle incomming packets in the connection
+    void *custom_receive_args;              		// arguments to be passed to the custom receive method
+    void (*custom_receive_args_delete)(void *);		// method to delete the arguments when the connection gets deleted
 
     bool authenticated;                     // the connection has been authenticated to the cerver
     void *auth_data;                        // maybe auth credentials
@@ -102,6 +104,9 @@ struct _Connection {
     struct _Packet *auth_packet;
 
     ConnectionStats *stats;
+
+    pthread_cond_t *cond;
+    pthread_mutex_t *mutex;
 
 };
 
@@ -114,8 +119,10 @@ CERVER_PUBLIC void connection_delete (void *ptr);
 CERVER_PUBLIC Connection *connection_create_empty (void);
 
 // creates a new client connection with the specified values
-CERVER_PUBLIC Connection *connection_create (const i32 sock_fd, const struct sockaddr_storage address,
-    Protocol protocol);
+CERVER_PUBLIC Connection *connection_create (
+    const i32 sock_fd, const struct sockaddr_storage address,
+    Protocol protocol
+);
 
 // compare two connections by their socket fds
 CERVER_PUBLIC int connection_comparator (const void *a, const void *b);
@@ -127,8 +134,10 @@ CERVER_PUBLIC void connection_set_name (Connection *connection, const char *name
 CERVER_PUBLIC void connection_get_values (Connection *connection);
 
 // sets the connection's newtwork values
-CERVER_PUBLIC void connection_set_values (Connection *connection,
-    const char *ip_address, u16 port, Protocol protocol, bool use_ipv6);
+CERVER_PUBLIC void connection_set_values (
+    Connection *connection,
+    const char *ip_address, u16 port, Protocol protocol, bool use_ipv6
+);
 
 // sets the connection max sleep (wait time) to try to connect to the cerver
 CERVER_EXPORT void connection_set_max_sleep (Connection *connection, u32 max_sleep);
@@ -145,10 +154,10 @@ CERVER_EXPORT void connection_set_receive_buffer_size (Connection *connection, u
 // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
 CERVER_EXPORT void connection_set_received_data (Connection *connection, void *data, size_t data_size, Action data_delete);
 
-// 17/06/2020
-// sets the waiting time (sleep) in micro secs between each call to recv () in connection_update () thread
-// the dault value is 200000 (DEFAULT_CONNECTION_UPDATE_SLEEP)
-CERVER_EXPORT void connection_set_update_sleep (Connection *connection, u32 sleep);
+// sets the timeout (in secs) the connection's socket will have
+// this refers to the time the socket will block waiting for new data to araive
+// note that this only has effect in connection_update ()
+CERVER_EXPORT void connection_set_update_timeout (Connection *connection, u32 timeout);
 
 typedef struct ConnectionCustomReceiveData {
 
@@ -162,14 +171,20 @@ typedef struct ConnectionCustomReceiveData {
 // a reference to the client and connection will be passed to the action as ClientConnection structure
 // alongside the arguments passed to this method
 // the method must return 0 on success & 1 on error
-CERVER_PUBLIC void connection_set_custom_receive (Connection *connection, delegate custom_receive, void *args);
+CERVER_PUBLIC void connection_set_custom_receive (
+    Connection *connection,
+    delegate custom_receive,
+    void *args, void (*args_delete)(void *)
+);
 
-// sets the connection auth data to send whenever the cerver requires authentication 
+// sets the connection auth data to send whenever the cerver requires authentication
 // and a method to destroy it once the connection has ended,
 // if delete_auth_data is NULL, the auth data won't be deleted
-CERVER_PUBLIC void connection_set_auth_data (Connection *connection, 
+CERVER_PUBLIC void connection_set_auth_data (
+    Connection *connection,
     void *auth_data, size_t auth_data_size, Action delete_auth_data,
-    bool admin_auth);
+    bool admin_auth
+);
 
 // removes the connection auth data using the connection's delete_auth_data method
 // if not such method, the data won't be deleted
@@ -211,8 +226,10 @@ CERVER_PRIVATE u8 connection_register_to_client (struct _Client *client, Connect
 
 // registers the client connection to the cerver's strcutures (like maps)
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 connection_register_to_cerver (struct _Cerver *cerver, 
-    struct _Client *client, Connection *connection);
+CERVER_PRIVATE u8 connection_register_to_cerver (
+    struct _Cerver *cerver,
+    struct _Client *client, Connection *connection
+);
 
 // unregister the client connection from the cerver's structures (like maps)
 // returns 0 on success, 1 on error

--- a/include/cerver/errors.h
+++ b/include/cerver/errors.h
@@ -14,23 +14,38 @@ struct _Client;
 struct _Packet;
 struct _Connection;
 
+#pragma region types
+
+#define CERVER_MAX_ERRORS				32
+
+#define CERVER_ERROR_MAP(XX)													\
+	XX(0,	NONE, 				No error)										\
+	XX(1,	CERVER_ERROR, 		The cerver had an internal error)				\
+	XX(2,	PACKET_ERROR, 		The cerver was unable to handle the packet)		\
+	XX(3,	FAILED_AUTH, 		Client failed to authenticate)					\
+	XX(4,	GET_FILE, 			Bad get file request)							\
+	XX(5,	SEND_FILE, 			Bad upload file request)						\
+	XX(6,	FILE_NOT_FOUND, 	The request file was not found)					\
+	XX(7,	CREATE_LOBBY, 		Failed to create a new game lobby)				\
+	XX(8,	JOIN_LOBBY, 		The player failed to join an existing lobby)	\
+	XX(9,	LEAVE_LOBBY, 		The player failed to exit the lobby)			\
+	XX(10,	FIND_LOBBY, 		Failed to find a suitable game lobby)			\
+	XX(11,	GAME_INIT, 			The game failed to init)						\
+	XX(12,	GAME_START, 		The game failed to start)						\
+	XX(13,	UNKNOWN, 			Unknown error)
+
 typedef enum CerverErrorType {
 
-    CERVER_ERROR_NONE                    = 0,
-
-	CERVER_ERROR_CERVER_ERROR            = 1, // sent to the client when the cerver has an internal error
-
-	CERVER_ERROR_FAILED_AUTH             = 2, // errors that is sent to the client when he failed to authenticate
-
-	CERVER_ERROR_CREATE_LOBBY            = 3, // failed to create a new game lobby
-	CERVER_ERROR_JOIN_LOBBY              = 4, // a client / player failed to join an existin lobby
-	CERVER_ERROR_LEAVE_LOBBY             = 5, // a player failed to leave from a lobby
-	CERVER_ERROR_FIND_LOBBY              = 6, // failed to find a game lobby for a player
-
-	CERVER_ERROR_GAME_INIT               = 7, // the game failed to init properly
-	CERVER_ERROR_GAME_START              = 8, // the game failed to start
+	#define XX(num, name, description) CERVER_ERROR_##name = num,
+	CERVER_ERROR_MAP (XX)
+	#undef XX
 
 } CerverErrorType;
+
+// get the description for the current error type
+CERVER_EXPORT const char *cerver_error_type_description (CerverErrorType type);
+
+#pragma endregion
 
 #pragma region event
 
@@ -39,7 +54,7 @@ typedef struct CerverErrorEvent {
 	CerverErrorType type;
 
 	bool create_thread;                 // create a detachable thread to run action
-	bool drop_after_trigger;            // if we only want to trigger the event once 
+	bool drop_after_trigger;            // if we only want to trigger the event once
 
 	Action action;                      // the action to be triggered
 	void *action_args;                  // the action arguments
@@ -51,23 +66,27 @@ CERVER_PUBLIC void cerver_error_event_delete (void *event_ptr);
 
 // registers an action to be triggered when the specified error event occurs
 // if there is an existing action registered to an error event, it will be overrided
-// a newly allocated CerverErrorEventData structure will be passed to your method 
+// a newly allocated CerverErrorEventData structure will be passed to your method
 // that should be free using the cerver_error_event_data_delete () method
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_error_event_register (struct _Cerver *cerver, const CerverErrorType error_type, 
-    Action action, void *action_args, Action delete_action_args, 
-    bool create_thread, bool drop_after_trigger);
+CERVER_EXPORT u8 cerver_error_event_register (
+	struct _Cerver *cerver,
+	const CerverErrorType error_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
+);
 
 // unregister the action associated with an error event
 // deletes the action args using the delete_action_args () if NOT NULL
-// returns 0 on success, 1 on error
+// returns 0 on success, 1 on error or if error is NOT registered
 CERVER_EXPORT u8 cerver_error_event_unregister (struct _Cerver *cerver, const CerverErrorType error_type);
 
 // triggers all the actions that are registred to an error
-CERVER_PRIVATE void cerver_error_event_trigger (const CerverErrorType error_type, 
-    const struct _Cerver *cerver, 
+CERVER_PRIVATE void cerver_error_event_trigger (
+	const CerverErrorType error_type,
+	const struct _Cerver *cerver,
 	const struct _Client *client, const struct _Connection *connection,
-    const char *error_message
+	const char *error_message
 );
 
 #pragma endregion
@@ -92,19 +111,10 @@ CERVER_PUBLIC void cerver_error_event_data_delete (CerverErrorEventData *error_e
 
 #pragma endregion
 
-#pragma region error
+#pragma region handler
 
-typedef struct CerverError {
-
-	CerverErrorType type;
-    time_t timestamp;
-    String *msg;
-
-} CerverError;
-
-CERVER_PRIVATE CerverError *cerver_error_new (const CerverErrorType type, const char *msg);
-
-CERVER_PRIVATE void cerver_error_delete (void *cerver_error_ptr);
+// handles error packets
+CERVER_PRIVATE void cerver_error_packet_handler (struct _Packet *packet);
 
 #pragma endregion
 
@@ -115,8 +125,10 @@ CERVER_PUBLIC struct _Packet *error_packet_generate (const CerverErrorType type,
 
 // creates and send a new error packet
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 error_packet_generate_and_send (const CerverErrorType type, const char *msg,
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection);
+CERVER_PUBLIC u8 error_packet_generate_and_send (
+	const CerverErrorType type, const char *msg,
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection
+);
 
 #pragma endregion
 
@@ -127,9 +139,9 @@ CERVER_PUBLIC u8 error_packet_generate_and_send (const CerverErrorType type, con
 // serialized error data
 typedef struct SError {
 
-    time_t timestamp;
-    u32 error_type;
-    char msg[ERROR_MESSAGE_LENGTH];
+	time_t timestamp;
+	u32 error_type;
+	char msg[ERROR_MESSAGE_LENGTH];
 
 } SError;
 

--- a/include/cerver/events.h
+++ b/include/cerver/events.h
@@ -11,45 +11,57 @@ struct _Cerver;
 struct _Client;
 struct _Connection;
 
+#pragma region types
+
+#define CERVER_MAX_EVENTS				32
+
+#define CERVER_EVENT_MAP(XX)																		\
+	XX(0,	NONE, 						No event)													\
+	XX(1,	STARTED, 					The cerver has started)										\
+	XX(2,	TEARDOWN, 					The cerver is going to be teardown)							\
+	XX(3,	ON_HOLD_CONNECTED, 			A new connection has been put on hold)						\
+	XX(4,	ON_HOLD_DISCONNECTED, 		An on hold connection disconnected)							\
+	XX(5,	ON_HOLD_DROPPED, 			An on hold connection was dropped)							\
+	XX(6,	CLIENT_SUCCESS_AUTH, 		A client connection has successfully authenticated)			\
+	XX(7,	CLIENT_FAILED_AUTH,			A client connection failed to authenticate)					\
+	XX(8,	CLIENT_CONNECTED, 			A new client has connected to the cerver)					\
+	XX(9,	CLIENT_NEW_CONNECTION, 		Added a connection to an existing client)					\
+	XX(11,	CLIENT_CLOSE_CONNECTION,	A connection from an existing client was closed)			\
+	XX(12,	CLIENT_DISCONNECTED, 		A client has disconnected from the cerver)					\
+	XX(13,	CLIENT_DROPPED, 			A client has been dropped from the cerver)					\
+	XX(14,	ADMIN_FAILED_AUTH, 			A possible admin connection failed to authenticate)			\
+	XX(15,	ADMIN_CONNECTED, 			A new admin has connected & authenticated to the cerver)	\
+	XX(16,	ADMIN_NEW_CONNECTION, 		Added a connection to an existing client)					\
+	XX(17,	ADMIN_CLOSE_CONNECTION, 	A connection from an existing client was closed)			\
+	XX(18,	ADMIN_DISCONNECTED, 		An admin disconnected from the cerver)						\
+	XX(19,	ADMIN_DROPPED, 				An admin was dropped from the cerver)						\
+	XX(20,	LOBBY_CREATE, 				A new lobby was successfully created)						\
+	XX(21,	LOBBY_JOIN, 				Someone has joined a lobby)									\
+	XX(22,	LOBBY_LEAVE, 				Someone has exited the lobby)								\
+	XX(23,	LOBBY_START, 				The game in the lobby has started)							\
+	XX(24,	UNKNOWN, 					Unknown event)
+
 typedef enum CerverEventType {
 
-	CERVER_EVENT_NONE                  		= 0, 
-
-	CERVER_EVENT_STARTED,              		// the cerver has started
-	CERVER_EVENT_TEARDOWN,             		// the cerver is going to be teardown 
-
-	CERVER_EVENT_ON_HOLD_CONNECTED,   		// a connection has been put on hold
-	CERVER_EVENT_ON_HOLD_DISCONNECTED,  	// an on hold connection disconnected
-	CERVER_EVENT_ON_HOLD_DROPPED,   		// an on hold connection was dropped
-
-	CERVER_EVENT_CLIENT_SUCCESS_AUTH,  		// a client connection has successfully authenticated
-	CERVER_EVENT_CLIENT_FAILED_AUTH,   		// a client connection failed to authenticate
-	CERVER_EVENT_CLIENT_CONNECTED,     		// a new client has connected to the cerver
-	CERVER_EVENT_CLIENT_NEW_CONNECTION,		// added a connection to an existing client
-	CERVER_EVENT_CLIENT_CLOSE_CONNECTION,	// a connection from an existing client was closed
-	CERVER_EVENT_CLIENT_DISCONNECTED,  		// a client has disconnected from the cerver
-	CERVER_EVENT_CLIENT_DROPPED,       		// a client has been dropped from the cerver
-
-	CERVER_EVENT_ADMIN_FAILED_AUTH,  		// a possible admin connection failed to authenticate
-	CERVER_EVENT_ADMIN_CONNECTED,      		// a new admin has connected & authenticated to the cerver
-	CERVER_EVENT_ADMIN_NEW_CONNECTION,		// added a connection to an existing client
-	CERVER_EVENT_ADMIN_CLOSE_CONNECTION,	// a connection from an existing client was closed
-	CERVER_EVENT_ADMIN_DISCONNECTED,    	// an admin disconnected from the cerver
-	CERVER_EVENT_ADMIN_DROPPED,    			// an admin was dropped from the cerver
-
-	CERVER_EVENT_LOBBY_CREATE,         		// a new lobby was successfully created
-	CERVER_EVENT_LOBBY_JOIN,           		// someone has joined a lobby
-	CERVER_EVENT_LOBBY_LEAVE,          		// someone has exited the lobby
-	CERVER_EVENT_LOBBY_START,          		// the game in the lobby has started
+	#define XX(num, name, description) CERVER_EVENT_##name = num,
+	CERVER_EVENT_MAP (XX)
+	#undef XX
 
 } CerverEventType;
+
+// get the description for the current event type
+CERVER_EXPORT const char *cerver_event_type_description (CerverEventType type);
+
+#pragma endregion
+
+#pragma region event
 
 typedef struct CerverEvent {
 
 	CerverEventType type;               // the event we are waiting to happen
 
 	bool create_thread;                 // create a detachable thread to run action
-	bool drop_after_trigger;            // if we only want to trigger the event once 
+	bool drop_after_trigger;            // if we only want to trigger the event once
 
 	Action action;                      // the action to be triggered
 	void *action_args;                  // the action arguments
@@ -61,21 +73,29 @@ CERVER_PUBLIC void cerver_event_delete (void *event_ptr);
 
 // registers an action to be triggered when the specified event occurs
 // if there is an existing action registered to an event, it will be overrided
-// a newly allocated CerverEventData structure will be passed to your method 
+// a newly allocated CerverEventData structure will be passed to your method
 // that should be free using the cerver_event_data_delete () method
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_event_register (struct _Cerver *cerver, const CerverEventType event_type, 
-	Action action, void *action_args, Action delete_action_args, 
-	bool create_thread, bool drop_after_trigger);
+CERVER_EXPORT u8 cerver_event_register (
+	struct _Cerver *cerver,
+	const CerverEventType event_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
+);
 
 // unregister the action associated with an event
 // deletes the action args using the delete_action_args () if NOT NULL
-// returns 0 on success, 1 on error
+// returns 0 on success, 1 on error or if event is NOT registered
 CERVER_EXPORT u8 cerver_event_unregister (struct _Cerver *cerver, const CerverEventType event_type);
 
 // triggers all the actions that are registred to an event
-CERVER_PRIVATE void cerver_event_trigger (const CerverEventType event_type, const struct _Cerver *cerver, 
-	const struct _Client *client, const struct _Connection *connection);
+CERVER_PRIVATE void cerver_event_trigger (
+	const CerverEventType event_type,
+	const struct _Cerver *cerver,
+	const struct _Client *client, const struct _Connection *connection
+);
+
+#pragma endregion
 
 #pragma region data
 

--- a/include/cerver/files.h
+++ b/include/cerver/files.h
@@ -26,45 +26,45 @@ struct _FileHeader;
 
 typedef struct FileCerverStats {
 
-    u64 n_files_requests;				// n requests to get a file
-    u64 n_success_files_requests;		// fulfilled requests
-    u64 n_bad_files_requests;			// bad requests
-    u64 n_files_sent;					// n files sent
-    u64 n_bad_files_sent;				// n files that failed to send
-    u64 n_bytes_sent;					// total bytes sent
+	u64 n_files_requests;				// n requests to get a file
+	u64 n_success_files_requests;		// fulfilled requests
+	u64 n_bad_files_requests;			// bad requests
+	u64 n_files_sent;					// n files sent
+	u64 n_bad_files_sent;				// n files that failed to send
+	u64 n_bytes_sent;					// total bytes sent
 
-    u64 n_files_upload_requests;		// n requests to upload a file
-    u64 n_success_files_uploaded;		// n files received
-    u64 n_bad_files_upload_requests;	// bad requests to upload files
-    u64 n_bad_files_received;			// files that failed to be received
-    u64 n_bytes_received;				// total bytes received
+	u64 n_files_upload_requests;		// n requests to upload a file
+	u64 n_success_files_uploaded;		// n files received
+	u64 n_bad_files_upload_requests;	// bad requests to upload files
+	u64 n_bad_files_received;			// files that failed to be received
+	u64 n_bytes_received;				// total bytes received
 
 } FileCerverStats;
 
 struct _FileCerver {
 
-    struct _Cerver *cerver;
+	struct _Cerver *cerver;
 
-    // search for requested files in these paths
-    unsigned int n_paths;
-    String *paths[FILE_CERVER_MAX_PATHS];
+	// search for requested files in these paths
+	unsigned int n_paths;
+	String *paths[FILE_CERVER_MAX_PATHS];
 
-    // default path where uploads files will be placed
-    String *uploads_path;
+	// default path where uploads files will be placed
+	String *uploads_path;
 
-    u8 (*file_upload_handler) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    );
+	u8 (*file_upload_handler) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	);
 
-    void (*file_upload_cb) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        const char *saved_filename
-    );
-    
-    FileCerverStats *stats;
+	void (*file_upload_cb) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		const char *saved_filename
+	);
+
+	FileCerverStats *stats;
 
 };
 
@@ -87,22 +87,22 @@ CERVER_EXPORT void file_cerver_set_uploads_path (FileCerver *file_cerver, const 
 // in this method, file contents must be consumed from the sock fd
 // and return 0 on success and 1 on error
 CERVER_EXPORT void file_cerver_set_file_upload_handler (
-    FileCerver *file_cerver,
-    u8 (*file_upload_handler) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    )
+	FileCerver *file_cerver,
+	u8 (*file_upload_handler) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	)
 );
 
 // sets a callback to be executed after a file has been successfully uploaded by a client
 CERVER_EXPORT void file_cerver_set_file_upload_cb (
-    FileCerver *file_cerver,
-    void (*file_upload_cb) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        const char *saved_filename
-    )
+	FileCerver *file_cerver,
+	void (*file_upload_cb) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		const char *saved_filename
+	)
 );
 
 // search for the requested file in the configured paths
@@ -114,8 +114,8 @@ CERVER_PUBLIC String *file_cerver_search_file (FileCerver *file_cerver, const ch
 // if the file is not found, a CERVER_ERROR_FILE_NOT_FOUND error packet will be sent
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_cerver_send_file (
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
-    const char *filename
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	const char *filename
 );
 
 CERVER_EXPORT void file_cerver_stats_print (FileCerver *file_cerver);
@@ -143,8 +143,8 @@ CERVER_EXPORT bool file_exists (const char *filename);
 
 // opens a file and returns it as a FILE
 CERVER_EXPORT FILE *file_open_as_file (
-    const char *filename,
-    const char *modes, struct stat *filestatus
+	const char *filename,
+	const char *modes, struct stat *filestatus
 );
 
 // opens and reads a file into a buffer
@@ -161,8 +161,8 @@ CERVER_EXPORT int file_open_as_fd (const char *filename, struct stat *filestatus
 
 struct _FileHeader {
 
-    char filename[DEFAULT_FILENAME_LEN];
-    size_t len;
+	char filename[DEFAULT_FILENAME_LEN];
+	size_t len;
 
 };
 
@@ -172,16 +172,16 @@ typedef struct _FileHeader FileHeader;
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_send (
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
-    const char *filename
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	const char *filename
 );
 
 // sends the file contents of the file referenced by a fd
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_send_by_fd (
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
-    int file_fd, const char *actual_filename, size_t filelen
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	int file_fd, const char *actual_filename, size_t filelen
 );
 
 #pragma endregion
@@ -191,10 +191,10 @@ CERVER_PUBLIC ssize_t file_send_by_fd (
 // opens the file using an already created filename
 // and use the fd to receive and save the file
 CERVER_PRIVATE u8 file_receive_actual (
-    struct _Client *client, struct _Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	struct _Client *client, struct _Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 );
 
 #pragma endregion

--- a/include/cerver/files.h
+++ b/include/cerver/files.h
@@ -5,9 +5,124 @@
 
 #include <sys/stat.h>
 
+#include "cerver/types/types.h"
+#include "cerver/types/string.h"
+
 #include "cerver/collections/dlist.h"
 
 #include "cerver/config.h"
+
+struct _Cerver;
+struct _Client;
+struct _Connection;
+
+struct _FileHeader;
+
+#define DEFAULT_FILENAME_LEN			1024
+
+#pragma region cerver
+
+#define FILE_CERVER_MAX_PATHS           32
+
+typedef struct FileCerverStats {
+
+    u64 n_files_requests;				// n requests to get a file
+    u64 n_success_files_requests;		// fulfilled requests
+    u64 n_bad_files_requests;			// bad requests
+    u64 n_files_sent;					// n files sent
+    u64 n_bad_files_sent;				// n files that failed to send
+    u64 n_bytes_sent;					// total bytes sent
+
+    u64 n_files_upload_requests;		// n requests to upload a file
+    u64 n_success_files_uploaded;		// n files received
+    u64 n_bad_files_upload_requests;	// bad requests to upload files
+    u64 n_bad_files_received;			// files that failed to be received
+    u64 n_bytes_received;				// total bytes received
+
+} FileCerverStats;
+
+struct _FileCerver {
+
+    struct _Cerver *cerver;
+
+    // search for requested files in these paths
+    unsigned int n_paths;
+    String *paths[FILE_CERVER_MAX_PATHS];
+
+    // default path where uploads files will be placed
+    String *uploads_path;
+
+    u8 (*file_upload_handler) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        struct _FileHeader *,
+        const char *file_data, size_t file_data_len,
+        char **saved_filename
+    );
+
+    void (*file_upload_cb) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        const char *saved_filename
+    );
+    
+    FileCerverStats *stats;
+
+};
+
+typedef struct _FileCerver FileCerver;
+
+CERVER_PRIVATE FileCerver *file_cerver_new (void);
+
+CERVER_PRIVATE void file_cerver_delete (void *file_cerver_ptr);
+
+CERVER_PRIVATE FileCerver *file_cerver_create (struct _Cerver *cerver);
+
+// adds a new file path to take into account when a client request for a file
+// returns 0 on success, 1 on error
+CERVER_EXPORT u8 file_cerver_add_path (FileCerver *file_cerver, const char *path);
+
+// sets the default uploads path to be used when a client sends a file
+CERVER_EXPORT void file_cerver_set_uploads_path (FileCerver *file_cerver, const char *uploads_path);
+
+// sets a custom method to be used to handle a file upload
+// in this method, file contents must be consumed from the sock fd
+// and return 0 on success and 1 on error
+CERVER_EXPORT void file_cerver_set_file_upload_handler (
+    FileCerver *file_cerver,
+    u8 (*file_upload_handler) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        struct _FileHeader *,
+        const char *file_data, size_t file_data_len,
+        char **saved_filename
+    )
+);
+
+// sets a callback to be executed after a file has been successfully uploaded by a client
+CERVER_EXPORT void file_cerver_set_file_upload_cb (
+    FileCerver *file_cerver,
+    void (*file_upload_cb) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        const char *saved_filename
+    )
+);
+
+// search for the requested file in the configured paths
+// returns the actual filename (path + directory) where it was found, NULL on error
+CERVER_PUBLIC String *file_cerver_search_file (FileCerver *file_cerver, const char *filename);
+
+// opens a file and sends the content back to the client
+// first the FileHeader in a regular packet, then the file contents between sockets
+// if the file is not found, a CERVER_ERROR_FILE_NOT_FOUND error packet will be sent
+// returns the number of bytes sent, or -1 on error
+CERVER_PUBLIC ssize_t file_cerver_send_file (
+    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+    const char *filename
+);
+
+CERVER_EXPORT void file_cerver_stats_print (FileCerver *file_cerver);
+
+#pragma endregion
+
+#pragma region main
 
 // check if a directory already exists, and if not, creates it
 // returns 0 on success, 1 on error
@@ -27,8 +142,10 @@ CERVER_EXPORT DoubleList *file_get_lines (const char *filename);
 CERVER_EXPORT bool file_exists (const char *filename);
 
 // opens a file and returns it as a FILE
-CERVER_EXPORT FILE *file_open_as_file (const char *filename, 
-    const char *modes, struct stat *filestatus);
+CERVER_EXPORT FILE *file_open_as_file (
+    const char *filename,
+    const char *modes, struct stat *filestatus
+);
 
 // opens and reads a file into a buffer
 // sets file size to the amount of bytes read
@@ -38,8 +155,48 @@ CERVER_EXPORT char *file_read (const char *filename, size_t *file_size);
 // returns fd on success, -1 on error
 CERVER_EXPORT int file_open_as_fd (const char *filename, struct stat *filestatus, int flags);
 
-// sends a file to the sock fd
-// returns 0 on success, 1 on error
-CERVER_EXPORT int file_send (const char *filename, int sock_fd);
+#pragma endregion
+
+#pragma region send
+
+struct _FileHeader {
+
+    char filename[DEFAULT_FILENAME_LEN];
+    size_t len;
+
+};
+
+typedef struct _FileHeader FileHeader;
+
+// opens a file and sends its contents
+// first the FileHeader in a regular packet, then the file contents between sockets
+// returns the number of bytes sent, or -1 on error
+CERVER_PUBLIC ssize_t file_send (
+    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+    const char *filename
+);
+
+// sends the file contents of the file referenced by a fd
+// first the FileHeader in a regular packet, then the file contents between sockets
+// returns the number of bytes sent, or -1 on error
+CERVER_PUBLIC ssize_t file_send_by_fd (
+    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+    int file_fd, const char *actual_filename, size_t filelen
+);
+
+#pragma endregion
+
+#pragma region receive
+
+// opens the file using an already created filename
+// and use the fd to receive and save the file
+CERVER_PRIVATE u8 file_receive_actual (
+    struct _Client *client, struct _Connection *connection,
+    FileHeader *file_header,
+    const char *file_data, size_t file_data_len,
+    char **saved_filename
+);
+
+#pragma endregion
 
 #endif

--- a/include/cerver/game/game.h
+++ b/include/cerver/game/game.h
@@ -25,8 +25,8 @@ struct _Packet;
 
 typedef struct GameCerverStats {
 
-    u32 current_active_lobbys;      // total current lobbys 
-    u32 lobbys_created;             // total amount of lobbys that were created in cerver life span
+	u32 current_active_lobbys;      // total current lobbys 
+	u32 lobbys_created;             // total amount of lobbys that were created in cerver life span
 
 } GameCerverStats;
 
@@ -34,26 +34,26 @@ extern void game_cerver_stats_print (struct _Cerver *cerver);
 
 struct _GameCerver {
 
-    struct _Cerver *cerver;                         // refernce to the cerver this is located
+	struct _Cerver *cerver;                         // refernce to the cerver this is located
 
-    DoubleList *current_lobbys;                     // a list of the current lobbys
-    void *(*lobby_id_generator) (const void *);
+	DoubleList *current_lobbys;                     // a list of the current lobbys
+	void *(*lobby_id_generator) (const void *);
 
-    DoubleList *game_types;
+	DoubleList *game_types;
 
-    Comparator player_comparator;
+	Comparator player_comparator;
 
-    // we can define a function to load game data at start, 
-    // for example to connect to a db or something like that
-    Action load_game_data;
-    Action delete_game_data;
-    void *game_data;
+	// we can define a function to load game data at start, 
+	// for example to connect to a db or something like that
+	Action load_game_data;
+	Action delete_game_data;
+	void *game_data;
 
-    // action to be performed right before the game server teardown
-    Action final_game_action;
-    void *final_action_args;
+	// action to be performed right before the game server teardown
+	Action final_game_action;
+	void *final_action_args;
 
-    GameCerverStats *stats;
+	GameCerverStats *stats;
 
 };
 
@@ -72,20 +72,20 @@ extern void *lobby_default_id_generator (const void *data_ptr);
 
 // option to set the game cerver lobby id generator
 extern void game_set_lobby_id_generator (GameCerver *game_cerver, 
-    void *(*lobby_id_generator) (const void *));
+	void *(*lobby_id_generator) (const void *));
 
 // option to set the game cerver comparator
 extern void game_set_player_comparator (GameCerver *game_cerver, 
-    Comparator player_comparator);
+	Comparator player_comparator);
 
 // sets a way to get and destroy game cerver game data
 extern void game_set_load_game_data (GameCerver *game_cerver, 
-    Action load_game_data, Action delete_game_data);
+	Action load_game_data, Action delete_game_data);
 
 // option to set an action to be performed right before the game cerver teardown
 // eg. send a message to all players
 extern void game_set_final_action (GameCerver *game_cerver, 
-    Action final_action, void *final_action_args);
+	Action final_action, void *final_action_args);
 
 // handles a game type packet
 extern void game_packet_handler (struct _Packet *packet);
@@ -100,8 +100,8 @@ extern void game_cerver_unregister_lobby (GameCerver *game_cerver, struct _Lobby
 
 typedef struct LobbyPlayer {
 
-    struct _Lobby *lobby;
-    struct _Player *player;
+	struct _Lobby *lobby;
+	struct _Player *player;
 
 } LobbyPlayer;
 

--- a/include/cerver/game/score.h
+++ b/include/cerver/game/score.h
@@ -10,10 +10,10 @@
 
 typedef struct ScoreBoard {
 
-    Htab *scores;
-    u8 registeredPlayers;
-    u8 scoresNum;
-    char **scoreTypes;
+	Htab *scores;
+	u8 registeredPlayers;
+	u8 scoresNum;
+	char **scoreTypes;
 
 } ScoreBoard;
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -29,62 +29,62 @@ struct _Admin;
 
 typedef enum HandlerType {
 
-    HANDLER_TYPE_NONE         = 0,
+	HANDLER_TYPE_NONE         = 0,
 
-    HANDLER_TYPE_CERVER       = 1,
-    HANDLER_TYPE_CLIENT       = 2,
-    HANDLER_TYPE_ADMIN        = 3,
+	HANDLER_TYPE_CERVER       = 1,
+	HANDLER_TYPE_CLIENT       = 2,
+	HANDLER_TYPE_ADMIN        = 3,
 
 } HandlerType;
 
 // the strcuture that will be passed to the handler
 typedef struct HandlerData {
 
-    int handler_id;
+	int handler_id;
 
-    void *data;                     // handler's own data
-    struct _Packet *packet;         // the packet to handle
+	void *data;                     // handler's own data
+	struct _Packet *packet;         // the packet to handle
 
 } HandlerData;
 
 struct _Handler {
 
-    HandlerType type;
-    int unique_id;                  // added every time a new handler gets created
+	HandlerType type;
+	int unique_id;                  // added every time a new handler gets created
 
-    int id;
-    pthread_t thread_id;
+	int id;
+	pthread_t thread_id;
 
-    // unique handler data
-    // will be passed to jobs alongside any job specific data as the args
-    void *data;
-    
-    // must return a newly allocated handler unique data
-    // will be executed when the handler starts
-    void *(*data_create) (void *args);
-    void *data_create_args;
+	// unique handler data
+	// will be passed to jobs alongside any job specific data as the args
+	void *data;
 
-    // called at the end of the handler to delete the handler's data
-    // if no method is set, it won't be deleted
-    Action data_delete;
+	// must return a newly allocated handler unique data
+	// will be executed when the handler starts
+	void *(*data_create) (void *args);
+	void *data_create_args;
 
-    // the method that this handler will execute to handle packets
-    Action handler;
+	// called at the end of the handler to delete the handler's data
+	// if no method is set, it won't be deleted
+	Action data_delete;
 
-    // 27/05/2020 - used to avoid pushing job to the queue and instead handle
-    // the packet directly in the same thread
-    // this option is set to false as default
-    // pros - inmediate handle with no delays
-    //      - handler method can be called from multiple threads
-    // neutral - data create and delete will be executed every time
-    // cons - calling thread will be busy until handler method is done
-    bool direct_handle;
+	// the method that this handler will execute to handle packets
+	Action handler;
 
-    // the jobs (packets) that are waiting to be handled - passed as args to the handler method
-    JobQueue *job_queue;
+	// 27/05/2020 - used to avoid pushing job to the queue and instead handle
+	// the packet directly in the same thread
+	// this option is set to false as default
+	// pros - inmediate handle with no delays
+	//      - handler method can be called from multiple threads
+	// neutral - data create and delete will be executed every time
+	// cons - calling thread will be busy until handler method is done
+	bool direct_handle;
 
-    struct _Cerver *cerver;     // the cerver this handler belongs to
-    struct _Client *client;     // the client this handler belongs to
+	// the jobs (packets) that are waiting to be handled - passed as args to the handler method
+	JobQueue *job_queue;
+
+	struct _Cerver *cerver;     // the cerver this handler belongs to
+	struct _Client *client;     // the client this handler belongs to
 
 };
 
@@ -109,8 +109,8 @@ CERVER_EXPORT void handler_set_data (Handler *handler, void *data);
 
 // set a method to create the handler's data before it starts handling any packet
 // this data will be passed to the handler method using a HandlerData structure
-CERVER_EXPORT void handler_set_data_create (Handler *handler, 
-    void *(*data_create) (void *args), void *data_create_args);
+CERVER_EXPORT void handler_set_data_create (Handler *handler,
+	void *(*data_create) (void *args), void *data_create_args);
 
 // set the method to be used to delete the handler's data
 CERVER_EXPORT void handler_set_data_delete (Handler *handler, Action data_delete);
@@ -140,14 +140,14 @@ CERVER_PRIVATE void cerver_test_packet_handler (struct _Packet *packet);
 
 struct _SockReceive {
 
-    struct _Packet *spare_packet;
-    size_t missing_packet;
+	struct _Packet *spare_packet;
+	size_t missing_packet;
 
-    void *header;
-    char *header_end;
-    // unsigned int curr_header_pos;
-    unsigned int remaining_header;
-    bool complete_header;
+	void *header;
+	char *header_end;
+	// unsigned int curr_header_pos;
+	unsigned int remaining_header;
+	bool complete_header;
 
 };
 
@@ -166,19 +166,19 @@ CERVER_PRIVATE void sock_receive_delete (void *sock_receive_ptr);
 
 typedef struct ReceiveHandle {
 
-    ReceiveType type;
+	ReceiveType type;
 
-    struct _Cerver *cerver;
+	struct _Cerver *cerver;
 
-    struct _Socket *socket;
-    struct _Connection *connection;
-    struct _Client *client;
-    struct _Admin *admin;
+	struct _Socket *socket;
+	struct _Connection *connection;
+	struct _Client *client;
+	struct _Admin *admin;
 
-    struct _Lobby *lobby;
+	struct _Lobby *lobby;
 
-    char *buffer;
-    size_t buffer_size;
+	char *buffer;
+	size_t buffer_size;
 
 } ReceiveHandle;
 
@@ -189,16 +189,16 @@ CERVER_PRIVATE void cerver_receive_handle_buffer (void *receive_ptr);
 
 typedef struct CerverReceive {
 
-    ReceiveType type;
+	ReceiveType type;
 
-    struct _Cerver *cerver;
+	struct _Cerver *cerver;
 
-    struct _Socket *socket;
-    struct _Connection *connection;
-    struct _Client *client;
-    struct _Admin *admin;
+	struct _Socket *socket;
+	struct _Connection *connection;
+	struct _Client *client;
+	struct _Admin *admin;
 
-    struct _Lobby *lobby;
+	struct _Lobby *lobby;
 
 } CerverReceive;
 
@@ -206,9 +206,9 @@ CERVER_PRIVATE void cerver_receive_delete (void *ptr);
 
 CERVER_PRIVATE CerverReceive *cerver_receive_create (ReceiveType receive_type, struct _Cerver *cerver, const i32 sock_fd);
 
-CERVER_PRIVATE CerverReceive *cerver_receive_create_full (ReceiveType receive_type, 
-    struct _Cerver *cerver, 
-    struct _Client *client, struct _Connection *connection
+CERVER_PRIVATE CerverReceive *cerver_receive_create_full (ReceiveType receive_type,
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection
 );
 
 CERVER_PRIVATE void cerver_switch_receive_handle_failed (CerverReceive *cr);

--- a/include/cerver/http/http.h
+++ b/include/cerver/http/http.h
@@ -52,8 +52,8 @@ CERVER_PUBLIC const char *http_content_type_by_extension (const char *ext);
 
 typedef struct KeyValuePair { 
 
-    String *key;
-    String *value;
+	String *key;
+	String *value;
 
 } KeyValuePair;
 
@@ -73,33 +73,33 @@ CERVER_PUBLIC void key_value_pairs_print (DoubleList *pairs);
 
 struct _HttpCerver {
 
-    struct _Cerver *cerver;
+	struct _Cerver *cerver;
 
-    // paths to serve static files
-    DoubleList *static_paths;
+	// paths to serve static files
+	DoubleList *static_paths;
 
-    // list of top level routes
-    DoubleList *routes;
+	// list of top level routes
+	DoubleList *routes;
 
-    // catch all route (/*)
-    void (*default_handler)(CerverReceive *cr, HttpRequest *request);
+	// catch all route (/*)
+	void (*default_handler)(CerverReceive *cr, HttpRequest *request);
 
-    // uploads
-    String *uploads_path;              // default uploads path
-    String *(*uploads_dirname_generator)(CerverReceive *cr);
+	// uploads
+	String *uploads_path;              // default uploads path
+	String *(*uploads_dirname_generator)(CerverReceive *cr);
 
-    // auth
-    jwt_alg_t jwt_alg;
+	// auth
+	jwt_alg_t jwt_alg;
 
-    String *jwt_opt_key_name;          // jwt private key filename
-    String *jwt_private_key;           // jwt actual private key
+	String *jwt_opt_key_name;          // jwt private key filename
+	String *jwt_private_key;           // jwt actual private key
 
-    String *jwt_opt_pub_key_name;      // jwt public key filename
-    String *jwt_public_key;            // jwt actual public key
+	String *jwt_opt_pub_key_name;      // jwt public key filename
+	String *jwt_public_key;            // jwt actual public key
 
-    // stats
-    size_t n_cath_all_requests;        // failed to match a route
-    size_t n_failed_auth_requests;     // failed to auth with private route 
+	// stats
+	size_t n_cath_all_requests;        // failed to match a route
+	size_t n_failed_auth_requests;     // failed to auth with private route 
 
 };
 
@@ -119,9 +119,9 @@ CERVER_PRIVATE void http_cerver_init (HttpCerver *http_cerver);
 
 typedef struct HttpStaticPath {
 
-    String *path;
+	String *path;
 
-    HttpRouteAuthType auth_type;
+	HttpRouteAuthType auth_type;
 
 } HttpStaticPath;
 
@@ -218,28 +218,28 @@ CERVER_PUBLIC void http_query_pairs_print (DoubleList *pairs);
 
 typedef struct HttpReceive {
 
-    CerverReceive *cr;
+	CerverReceive *cr;
 
-    // keep connection alive - don't close after request has ended
-    bool keep_alive;
+	// keep connection alive - don't close after request has ended
+	bool keep_alive;
 
-    void (*handler)(struct HttpReceive *, ssize_t, char *);
+	void (*handler)(struct HttpReceive *, ssize_t, char *);
 
-    HttpCerver *http_cerver;
+	HttpCerver *http_cerver;
 
 	http_parser *parser;
 	http_parser_settings settings;
 
-    multipart_parser *mpart_parser;
-    multipart_parser_settings mpart_settings;
-    
+	multipart_parser *mpart_parser;
+	multipart_parser_settings mpart_settings;
+	
 	HttpRequest *request;
 
-    // websockets
-    unsigned char fin_rsv_opcode;
-    size_t fragmented_message_len;
-    char *fragmented_message;
-    void (*ws_on_open)(struct _Cerver *, struct _Connection *);
+	// websockets
+	unsigned char fin_rsv_opcode;
+	size_t fragmented_message_len;
+	char *fragmented_message;
+	void (*ws_on_open)(struct _Cerver *, struct _Connection *);
 	void (*ws_on_close)(struct _Cerver *, const char *reason);
 	void (*ws_on_ping)(struct _Cerver *, struct _Connection *);
 	void (*ws_on_pong)(struct _Cerver *, struct _Connection *);

--- a/include/cerver/http/socket.h
+++ b/include/cerver/http/socket.h
@@ -3,10 +3,10 @@
 
 enum _HttpWebSocketError {
 
-    HTTP_WEB_SOCKET_ERROR_NONE                      = 0,
+	HTTP_WEB_SOCKET_ERROR_NONE                      = 0,
 
-    HTTP_WEB_SOCKET_ERROR_READ_HANDSHAKE            = 1,
-    HTTP_WEB_SOCKET_ERROR_WRITE_HANDSHAKE           = 2,
+	HTTP_WEB_SOCKET_ERROR_READ_HANDSHAKE            = 1,
+	HTTP_WEB_SOCKET_ERROR_WRITE_HANDSHAKE           = 2,
 
 };
 

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -27,7 +27,7 @@ typedef u32 ProtocolID;
 // gets the current protocol id set in your application
 CERVER_EXPORT ProtocolID packets_get_protocol_id (void);
 
-// Sets the protocol id that this cerver will use for its packets. 
+// Sets the protocol id that this cerver will use for its packets.
 // The protocol id is a unique number that you can set to only accept packets that are comming from your application
 // If the protocol id coming from the cerver don't match your application's, it will be considered a bad packet
 // This value is only cheked if you enable packet checking for your cerver
@@ -37,13 +37,13 @@ typedef struct ProtocolVersion {
 
 	u16 major;
 	u16 minor;
-	
+
 } ProtocolVersion;
 
 // gets the current version set in your application
 CERVER_EXPORT ProtocolVersion packets_get_protocol_version (void);
 
-// Sets the protocol version for the cerver. 
+// Sets the protocol version for the cerver.
 // The version is an identifier to help you manage different versions of your deployed applications
 // If the versions of your packet don't match, it will be considered a bad packet
 // This value is only cheked if you enable packet checking for your cerver
@@ -74,34 +74,35 @@ CERVER_PUBLIC void packet_version_print (PacketVersion *version);
 
 #pragma region types
 
+#define PACKET_TYPE_MAP(XX)					\
+	XX(0, 	NONE)							\
+	XX(1, 	CERVER)							\
+	XX(2, 	CLIENT)							\
+	XX(3, 	ERROR)							\
+	XX(4, 	REQUEST)						\
+	XX(5, 	AUTH)							\
+	XX(6, 	GAME)							\
+	XX(7, 	APP)							\
+	XX(8, 	APP_ERROR)						\
+	XX(9, 	CUSTOM)							\
+	XX(10, 	TEST)
+
 // these indicate what type of packet we are sending/recieving
 typedef enum PacketType {
 
-    CERVER_PACKET       = 0,
-    CLIENT_PACKET       = 1,
-
-    ERROR_PACKET        = 2,
-
-	REQUEST_PACKET      = 3,
-    AUTH_PACKET         = 4,
-    GAME_PACKET         = 5,
-
-    APP_PACKET          = 6,
-    APP_ERROR_PACKET    = 7,
-
-    CUSTOM_PACKET       = 70,
-
-    TEST_PACKET         = 100,
-    DONT_CHECK_TYPE     = 101,
+	#define XX(num, name) PACKET_TYPE_##name = num,
+	PACKET_TYPE_MAP (XX)
+	#undef XX
 
 } PacketType;
 
 struct _PacketsPerType {
 
 	u64 n_cerver_packets;
+	u64 n_client_packets;
 	u64 n_error_packets;
-	u64 n_auth_packets;
 	u64 n_request_packets;
+	u64 n_auth_packets;
 	u64 n_game_packets;
 	u64 n_app_packets;
 	u64 n_app_error_packets;
@@ -127,12 +128,14 @@ CERVER_PUBLIC void packets_per_type_print (PacketsPerType *packets_per_type);
 
 struct _PacketHeader {
 
-	PacketType packet_type;
-	size_t packet_size;
+	PacketType packet_type;		// the main packet type
+	size_t packet_size;			// total size of the packet (header + data)
 
-	u8 handler_id;
+	u8 handler_id;				// used in cervers with multiple app handlers
 
-	u32 request_type;
+	u32 request_type;			// the packet's subtype
+
+	u16 sock_fd;				// used in when working with load balancers
 
 };
 
@@ -155,55 +158,75 @@ CERVER_PUBLIC u8 packet_header_copy (PacketHeader **dest, PacketHeader *source);
 
 #pragma region packets
 
-typedef enum RequestType {
-
-    REQ_GET_FILE                = 1,
-    POST_SEND_FILE              = 2,
-    
-} RequestType;
+#define CERVER_PACKET_TYPE_MAP(XX)			\
+	XX(0, 	NONE)							\
+	XX(1, 	INFO)							\
+	XX(2, 	TEARDOWN)
 
 typedef enum CerverPacketType {
 
-	CERVER_INFO                 = 0,
-	CERVER_TEARDOWN             = 1,
-
-	CERVER_INFO_STATS           = 2,
-	CERVER_GAME_STATS           = 3
+	#define XX(num, name) CERVER_PACKET_TYPE_##name = num,
+	CERVER_PACKET_TYPE_MAP (XX)
+	#undef XX
 
 } CerverPacketType;
 
+#define CLIENT_PACKET_TYPE_MAP(XX)			\
+	XX(0, 	NONE)							\
+	XX(1, 	CLOSE_CONNECTION)				\
+	XX(2, 	DISCONNECT)
+
 typedef enum ClientPacketType {
 
-	CLIENT_CLOSE_CONNECTION     = 1,
-	CLIENT_DISCONNET            = 2,
+	#define XX(num, name) CLIENT_PACKET_TYPE_##name = num,
+	CLIENT_PACKET_TYPE_MAP (XX)
+	#undef XX
 
 } ClientPacketType;
 
+#define REQUEST_PACKET_TYPE_MAP(XX)			\
+	XX(0, 	NONE)							\
+	XX(1, 	GET_FILE)						\
+	XX(2, 	SEND_FILE)
+
+typedef enum RequestPacketType {
+
+	#define XX(num, name) REQUEST_PACKET_TYPE_##name = num,
+	REQUEST_PACKET_TYPE_MAP (XX)
+	#undef XX
+
+} RequestPacketType;
+
+#define AUTH_PACKET_TYPE_MAP(XX)			\
+	XX(0, 	NONE)							\
+	XX(1, 	REQUEST_AUTH)					\
+	XX(2, 	CLIENT_AUTH)					\
+	XX(3, 	ADMIN_AUTH)						\
+	XX(4, 	SUCCESS)
+
 typedef enum AuthPacketType {
 
-	AUTH_PACKET_TYPE_NONE			= 0,
-
-	AUTH_PACKET_TYPE_REQUEST_AUTH	= 1,
-
-	AUTH_PACKET_TYPE_CLIENT_AUTH	= 2,
-	AUTH_PACKET_TYPE_ADMIN_AUTH		= 3,
-
-	AUTH_PACKET_TYPE_SUCCESS		= 4
+	#define XX(num, name) AUTH_PACKET_TYPE_##name = num,
+	AUTH_PACKET_TYPE_MAP (XX)
+	#undef XX
 
 } AuthPacketType;
 
+#define GAME_PACKET_TYPE_MAP(XX)			\
+	XX(0, 	NONE)							\
+	XX(1, 	GAME_INIT)						\
+	XX(2, 	GAME_START)						\
+	XX(3, 	LOBBY_CREATE)					\
+	XX(4, 	LOBBY_JOIN)						\
+	XX(5, 	LOBBY_LEAVE)					\
+	XX(6, 	LOBBY_UPDATE)					\
+	XX(7, 	LOBBY_DESTROY)					\
+
 typedef enum GamePacketType {
 
-	GAME_LOBBY_CREATE           = 0,
-	GAME_LOBBY_JOIN             = 1,
-	GAME_LOBBY_LEAVE            = 2,
-	GAME_LOBBY_UPDATE           = 3,
-	GAME_LOBBY_DESTROY          = 4,
-
-	GAME_INIT                   = 5,   // prepares the game structures
-	GAME_START                  = 6,   // strat running the game
-	GAME_INPUT_UPDATE           = 7,
-	GAME_SEND_MSG               = 8,
+	#define XX(num, name) GAME_PACKET_TYPE_##name = num,
+	GAME_PACKET_TYPE_MAP (XX)
+	#undef XX
 
 } GamePacketType;
 
@@ -247,8 +270,23 @@ CERVER_PUBLIC void packet_delete (void *ptr);
 CERVER_EXPORT Packet *packet_create (PacketType type, void *data, size_t data_size);
 
 // sets the packet destinatary to whom this packet is going to be sent
-CERVER_EXPORT void packet_set_network_values (Packet *packet, struct _Cerver *cerver, 
-	struct _Client *client, struct _Connection *connection, struct _Lobby *lobby);
+CERVER_EXPORT void packet_set_network_values (
+	Packet *packet,
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+);
+
+// sets the packet's header
+// copies the header's values into the packet
+CERVER_EXPORT void packet_set_header (Packet *packet, PacketHeader *header);
+
+// sets the packet's header values
+// if the packet does NOT yet have a header, it will be created
+CERVER_EXPORT void packet_set_header_values (
+	Packet *packet,
+	PacketType packet_type, size_t packet_size,
+	u8 handler_id, u32 request_type,
+	u16 sock_fd
+);
 
 // sets the data of the packet -> copies the data into the packet
 // if the packet had data before it is deleted and replaced with the new one
@@ -286,27 +324,37 @@ CERVER_EXPORT u8 packet_set_packet_ref (Packet *packet, void *data, size_t packe
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 packet_generate (Packet *packet);
 
-// generates a simple request packet of the requested type reday to be sent, 
+// generates a simple request packet of the requested type reday to be sent,
 // and with option to pass some data
 // returns a newly allocated packet that should be deleted after use
-CERVER_EXPORT Packet *packet_generate_request (PacketType packet_type, u32 req_type, 
-	void *data, size_t data_size);
+CERVER_EXPORT Packet *packet_generate_request (
+	PacketType packet_type, u32 req_type,
+	void *data, size_t data_size
+);
 
 // sends a packet using its network values
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw);
 
+// works just as packet_send () but the socket's write mutex won't be locked
+// useful when you need to lock the mutex manually
+// returns 0 on success, 1 on error
+CERVER_PUBLIC u8 packet_send_unsafe (const Packet *packet, int flags, size_t *total_sent, bool raw);
+
 // sends a packet to the specified destination
 // sets flags to 0
 // at least a packet & an active connection are required for this method to succeed
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_send_to (const Packet *packet, size_t *total_sent, bool raw,
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby);
+CERVER_EXPORT u8 packet_send_to (
+	const Packet *packet,
+	size_t *total_sent, bool raw,
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+);
 
 // sends a packet to the socket in two parts, first the header & then the data
-// this method can be useful when trying to forward a big received packet without the overhead of 
+// this method can be useful when trying to forward a big received packet without the overhead of
 // performing and additional copy to create a continuos data (packet) buffer
 // the socket's write mutex will be locked to ensure that the packet
 // is sent correctly and to avoid race conditions
@@ -316,25 +364,30 @@ CERVER_EXPORT u8 packet_send_split (const Packet *packet, int flags, size_t *tot
 // sends a packet to the socket in two parts, first the header & then the data
 // works just as packet_send_split () but with the flags set to 0
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_send_to_split (const Packet *packet, size_t *total_sent,
-    struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby);
+CERVER_EXPORT u8 packet_send_to_split (
+	const Packet *packet,
+	size_t *total_sent,
+	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+);
 
 // sends a packet in pieces, taking the header from the packet's field
 // sends each buffer as they are with they respective sizes
 // socket mutex will be locked for the entire operation
 // returns 0 on success, 1 on error
 CERVER_EXPORT u8 packet_send_pieces (
-    const Packet *packet, 
-    void **pieces, size_t *sizes, u32 n_pieces, 
-    int flags, 
-    size_t *total_sent
+	const Packet *packet,
+	void **pieces, size_t *sizes, u32 n_pieces,
+	int flags,
+	size_t *total_sent
 );
 
 // sends a packet directly to the socket
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_send_to_socket (const Packet *packet, struct _Socket *socket, 
-    int flags, size_t *total_sent, bool raw);
+CERVER_EXPORT u8 packet_send_to_socket (
+	const Packet *packet,
+	struct _Socket *socket, int flags, size_t *total_sent, bool raw
+);
 
 // check if packet has a compatible protocol id and a version
 // returns false on a bad packet

--- a/include/cerver/receive.h
+++ b/include/cerver/receive.h
@@ -3,11 +3,11 @@
 
 typedef enum ReceiveType {
 
-    RECEIVE_TYPE_NONE            = 0,
+	RECEIVE_TYPE_NONE            = 0,
 
-    RECEIVE_TYPE_NORMAL          = 1,
-    RECEIVE_TYPE_ON_HOLD         = 2,
-    RECEIVE_TYPE_ADMIN           = 3,
+	RECEIVE_TYPE_NORMAL          = 1,
+	RECEIVE_TYPE_ON_HOLD         = 2,
+	RECEIVE_TYPE_ADMIN           = 3,
 
 } ReceiveType;
 

--- a/include/cerver/sessions.h
+++ b/include/cerver/sessions.h
@@ -9,9 +9,9 @@ struct _AuthData;
 // auxiliary struct that is passed to cerver session id generator
 typedef struct SessionData {
 
-    Packet *packet;
-    struct _AuthData *auth_data;
-    Client *client;
+	Packet *packet;
+	struct _AuthData *auth_data;
+	Client *client;
 
 } SessionData;
 
@@ -29,7 +29,7 @@ CERVER_PRIVATE void *session_default_generate_id (const void *session_data);
 // serialized session id - token
 struct _SToken {
 
-    char token[TOKEN_SIZE];
+	char token[TOKEN_SIZE];
 
 };
 

--- a/include/cerver/socket.h
+++ b/include/cerver/socket.h
@@ -11,7 +11,7 @@ struct _Cerver;
 
 struct _Socket {
 
-    int sock_fd;
+	int sock_fd;
 
 	char *packet_buffer;
 	size_t packet_buffer_size;

--- a/include/cerver/threads/thpool.h
+++ b/include/cerver/threads/thpool.h
@@ -11,19 +11,19 @@ struct _PoolThread;
 
 typedef struct Thpool {
 
-    const char *name;
+	const char *name;
 
-    unsigned int n_threads;
-    struct _PoolThread **threads;
+	unsigned int n_threads;
+	struct _PoolThread **threads;
 
-    volatile bool keep_alive;
-    volatile unsigned int num_threads_alive;
-    volatile unsigned int num_threads_working;
+	volatile bool keep_alive;
+	volatile unsigned int num_threads_alive;
+	volatile unsigned int num_threads_working;
 
-    pthread_mutex_t *mutex;
-    pthread_cond_t *threads_all_idle;
+	pthread_mutex_t *mutex;
+	pthread_cond_t *threads_all_idle;
 
-    JobQueue *job_queue;
+	JobQueue *job_queue;
 
 } Thpool;
 

--- a/include/cerver/timer.h
+++ b/include/cerver/timer.h
@@ -1,5 +1,5 @@
-#ifndef _CERVER_TIME_H_
-#define _CERVER_TIME_H_
+#ifndef _CERVER_TIMER_H_
+#define _CERVER_TIMER_H_
 
 #ifndef __USE_POSIX199309
 	#define __USE_POSIX199309

--- a/include/cerver/types/string.h
+++ b/include/cerver/types/string.h
@@ -1,5 +1,5 @@
-#ifndef _CERVER_ESTRING_H_
-#define _CERVER_ESTRING_H_
+#ifndef _CERVER_STRING_H_
+#define _CERVER_STRING_H_
 
 #include "cerver/types/types.h"
 

--- a/include/cerver/types/string.h
+++ b/include/cerver/types/string.h
@@ -7,8 +7,8 @@
 
 typedef struct String {
 
-    unsigned int len;
-    char *str;
+	unsigned int len;
+	char *str;
 
 } String;
 
@@ -58,42 +58,42 @@ CERVER_PUBLIC int str_contains (String *str, char *to_find);
 
 typedef enum SStringSize {
 
-    SS_SMALL = 64,
-    SS_MEDIUM = 128,
-    SS_LARGE = 256,
-    SS_EXTRA_LARGE = 512
+	SS_SMALL = 64,
+	SS_MEDIUM = 128,
+	SS_LARGE = 256,
+	SS_EXTRA_LARGE = 512
 
 } SStringSize;
 
 // serialized str (small)
 typedef struct SStringS {
 
-    u16 len;
-    char str[64];
+	u16 len;
+	char str[64];
 
 } SStringS;
 
 // serialized str (medium)
 typedef struct SStringM {
 
-    u16 len;
-    char str[128];
+	u16 len;
+	char str[128];
 
 } SStringM;
 
 // serialized str (large)
 typedef struct SStringL {
 
-    u16 len;
-    char str[256];
+	u16 len;
+	char str[256];
 
 } SStringL;
 
 // serialized str (extra large)
 typedef struct SStringXL {
 
-    u16 len;
-    char str[512];
+	u16 len;
+	char str[512];
 
 } SStringXL;
 

--- a/include/cerver/utils/log.h
+++ b/include/cerver/utils/log.h
@@ -2,11 +2,15 @@
 #define _CERVER_UTILS_LOG_H_
 
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "cerver/config.h"
 
+#define LOG_DEFAULT_PATH		"/var/log/cerver"
+
 #define LOG_POOL_INIT			32
 
+#define LOG_DATETIME_SIZE		32
 #define LOG_HEADER_SIZE			32
 #define LOG_HEADER_HALF_SIZE	LOG_HEADER_SIZE / 2
 
@@ -51,18 +55,71 @@ typedef enum LogType {
 
 #pragma endregion
 
+#pragma region configuration
+
+typedef enum LogOutputType {
+
+	LOG_OUTPUT_TYPE_NONE		= 0,
+	LOG_OUTPUT_TYPE_STD			= 1,	// log to stdout & stderr
+	LOG_OUTPUT_TYPE_FILE		= 2,	// log to a file
+	LOG_OUTPUT_TYPE_BOTH		= 3		// log to both std output and file
+
+} LogOutputType;
+
+// returns the current log output type
+CERVER_EXPORT LogOutputType cerver_log_get_output_type (void);
+
+// sets the log output type to use
+CERVER_EXPORT void cerver_log_set_output_type (LogOutputType type);
+
+// sets the path where logs files will be stored
+// returns 0 on success, 1 on error
+CERVER_EXPORT unsigned int cerver_log_set_path (const char *pathname);
+
+#define LOG_TIME_TYPE_MAP(XX)										\
+	XX(0, 	NONE, 		None,		Logs without time)				\
+	XX(1, 	TIME, 		Time,		Logs with time)					\
+	XX(2, 	DATE, 		Date,		Logs with date)					\
+	XX(3, 	BOTH, 		Both,		Logs with date and time)
+
+typedef enum LogTimeType {
+
+	#define XX(num, name, string, description) LOG_TIME_TYPE_##name = num,
+	LOG_TIME_TYPE_MAP (XX)
+	#undef XX
+
+} LogTimeType;
+
+CERVER_PUBLIC const char *cerver_log_time_type_to_string (LogTimeType type);
+
+CERVER_PUBLIC const char *cerver_log_time_type_description (LogTimeType type);
+
+// returns the current log time configuration
+CERVER_EXPORT LogTimeType cerver_log_get_time_config (void);
+
+// sets the log time configuration to be used by log methods
+// none: print logs with no dates
+// time: 24h time format
+// date: day/month/year format
+// both: day/month/year - 24h date time format
+CERVER_EXPORT void cerver_log_set_time_config (LogTimeType type);
+
+// set if logs datetimes will use local time or not
+CERVER_EXPORT void cerver_log_set_local_time (bool value);
+
+#pragma endregion
+
 #pragma region public
 
+// creates and prints a message of custom types
+// based on the first type, the message can be printed with colors to stdout
 CERVER_PUBLIC void cerver_log (
 	LogType first_type, LogType second_type,
 	const char *format, ...
 );
 
-CERVER_PUBLIC void cerver_log_msg (
-	FILE *__restrict __stream, 
-	LogType first_type, LogType second_type,
-	const char *msg
-);
+// prints a message with no type, effectively making this a custom printf ()
+CERVER_PUBLIC void cerver_log_msg (const char *msg, ...);
 
 // prints a red error message to stderr
 CERVER_PUBLIC void cerver_log_error (const char *msg, ...);

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-2"
-#define CERVER_VERSION_NAME             "Beta 2.0b-2"
-#define CERVER_VERSION_DATE			    "18/10/2020"
-#define CERVER_VERSION_TIME			    "19:17 CST"
+#define CERVER_VERSION                  "2.0b-3"
+#define CERVER_VERSION_NAME             "Beta 2.0b-3"
+#define CERVER_VERSION_DATE			    "22/10/2020"
+#define CERVER_VERSION_TIME			    "05:25 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -9,7 +9,7 @@
 #define CERVER_VERSION_TIME			    "19:17 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
-// print full cerver version information 
+// print full cerver version information
 CERVER_EXPORT void cerver_version_print_full (void);
 
 // print the version id

--- a/makefile
+++ b/makefile
@@ -111,6 +111,7 @@ examples: $(EXOBJS)
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/game.o -o ./$(EXATARGET)/game -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/client/client.o -o ./$(EXATARGET)/client/client -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/client/auth.o -o ./$(EXATARGET)/client/auth -l cerver
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/client/files.o -o ./$(EXATARGET)/client/files -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/web/api.o -o ./$(EXATARGET)/web/api -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/web/sockets.o -o ./$(EXATARGET)/web/sockets -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/web/upload.o -o ./$(EXATARGET)/web/upload -l cerver

--- a/makefile
+++ b/makefile
@@ -6,14 +6,17 @@ MATH		:= -lm
 
 OPENSSL		:= -l ssl -l crypto
 
-# print additional information
-DEFINES	= -D CERVER_DEBUG -D CERVER_STATS 	\
-			-D CLIENT_DEBUG 				\
-			-D HANDLER_DEBUG 				\
-			-D PACKETS_DEBUG 				\
-			-D AUTH_DEBUG 					\
-			-D ADMIN_DEBUG					\
-			-D HTTP_DEBUG					\
+DEFINES		:= -D _GNU_SOURCE
+
+DEVELOPMENT	:= -g \
+				-D CERVER_DEBUG -D CERVER_STATS \
+				-D CLIENT_DEBUG					\
+				-D HANDLER_DEBUG 				\
+				-D PACKETS_DEBUG 				\
+				-D AUTH_DEBUG 					\
+				-D ADMIN_DEBUG					\
+				-D FILES_DEBUG					\
+				-D HTTP_DEBUG
 
 CC          := gcc
 
@@ -30,7 +33,7 @@ SRCEXT      := c
 DEPEXT      := d
 OBJEXT      := o
 
-CFLAGS      := -g $(DEFINES) -Wall -Wno-unknown-pragmas -fPIC
+CFLAGS      := $(DEVELOPMENT) $(DEFINES) -Wall -Wno-unknown-pragmas -std=gnu99 -fPIC
 LIB         := $(PTHREAD) $(MATH) $(OPENSSL)
 INC         := -I $(INCDIR) -I /usr/local/include
 INCDEP      := -I $(INCDIR)
@@ -99,12 +102,13 @@ examples: $(EXOBJS)
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/threads.o -o ./$(EXATARGET)/threads -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/advanced.o -o ./$(EXATARGET)/advanced -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/requests.o -o ./$(EXATARGET)/requests -l cerver
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/files.o -o ./$(EXATARGET)/files -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/auth.o -o ./$(EXATARGET)/auth -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/sessions.o -o ./$(EXATARGET)/sessions -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/admin.o -o ./$(EXATARGET)/admin -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/packets.o -o ./$(EXATARGET)/packets -l cerver
-	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/game.o -o ./$(EXATARGET)/game -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/logs.o -o ./$(EXATARGET)/logs -l cerver
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/game.o -o ./$(EXATARGET)/game -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/client/client.o -o ./$(EXATARGET)/client/client -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/client/auth.o -o ./$(EXATARGET)/client/auth -l cerver
 	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/web/api.o -o ./$(EXATARGET)/web/api -l cerver

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -31,91 +31,91 @@ static u8 admin_cerver_poll_unregister_connection (AdminCerver *admin_cerver, Co
 
 static AdminCerverStats *admin_cerver_stats_new (void) {
 
-    AdminCerverStats *admin_cerver_stats = (AdminCerverStats *) malloc (sizeof (AdminCerverStats));
-    if (admin_cerver_stats) {
-        memset (admin_cerver_stats, 0, sizeof (AdminCerverStats));
-        admin_cerver_stats->received_packets = packets_per_type_new ();
-        admin_cerver_stats->sent_packets = packets_per_type_new ();
-    } 
+	AdminCerverStats *admin_cerver_stats = (AdminCerverStats *) malloc (sizeof (AdminCerverStats));
+	if (admin_cerver_stats) {
+		memset (admin_cerver_stats, 0, sizeof (AdminCerverStats));
+		admin_cerver_stats->received_packets = packets_per_type_new ();
+		admin_cerver_stats->sent_packets = packets_per_type_new ();
+	}
 
-    return admin_cerver_stats;
+	return admin_cerver_stats;
 
 }
 
 static void admin_cerver_stats_delete (AdminCerverStats *admin_cerver_stats) {
 
-    if (admin_cerver_stats) {
-        packets_per_type_delete (admin_cerver_stats->received_packets);
-        packets_per_type_delete (admin_cerver_stats->sent_packets);
-        
-        free (admin_cerver_stats);
-    } 
+	if (admin_cerver_stats) {
+		packets_per_type_delete (admin_cerver_stats->received_packets);
+		packets_per_type_delete (admin_cerver_stats->sent_packets);
+
+		free (admin_cerver_stats);
+	}
 
 }
 
 void admin_cerver_stats_print (AdminCerverStats *stats) {
 
-    if (stats) {
-        printf ("\nAdmin stats: \n");
-        printf ("Threshold_time: %ld\n", stats->threshold_time);
-    
-        printf ("\n");
-        printf ("Total n receives done:                  %ld\n", stats->total_n_receives_done);
-        printf ("Total n packets received:               %ld\n", stats->total_n_packets_received);
-        printf ("Total bytes received:                   %ld\n", stats->total_bytes_received);
+	if (stats) {
+		printf ("\nAdmin stats: \n");
+		printf ("Threshold_time: %ld\n", stats->threshold_time);
 
-        printf ("\n");
-        printf ("Total n packets sent:                   %ld\n", stats->total_n_packets_sent);
-        printf ("Total bytes sent:                       %ld\n", stats->total_bytes_sent);
+		printf ("\n");
+		printf ("Total n receives done:                  %ld\n", stats->total_n_receives_done);
+		printf ("Total n packets received:               %ld\n", stats->total_n_packets_received);
+		printf ("Total bytes received:                   %ld\n", stats->total_bytes_received);
 
-        printf ("\n");
-        printf ("Current connections:                    %ld\n", stats->current_connections);
-        printf ("Current connected admins:               %ld\n", stats->current_connected_admins);
+		printf ("\n");
+		printf ("Total n packets sent:                   %ld\n", stats->total_n_packets_sent);
+		printf ("Total bytes sent:                       %ld\n", stats->total_bytes_sent);
 
-        printf ("\n");
-        printf ("Total admin connections:                %ld\n", stats->total_admin_connections);
-        printf ("Total n admins:                         %ld\n", stats->total_n_admins);
+		printf ("\n");
+		printf ("Current connections:                    %ld\n", stats->current_connections);
+		printf ("Current connected admins:               %ld\n", stats->current_connected_admins);
 
-        printf ("\nReceived packets:\n");
-        packets_per_type_print (stats->received_packets);
+		printf ("\n");
+		printf ("Total admin connections:                %ld\n", stats->total_admin_connections);
+		printf ("Total n admins:                         %ld\n", stats->total_n_admins);
 
-        printf ("\nSent packets:\n");
-        packets_per_type_print (stats->sent_packets);
-    }
+		printf ("\nReceived packets:\n");
+		packets_per_type_print (stats->received_packets);
+
+		printf ("\nSent packets:\n");
+		packets_per_type_print (stats->sent_packets);
+	}
 
 }
 
 static void admin_cerver_packet_send_update_stats (AdminCerverStats *stats,
-    PacketType packet_type, size_t sent) {
+	PacketType packet_type, size_t sent) {
 
-    stats->total_n_packets_sent += 1;
-    stats->total_bytes_sent += sent;
+	stats->total_n_packets_sent += 1;
+	stats->total_bytes_sent += sent;
 
-    switch (packet_type) {
-        case PACKET_TYPE_NONE: break;
+	switch (packet_type) {
+		case PACKET_TYPE_NONE: break;
 
-        case PACKET_TYPE_CERVER: stats->sent_packets->n_cerver_packets += 1; break;
+		case PACKET_TYPE_CERVER: stats->sent_packets->n_cerver_packets += 1; break;
 
-        case PACKET_TYPE_CLIENT: break;
+		case PACKET_TYPE_CLIENT: break;
 
-        case PACKET_TYPE_ERROR: stats->sent_packets->n_error_packets += 1; break;
+		case PACKET_TYPE_ERROR: stats->sent_packets->n_error_packets += 1; break;
 
-        case PACKET_TYPE_REQUEST: stats->sent_packets->n_request_packets += 1; break;
+		case PACKET_TYPE_REQUEST: stats->sent_packets->n_request_packets += 1; break;
 
-        case PACKET_TYPE_AUTH: stats->sent_packets->n_auth_packets += 1; break;
+		case PACKET_TYPE_AUTH: stats->sent_packets->n_auth_packets += 1; break;
 
-        case PACKET_TYPE_GAME: stats->sent_packets->n_game_packets += 1; break;
+		case PACKET_TYPE_GAME: stats->sent_packets->n_game_packets += 1; break;
 
-        case PACKET_TYPE_APP: stats->sent_packets->n_app_packets += 1; break;
+		case PACKET_TYPE_APP: stats->sent_packets->n_app_packets += 1; break;
 
-        case PACKET_TYPE_APP_ERROR: stats->sent_packets->n_app_error_packets += 1; break;
+		case PACKET_TYPE_APP_ERROR: stats->sent_packets->n_app_error_packets += 1; break;
 
-        case PACKET_TYPE_CUSTOM: stats->sent_packets->n_custom_packets += 1; break;
+		case PACKET_TYPE_CUSTOM: stats->sent_packets->n_custom_packets += 1; break;
 
-        case PACKET_TYPE_TEST: stats->sent_packets->n_test_packets += 1; break;
+		case PACKET_TYPE_TEST: stats->sent_packets->n_test_packets += 1; break;
 
-        default: stats->sent_packets->n_unknown_packets += 1; break;
-    }
+		default: stats->sent_packets->n_unknown_packets += 1; break;
+	}
 
 }
 
@@ -125,144 +125,144 @@ static void admin_cerver_packet_send_update_stats (AdminCerverStats *stats,
 
 Admin *admin_new (void) {
 
-    Admin *admin = (Admin *) malloc (sizeof (Admin));
-    if (admin) {
-        admin->admin_cerver = NULL;
+	Admin *admin = (Admin *) malloc (sizeof (Admin));
+	if (admin) {
+		admin->admin_cerver = NULL;
 
-        admin->id = NULL;
+		admin->id = NULL;
 
-        admin->client = NULL;
+		admin->client = NULL;
 
-        admin->data = NULL;
-        admin->delete_data = NULL;
+		admin->data = NULL;
+		admin->delete_data = NULL;
 
-        admin->bad_packets = 0;
-    }
+		admin->bad_packets = 0;
+	}
 
-    return admin;
+	return admin;
 
 }
 
 void admin_delete (void *admin_ptr) {
 
-    if (admin_ptr) {
-        Admin *admin = (Admin *) admin_ptr;
+	if (admin_ptr) {
+		Admin *admin = (Admin *) admin_ptr;
 
-        str_delete (admin->id);
+		str_delete (admin->id);
 
-        client_delete (admin->client);
+		client_delete (admin->client);
 
-        if (admin->data) {
-            if (admin->delete_data) admin->delete_data (admin->data);
-        }
+		if (admin->data) {
+			if (admin->delete_data) admin->delete_data (admin->data);
+		}
 
-        free (admin);
-    }
+		free (admin);
+	}
 
 }
 
 Admin *admin_create (void) {
 
-    Admin *admin = admin_new ();
-    if (admin) {
-        time_t rawtime = 0;
-        time (&rawtime);
-        admin->id = str_create ("%ld-%d", rawtime, random_int_in_range (0, 100));
-    }
+	Admin *admin = admin_new ();
+	if (admin) {
+		time_t rawtime = 0;
+		time (&rawtime);
+		admin->id = str_create ("%ld-%d", rawtime, random_int_in_range (0, 100));
+	}
 
-    return admin;
+	return admin;
 
 }
 
 Admin *admin_create_with_client (Client *client) {
 
-    Admin *admin = NULL;
+	Admin *admin = NULL;
 
-    if (client) {
-        admin = admin_create ();
-        if (admin) admin->client = client;
-    }
+	if (client) {
+		admin = admin_create ();
+		if (admin) admin->client = client;
+	}
 
-    return admin;
+	return admin;
 
 }
 
 int admin_comparator_by_id (const void *a, const void *b) {
 
-    if (a && b) return strcmp (((Admin *) a)->id->str, ((Admin *) b)->id->str);
+	if (a && b) return strcmp (((Admin *) a)->id->str, ((Admin *) b)->id->str);
 
-    else if (a && !b) return -1;
-    else if (!a && b) return 1;
-    return 0;
+	else if (a && !b) return -1;
+	else if (!a && b) return 1;
+	return 0;
 
 }
 
 // sets dedicated admin data and a way to delete it, if NULL, it won't be deleted
 void admin_set_data (Admin *admin, void *data, Action delete_data) {
 
-    if (admin) {
-        admin->data = data;
-        admin->delete_data = delete_data;
-    }
+	if (admin) {
+		admin->data = data;
+		admin->delete_data = delete_data;
+	}
 
 }
 
 static Connection *admin_connection_get_by_sock_fd (Admin *admin, const i32 sock_fd) {
 
-    Connection *retval = NULL;
+	Connection *retval = NULL;
 
-    if (admin) {
-        Connection *connection = NULL;
-        for (ListElement *le_sub = dlist_start (admin->client->connections); le_sub; le_sub = le_sub->next) {
-            connection = (Connection *) le_sub->data;
-            if (connection->socket->sock_fd == sock_fd) {
-                retval = connection;
-                break;
-            }
-        }
-    }
+	if (admin) {
+		Connection *connection = NULL;
+		for (ListElement *le_sub = dlist_start (admin->client->connections); le_sub; le_sub = le_sub->next) {
+			connection = (Connection *) le_sub->data;
+			if (connection->socket->sock_fd == sock_fd) {
+				retval = connection;
+				break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets an admin by a matching connection in its client with the specified sock fd
 Admin *admin_get_by_sock_fd (AdminCerver *admin_cerver, const i32 sock_fd) {
 
-    Admin *retval = NULL;
+	Admin *retval = NULL;
 
-    if (admin_cerver) {
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            if (admin_connection_get_by_sock_fd ((Admin *) le->data, sock_fd)) {
-                retval = (Admin *) le->data;
-                break;
-            }
-        }
-    }
+	if (admin_cerver) {
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			if (admin_connection_get_by_sock_fd ((Admin *) le->data, sock_fd)) {
+				retval = (Admin *) le->data;
+				break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets an admin by a matching client's session id
 Admin *admin_get_by_session_id (AdminCerver *admin_cerver, const char *session_id) {
 
-    Admin *retval = NULL;
+	Admin *retval = NULL;
 
-    if (admin_cerver) {
-        Admin *admin = NULL;
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            admin = (Admin *) le->data;
-            if (admin->client->session_id) {
-                if (!strcmp (admin->client->session_id->str, session_id)) {
-                    retval = (Admin *) le->data;
-                    break;
-                }
-            }
-        }
-    }
+	if (admin_cerver) {
+		Admin *admin = NULL;
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			admin = (Admin *) le->data;
+			if (admin->client->session_id) {
+				if (!strcmp (admin->client->session_id->str, session_id)) {
+					retval = (Admin *) le->data;
+					break;
+				}
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -271,90 +271,90 @@ Admin *admin_get_by_session_id (AdminCerver *admin_cerver, const char *session_i
 // returns 0 on success, 1 on error
 u8 admin_remove_connection_by_sock_fd (AdminCerver *admin_cerver, Admin *admin, const i32 sock_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && admin) {
-        Connection *connection = NULL;
-        switch (admin->client->connections->size) {
-            case 0: {
-                #ifdef ADMIN_DEBUG
-                cerver_log (
-                    LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
-                    "admin_remove_connection_by_sock_fd () - Admin client with id " 
-                    "%ld does not have ANY connection - removing him from cerver...",
-                    admin->client->id
-                );
-                #endif
-                
-                admin_cerver_unregister_admin (admin_cerver, admin);
-                admin_delete (admin);
-            } break;
+	if (admin_cerver && admin) {
+		Connection *connection = NULL;
+		switch (admin->client->connections->size) {
+			case 0: {
+				#ifdef ADMIN_DEBUG
+				cerver_log (
+					LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+					"admin_remove_connection_by_sock_fd () - Admin client with id "
+					"%ld does not have ANY connection - removing him from cerver...",
+					admin->client->id
+				);
+				#endif
 
-            case 1: {
-                connection = (Connection *) admin->client->connections->start->data;
-                if (!admin_cerver_poll_unregister_connection (admin_cerver, connection)) {
-                    // remove, close & delete the connection
-                    if (!client_connection_drop (
-                        admin_cerver->cerver,
-                        admin->client,
-                        connection
-                    )) {
-                        cerver_event_trigger (
-                            CERVER_EVENT_ADMIN_CLOSE_CONNECTION,
-                            admin_cerver->cerver,
-                            NULL, NULL
-                        );
+				admin_cerver_unregister_admin (admin_cerver, admin);
+				admin_delete (admin);
+			} break;
 
-                        // no connections left in admin, just remove and delete
-                        admin_cerver_unregister_admin (admin_cerver, admin);
-                        admin_delete (admin);
+			case 1: {
+				connection = (Connection *) admin->client->connections->start->data;
+				if (!admin_cerver_poll_unregister_connection (admin_cerver, connection)) {
+					// remove, close & delete the connection
+					if (!client_connection_drop (
+						admin_cerver->cerver,
+						admin->client,
+						connection
+					)) {
+						cerver_event_trigger (
+							CERVER_EVENT_ADMIN_CLOSE_CONNECTION,
+							admin_cerver->cerver,
+							NULL, NULL
+						);
 
-                        cerver_event_trigger (
-                            CERVER_EVENT_ADMIN_DROPPED,
-                            admin_cerver->cerver,
-                            NULL, NULL
-                        );
+						// no connections left in admin, just remove and delete
+						admin_cerver_unregister_admin (admin_cerver, admin);
+						admin_delete (admin);
 
-                        retval = 0;
-                    }
-                }
-            } break;
+						cerver_event_trigger (
+							CERVER_EVENT_ADMIN_DROPPED,
+							admin_cerver->cerver,
+							NULL, NULL
+						);
 
-            default: {
-                connection = admin_connection_get_by_sock_fd (admin, sock_fd);
-                if (connection) {
-                    if (!admin_cerver_poll_unregister_connection (admin_cerver, connection)) {
-                        if (!client_connection_drop (
-                            admin_cerver->cerver,
-                            admin->client,
-                            connection
-                        )) {
-                            cerver_event_trigger (
-                                CERVER_EVENT_ADMIN_CLOSE_CONNECTION,
-                                admin_cerver->cerver,
-                                NULL, NULL
-                            );
+						retval = 0;
+					}
+				}
+			} break;
 
-                            retval = 0;
-                        }
-                    }
-                }
+			default: {
+				connection = admin_connection_get_by_sock_fd (admin, sock_fd);
+				if (connection) {
+					if (!admin_cerver_poll_unregister_connection (admin_cerver, connection)) {
+						if (!client_connection_drop (
+							admin_cerver->cerver,
+							admin->client,
+							connection
+						)) {
+							cerver_event_trigger (
+								CERVER_EVENT_ADMIN_CLOSE_CONNECTION,
+								admin_cerver->cerver,
+								NULL, NULL
+							);
 
-                else {
-                    #ifdef ADMIN_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
-                        "admin_remove_connection_by_sock_fd () - Admin client with id " 
-                        "%ld does not have a connection related to sock fd %d",
-                        admin->client->id, sock_fd
-                    );
-                    #endif
-                }
-            } break;
-        }
-    }
+							retval = 0;
+						}
+					}
+				}
 
-    return retval;
+				else {
+					#ifdef ADMIN_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+						"admin_remove_connection_by_sock_fd () - Admin client with id "
+						"%ld does not have a connection related to sock fd %d",
+						admin->client->id, sock_fd
+					);
+					#endif
+				}
+			} break;
+		}
+	}
+
+	return retval;
 
 }
 
@@ -362,38 +362,38 @@ u8 admin_remove_connection_by_sock_fd (AdminCerver *admin_cerver, Admin *admin, 
 // returns 0 on success, 1 on error
 u8 admin_send_packet (Admin *admin, Packet *packet) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin && packet) {
-        // printf (
-        //     "admin client: %ld -- sock fd: %d\n", 
-        //     admin->client->id, 
-        //     ((Connection *) dlist_start (admin->client->connections))->socket->sock_fd
-        // );
+	if (admin && packet) {
+		// printf (
+		//     "admin client: %ld -- sock fd: %d\n",
+		//     admin->client->id,
+		//     ((Connection *) dlist_start (admin->client->connections))->socket->sock_fd
+		// );
 
-        packet_set_network_values (
-            packet, 
-            NULL, 
-            admin->client, 
-            (Connection *) dlist_start (admin->client->connections)->data, 
-            NULL
-        );
+		packet_set_network_values (
+			packet,
+			NULL,
+			admin->client,
+			(Connection *) dlist_start (admin->client->connections)->data,
+			NULL
+		);
 
-        size_t sent = 0;
-        if (!packet_send (packet, 0, &sent, false)) {
-            // printf ("admin_send_packet () - Sent to admin: %ld\n", sent);
+		size_t sent = 0;
+		if (!packet_send (packet, 0, &sent, false)) {
+			// printf ("admin_send_packet () - Sent to admin: %ld\n", sent);
 
-            admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
+			admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            cerver_log_error ("Failed to send packet to admin!");
-        }
-    }
+		else {
+			cerver_log_error ("Failed to send packet to admin!");
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -401,68 +401,68 @@ u8 admin_send_packet (Admin *admin, Packet *packet) {
 // returns 0 on success, 1 on error
 u8 admin_send_packet_split (Admin *admin, Packet *packet) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin && packet) {
-        size_t sent = 0;
-        if (!packet_send_to_split (
-            packet, &sent,
-            NULL,
-            admin->client, 
-            (Connection *) dlist_start (admin->client->connections)->data,
-            NULL
-        )) {
-            // printf ("admin_send_packet_split () - Sent to admin: %ld\n", sent);
+	if (admin && packet) {
+		size_t sent = 0;
+		if (!packet_send_to_split (
+			packet, &sent,
+			NULL,
+			admin->client,
+			(Connection *) dlist_start (admin->client->connections)->data,
+			NULL
+		)) {
+			// printf ("admin_send_packet_split () - Sent to admin: %ld\n", sent);
 
-            admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
+			admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            cerver_log_error ("admin_send_packet_split () - Failed to send packet!");
-        } 
-    }
+		else {
+			cerver_log_error ("admin_send_packet_split () - Failed to send packet!");
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sends a packet in pieces to the first connection of the specified admin
 // returns 0 on success, 1 on error
 u8 admin_send_packet_pieces (Admin *admin, Packet *packet,
-    void **pieces, size_t *sizes, u32 n_pieces) {
+	void **pieces, size_t *sizes, u32 n_pieces) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin && packet) {
-        packet_set_network_values (
-            packet, 
-            NULL, 
-            admin->client, 
-            (Connection *) dlist_start (admin->client->connections)->data, 
-            NULL
-        );
+	if (admin && packet) {
+		packet_set_network_values (
+			packet,
+			NULL,
+			admin->client,
+			(Connection *) dlist_start (admin->client->connections)->data,
+			NULL
+		);
 
-        size_t sent = 0;
-        if (!packet_send_pieces (
-            packet,
-            pieces, sizes, n_pieces,
-            0, &sent 
-        )) {
-            printf ("admin_send_packet_pieces () - Sent to admin: %ld\n", sent);
+		size_t sent = 0;
+		if (!packet_send_pieces (
+			packet,
+			pieces, sizes, n_pieces,
+			0, &sent
+		)) {
+			printf ("admin_send_packet_pieces () - Sent to admin: %ld\n", sent);
 
-            admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
-            
-            retval = 0;
-        }
+			admin_cerver_packet_send_update_stats (admin->admin_cerver->stats, packet->packet_type, sent);
 
-        else {
-            cerver_log_error ("admin_send_packet_in_pieces () - Failed to send packet!");
-        }
-    }
+			retval = 0;
+		}
 
-    return retval;
+		else {
+			cerver_log_error ("admin_send_packet_in_pieces () - Failed to send packet!");
+		}
+	}
+
+	return retval;
 
 }
 
@@ -472,93 +472,93 @@ u8 admin_send_packet_pieces (Admin *admin, Packet *packet,
 
 AdminCerver *admin_cerver_new (void) {
 
-    AdminCerver *admin_cerver = (AdminCerver *) malloc (sizeof (AdminCerver));
-    if (admin_cerver) {
-        admin_cerver->cerver = NULL;
+	AdminCerver *admin_cerver = (AdminCerver *) malloc (sizeof (AdminCerver));
+	if (admin_cerver) {
+		admin_cerver->cerver = NULL;
 
-        admin_cerver->admins = NULL;
+		admin_cerver->admins = NULL;
 
-        admin_cerver->authenticate = NULL;
+		admin_cerver->authenticate = NULL;
 
-        admin_cerver->max_admins = DEFAULT_MAX_ADMINS;
-        admin_cerver->max_admin_connections = DEFAULT_MAX_ADMIN_CONNECTIONS;
+		admin_cerver->max_admins = DEFAULT_MAX_ADMINS;
+		admin_cerver->max_admin_connections = DEFAULT_MAX_ADMIN_CONNECTIONS;
 
-        admin_cerver->n_bad_packets_limit = DEFAULT_N_BAD_PACKETS_LIMIT;
+		admin_cerver->n_bad_packets_limit = DEFAULT_N_BAD_PACKETS_LIMIT;
 
-        admin_cerver->fds = NULL;
-        admin_cerver->max_n_fds = DEFAULT_ADMIN_MAX_N_FDS;
-        admin_cerver->current_n_fds = 0;
-        admin_cerver->poll_timeout = DEFAULT_ADMIN_POLL_TIMEOUT;
+		admin_cerver->fds = NULL;
+		admin_cerver->max_n_fds = DEFAULT_ADMIN_MAX_N_FDS;
+		admin_cerver->current_n_fds = 0;
+		admin_cerver->poll_timeout = DEFAULT_ADMIN_POLL_TIMEOUT;
 
-        admin_cerver->app_packet_handler = NULL;
-        admin_cerver->app_error_packet_handler = NULL;
-        admin_cerver->custom_packet_handler = NULL;
+		admin_cerver->app_packet_handler = NULL;
+		admin_cerver->app_error_packet_handler = NULL;
+		admin_cerver->custom_packet_handler = NULL;
 
-        admin_cerver->num_handlers_alive = 0;
-        admin_cerver->num_handlers_working = 0;
-        admin_cerver->handlers_lock = NULL;
+		admin_cerver->num_handlers_alive = 0;
+		admin_cerver->num_handlers_working = 0;
+		admin_cerver->handlers_lock = NULL;
 
-        admin_cerver->app_packet_handler_delete_packet = true;
-        admin_cerver->app_error_packet_handler_delete_packet = true;
-        admin_cerver->custom_packet_handler_delete_packet = true;
+		admin_cerver->app_packet_handler_delete_packet = true;
+		admin_cerver->app_error_packet_handler_delete_packet = true;
+		admin_cerver->custom_packet_handler_delete_packet = true;
 
-        admin_cerver->update_thread_id = 0;
-        admin_cerver->update = NULL;
-        admin_cerver->update_args = NULL;
-        admin_cerver->delete_update_args = NULL;
-        admin_cerver->update_ticks = DEFAULT_UPDATE_TICKS;
+		admin_cerver->update_thread_id = 0;
+		admin_cerver->update = NULL;
+		admin_cerver->update_args = NULL;
+		admin_cerver->delete_update_args = NULL;
+		admin_cerver->update_ticks = DEFAULT_UPDATE_TICKS;
 
-        admin_cerver->update_interval_thread_id = 0;
-        admin_cerver->update_interval = NULL;
-        admin_cerver->update_interval_args = NULL;
-        admin_cerver->delete_update_interval_args = NULL;
-        admin_cerver->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
+		admin_cerver->update_interval_thread_id = 0;
+		admin_cerver->update_interval = NULL;
+		admin_cerver->update_interval_args = NULL;
+		admin_cerver->delete_update_interval_args = NULL;
+		admin_cerver->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
 
-        admin_cerver->stats = NULL;
-    }
+		admin_cerver->stats = NULL;
+	}
 
-    return admin_cerver;
+	return admin_cerver;
 
 }
 
 void admin_cerver_delete (AdminCerver *admin_cerver) {
 
-    if (admin_cerver) {
-        dlist_delete (admin_cerver->admins);
+	if (admin_cerver) {
+		dlist_delete (admin_cerver->admins);
 
-        if (admin_cerver->fds) free (admin_cerver->fds);
+		if (admin_cerver->fds) free (admin_cerver->fds);
 
-        if (admin_cerver->poll_lock) {
-            pthread_mutex_destroy (admin_cerver->poll_lock);
-            free (admin_cerver->poll_lock);
-        }
+		if (admin_cerver->poll_lock) {
+			pthread_mutex_destroy (admin_cerver->poll_lock);
+			free (admin_cerver->poll_lock);
+		}
 
-        handler_delete (admin_cerver->app_packet_handler);
-        handler_delete (admin_cerver->app_error_packet_handler);
-        handler_delete (admin_cerver->custom_packet_handler);
+		handler_delete (admin_cerver->app_packet_handler);
+		handler_delete (admin_cerver->app_error_packet_handler);
+		handler_delete (admin_cerver->custom_packet_handler);
 
-        if (admin_cerver->handlers_lock) {
-            pthread_mutex_destroy (admin_cerver->handlers_lock);
-            free (admin_cerver->handlers_lock);
-        }
+		if (admin_cerver->handlers_lock) {
+			pthread_mutex_destroy (admin_cerver->handlers_lock);
+			free (admin_cerver->handlers_lock);
+		}
 
-        admin_cerver_stats_delete (admin_cerver->stats);
+		admin_cerver_stats_delete (admin_cerver->stats);
 
-        free (admin_cerver);
-    }
+		free (admin_cerver);
+	}
 
 }
 
 AdminCerver *admin_cerver_create (void) {
 
-    AdminCerver *admin_cerver = admin_cerver_new ();
-    if (admin_cerver) {
-        admin_cerver->admins = dlist_init (admin_delete, admin_comparator_by_id);
+	AdminCerver *admin_cerver = admin_cerver_new ();
+	if (admin_cerver) {
+		admin_cerver->admins = dlist_init (admin_delete, admin_comparator_by_id);
 
-        admin_cerver->stats = admin_cerver_stats_new ();
-    }
+		admin_cerver->stats = admin_cerver_stats_new ();
+	}
 
-    return admin_cerver;
+	return admin_cerver;
 
 }
 
@@ -566,21 +566,21 @@ AdminCerver *admin_cerver_create (void) {
 // must return 0 on success, 1 on error
 void admin_cerver_set_authenticate (AdminCerver *admin_cerver, delegate authenticate) {
 
-    if (admin_cerver) admin_cerver->authenticate = authenticate;
+	if (admin_cerver) admin_cerver->authenticate = authenticate;
 
 }
 
 // sets the max numbers of admins allowed at any given time
 void admin_cerver_set_max_admins (AdminCerver *admin_cerver, u8 max_admins) {
 
-    if (admin_cerver) admin_cerver->max_admins = max_admins;
+	if (admin_cerver) admin_cerver->max_admins = max_admins;
 
 }
 
 // sets the max number of connections allowed per admin
 void admin_cerver_set_max_admin_connections (AdminCerver *admin_cerver, u8 max_admin_connections) {
 
-    if (admin_cerver) admin_cerver->max_admin_connections = max_admin_connections;
+	if (admin_cerver) admin_cerver->max_admin_connections = max_admin_connections;
 
 }
 
@@ -590,112 +590,112 @@ void admin_cerver_set_max_admin_connections (AdminCerver *admin_cerver, u8 max_a
 // -1 to use defaults (5 and 20)
 void admin_cerver_set_bad_packets_limit (AdminCerver *admin_cerver, i32 n_bad_packets_limit) {
 
-    if (admin_cerver) {
-        admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ? n_bad_packets_limit : DEFAULT_N_BAD_PACKETS_LIMIT;
-    }
+	if (admin_cerver) {
+		admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ? n_bad_packets_limit : DEFAULT_N_BAD_PACKETS_LIMIT;
+	}
 
 }
 
 // sets the max number of poll fds for the admin cerver
 void admin_cerver_set_max_fds (AdminCerver *admin_cerver, u32 max_n_fds) {
 
-    if (admin_cerver) admin_cerver->max_n_fds = max_n_fds;
+	if (admin_cerver) admin_cerver->max_n_fds = max_n_fds;
 
 }
 
 // sets a custom poll time out to use for admins
 void admin_cerver_set_poll_timeout (AdminCerver *admin_cerver, u32 poll_timeout) {
 
-    if (admin_cerver) admin_cerver->poll_timeout = poll_timeout;
+	if (admin_cerver) admin_cerver->poll_timeout = poll_timeout;
 
 }
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 void admin_cerver_set_app_handlers (AdminCerver *admin_cerver, Handler *app_handler, Handler *app_error_handler) {
 
-    if (admin_cerver) {
-        admin_cerver->app_packet_handler = app_handler;
-        if (admin_cerver->app_packet_handler) {
-            admin_cerver->app_packet_handler->type = HANDLER_TYPE_ADMIN;
-            admin_cerver->app_packet_handler->cerver = admin_cerver->cerver;
-        }
+	if (admin_cerver) {
+		admin_cerver->app_packet_handler = app_handler;
+		if (admin_cerver->app_packet_handler) {
+			admin_cerver->app_packet_handler->type = HANDLER_TYPE_ADMIN;
+			admin_cerver->app_packet_handler->cerver = admin_cerver->cerver;
+		}
 
-        admin_cerver->app_error_packet_handler = app_error_handler;
-        if (admin_cerver->app_error_packet_handler) {
-            admin_cerver->app_error_packet_handler->type = HANDLER_TYPE_ADMIN;
-            admin_cerver->app_error_packet_handler->cerver = admin_cerver->cerver;
-        }
-    }
+		admin_cerver->app_error_packet_handler = app_error_handler;
+		if (admin_cerver->app_error_packet_handler) {
+			admin_cerver->app_error_packet_handler->type = HANDLER_TYPE_ADMIN;
+			admin_cerver->app_error_packet_handler->cerver = admin_cerver->cerver;
+		}
+	}
 
 }
 
 // sets option to automatically delete PACKET_TYPE_APP packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 void admin_cerver_set_app_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
 
-    if (admin_cerver) admin_cerver->app_packet_handler_delete_packet = delete_packet;
+	if (admin_cerver) admin_cerver->app_packet_handler_delete_packet = delete_packet;
 
 }
 
 // sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 void admin_cerver_set_app_error_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
 
-    if (admin_cerver) admin_cerver->app_error_packet_handler_delete_packet = delete_packet;
+	if (admin_cerver) admin_cerver->app_error_packet_handler_delete_packet = delete_packet;
 
 }
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
 void admin_cerver_set_custom_handler (AdminCerver *admin_cerver, Handler *custom_handler) {
 
-    if (admin_cerver) {
-        admin_cerver->custom_packet_handler = custom_handler;
-        if (admin_cerver->custom_packet_handler) {
-            admin_cerver->custom_packet_handler->type = HANDLER_TYPE_ADMIN;
-            admin_cerver->custom_packet_handler->cerver = admin_cerver->cerver;
-        }
-    }
+	if (admin_cerver) {
+		admin_cerver->custom_packet_handler = custom_handler;
+		if (admin_cerver->custom_packet_handler) {
+			admin_cerver->custom_packet_handler->type = HANDLER_TYPE_ADMIN;
+			admin_cerver->custom_packet_handler->cerver = admin_cerver->cerver;
+		}
+	}
 
 }
 
 // sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
-// if set to false, user must delete the packets manualy 
+// if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
 void admin_cerver_set_custom_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
 
-    if (admin_cerver) admin_cerver->custom_packet_handler_delete_packet = delete_packet;
+	if (admin_cerver) admin_cerver->custom_packet_handler_delete_packet = delete_packet;
 
 }
 
 // returns the total number of handlers currently alive (ready to handle packets)
 unsigned int admin_cerver_get_n_handlers_alive (AdminCerver *admin_cerver) {
 
-    unsigned int retval = 0;
+	unsigned int retval = 0;
 
-    if (admin_cerver) {
-        pthread_mutex_lock (admin_cerver->handlers_lock);
-        retval = admin_cerver->num_handlers_alive;
-        pthread_mutex_unlock (admin_cerver->handlers_lock);
-    }
+	if (admin_cerver) {
+		pthread_mutex_lock (admin_cerver->handlers_lock);
+		retval = admin_cerver->num_handlers_alive;
+		pthread_mutex_unlock (admin_cerver->handlers_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // returns the total number of handlers currently working (handling a packet)
 unsigned int admin_cerver_get_n_handlers_working (AdminCerver *admin_cerver) {
 
-    unsigned int retval = 0;
+	unsigned int retval = 0;
 
-    if (admin_cerver) {
-        pthread_mutex_lock (admin_cerver->handlers_lock);
-        retval = admin_cerver->num_handlers_working;
-        pthread_mutex_unlock (admin_cerver->handlers_lock);
-    }
+	if (admin_cerver) {
+		pthread_mutex_lock (admin_cerver->handlers_lock);
+		retval = admin_cerver->num_handlers_working;
+		pthread_mutex_unlock (admin_cerver->handlers_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -706,9 +706,9 @@ unsigned int admin_cerver_get_n_handlers_working (AdminCerver *admin_cerver) {
 // by default, this option is turned off
 void admin_cerver_set_check_packets (AdminCerver *admin_cerver, bool check_packets) {
 
-    if (admin_cerver) {
-        admin_cerver->check_packets = check_packets;
-    }
+	if (admin_cerver) {
+		admin_cerver->check_packets = check_packets;
+	}
 
 }
 
@@ -717,17 +717,17 @@ void admin_cerver_set_check_packets (AdminCerver *admin_cerver, bool check_packe
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void admin_cerver_set_update (
-    AdminCerver *admin_cerver, 
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u8 fps
+	AdminCerver *admin_cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u8 fps
 ) {
 
-    if (admin_cerver) {
-        admin_cerver->update = update;
-        admin_cerver->update_args = update_args;
-        admin_cerver->delete_update_args = delete_update_args;
-        admin_cerver->update_ticks = fps;
-    }
+	if (admin_cerver) {
+		admin_cerver->update = update;
+		admin_cerver->update_args = update_args;
+		admin_cerver->delete_update_args = delete_update_args;
+		admin_cerver->update_ticks = fps;
+	}
 
 }
 
@@ -736,24 +736,24 @@ void admin_cerver_set_update (
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void admin_cerver_set_update_interval (
-    AdminCerver *admin_cerver, 
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u32 interval
+	AdminCerver *admin_cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u32 interval
 ) {
 
-    if (admin_cerver) {
-        admin_cerver->update_interval = update;
-        admin_cerver->update_interval_args = update_args;
-        admin_cerver->delete_update_interval_args = delete_update_args;
-        admin_cerver->update_interval_secs = interval;
-    }
+	if (admin_cerver) {
+		admin_cerver->update_interval = update;
+		admin_cerver->update_interval_args = update_args;
+		admin_cerver->delete_update_interval_args = delete_update_args;
+		admin_cerver->update_interval_secs = interval;
+	}
 
 }
 
 // returns the current number of connected admins
 u8 admin_cerver_get_current_admins (AdminCerver *admin_cerver) {
 
-    return admin_cerver ? (u8) dlist_size (admin_cerver->admins) : 0; 
+	return admin_cerver ? (u8) dlist_size (admin_cerver->admins) : 0;
 
 }
 
@@ -761,18 +761,18 @@ u8 admin_cerver_get_current_admins (AdminCerver *admin_cerver) {
 // returns 0 on success, 1 on error
 u8 admin_cerver_broadcast_to_admins (AdminCerver *admin_cerver, Packet *packet) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && packet) {
-        u8 errors = 0;
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            errors |= admin_send_packet ((Admin *) le->data, packet);
-        }
+	if (admin_cerver && packet) {
+		u8 errors = 0;
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			errors |= admin_send_packet ((Admin *) le->data, packet);
+		}
 
-        retval = errors;
-    }
+		retval = errors;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -780,39 +780,39 @@ u8 admin_cerver_broadcast_to_admins (AdminCerver *admin_cerver, Packet *packet) 
 // returns 0 on success, 1 on error
 u8 admin_cerver_broadcast_to_admins_split (AdminCerver *admin_cerver, Packet *packet) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && packet) {
-        u8 errors = 0;
+	if (admin_cerver && packet) {
+		u8 errors = 0;
 
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            errors |= admin_send_packet_split ((Admin *) le->data, packet);
-        }
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			errors |= admin_send_packet_split ((Admin *) le->data, packet);
+		}
 
-        retval = errors;
-    }
+		retval = errors;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // broadcasts a packet to all connected admins in an admin cerver using packet_send_pieces ()
 // returns 0 on success, 1 on error
-u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, Packet *packet, 
-    void **pieces, size_t *sizes, u32 n_pieces) {
+u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, Packet *packet,
+	void **pieces, size_t *sizes, u32 n_pieces) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && packet) {
-        u8 errors = 0;
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            errors |= admin_send_packet_pieces ((Admin *) le->data, packet, pieces, sizes, n_pieces);
-        }
+	if (admin_cerver && packet) {
+		u8 errors = 0;
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			errors |= admin_send_packet_pieces ((Admin *) le->data, packet, pieces, sizes, n_pieces);
+		}
 
-        retval = errors;
-    }
+		retval = errors;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -821,33 +821,33 @@ u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, Packet *p
 // returns 0 on success, 1 on error
 u8 admin_cerver_register_admin (AdminCerver *admin_cerver, Admin *admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && admin) {
-        if (!admin_cerver_poll_register_connection (
-            admin_cerver, 
-            (Connection *) dlist_start (admin->client->connections)->data
-        )) {
-            dlist_insert_after (admin_cerver->admins, dlist_end (admin_cerver->admins), admin);
+	if (admin_cerver && admin) {
+		if (!admin_cerver_poll_register_connection (
+			admin_cerver,
+			(Connection *) dlist_start (admin->client->connections)->data
+		)) {
+			dlist_insert_after (admin_cerver->admins, dlist_end (admin_cerver->admins), admin);
 
-            admin->admin_cerver = admin_cerver;
+			admin->admin_cerver = admin_cerver;
 
-            admin_cerver->stats->current_connected_admins += 1;
-            admin_cerver->stats->total_n_admins += 1;
+			admin_cerver->stats->current_connected_admins += 1;
+			admin_cerver->stats->total_n_admins += 1;
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
-                "Cerver %s ADMIN current connected admins: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+				"Cerver %s ADMIN current connected admins: %ld",
+				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+			);
+			#endif
 
-            retval = 0;     // success
-        }
-    }
+			retval = 0;     // success
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -855,32 +855,32 @@ u8 admin_cerver_register_admin (AdminCerver *admin_cerver, Admin *admin) {
 // returns 0 on success, 1 on error
 u8 admin_cerver_unregister_admin (AdminCerver *admin_cerver, Admin *admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && admin) {
-        if (dlist_remove (admin_cerver->admins, admin, NULL)) {
-            // unregister all his active connections from the poll array
-            for (ListElement *le = dlist_start (admin->client->connections); le; le = le->next) {
-                admin_cerver_poll_unregister_connection (admin_cerver, (Connection *) le->data);
-            }
+	if (admin_cerver && admin) {
+		if (dlist_remove (admin_cerver->admins, admin, NULL)) {
+			// unregister all his active connections from the poll array
+			for (ListElement *le = dlist_start (admin->client->connections); le; le = le->next) {
+				admin_cerver_poll_unregister_connection (admin_cerver, (Connection *) le->data);
+			}
 
-            admin->admin_cerver = NULL;
+			admin->admin_cerver = NULL;
 
-            admin_cerver->stats->current_connected_admins -= 1;
+			admin_cerver->stats->current_connected_admins -= 1;
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
-                "Cerver %s ADMIN current connected admins: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+				"Cerver %s ADMIN current connected admins: %ld",
+				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+			);
+			#endif
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -888,14 +888,14 @@ u8 admin_cerver_unregister_admin (AdminCerver *admin_cerver, Admin *admin) {
 // returns 0 on success, 1 on error
 u8 admin_cerver_drop_admin (AdminCerver *admin_cerver, Admin *admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && admin) {
-        admin_cerver_unregister_admin (admin_cerver, admin);
-        admin_delete (admin);
-    }
+	if (admin_cerver && admin) {
+		admin_cerver_unregister_admin (admin_cerver, admin);
+		admin_delete (admin);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -909,72 +909,72 @@ static void *admin_poll (void *cerver_ptr);
 // executes methods every tick
 static void admin_cerver_update (void *args) {
 
-    if (args) {
-        AdminCerver *admin_cerver = (AdminCerver *) args;
-        
-        #ifdef ADMIN_DEBUG
-        cerver_log_success (
-            "Cerver's %s admin_cerver_update () has started!",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
+	if (args) {
+		AdminCerver *admin_cerver = (AdminCerver *) args;
 
-        CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_args);
+		#ifdef ADMIN_DEBUG
+		cerver_log_success (
+			"Cerver's %s admin_cerver_update () has started!",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
 
-        u32 time_per_frame = 1000000 / admin_cerver->update_ticks;
-        // printf ("time per frame: %d\n", time_per_frame);
-        u32 temp = 0;
-        i32 sleep_time = 0;
-        u64 delta_time = 0;
+		CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_args);
 
-        u64 delta_ticks = 0;
-        u32 fps = 0;
-        struct timespec start = { 0 }, middle = { 0 }, end = { 0 };
+		u32 time_per_frame = 1000000 / admin_cerver->update_ticks;
+		// printf ("time per frame: %d\n", time_per_frame);
+		u32 temp = 0;
+		i32 sleep_time = 0;
+		u64 delta_time = 0;
 
-        while (admin_cerver->cerver->isRunning) {
-            clock_gettime (CLOCK_MONOTONIC_RAW, &start);
+		u64 delta_ticks = 0;
+		u32 fps = 0;
+		struct timespec start = { 0 }, middle = { 0 }, end = { 0 };
 
-            // do stuff
-            if (admin_cerver->update) admin_cerver->update (cu);
+		while (admin_cerver->cerver->isRunning) {
+			clock_gettime (CLOCK_MONOTONIC_RAW, &start);
 
-            // limit the fps
-            clock_gettime (CLOCK_MONOTONIC_RAW, &middle);
-            temp = (middle.tv_nsec - start.tv_nsec) / 1000;
-            // printf ("temp: %d\n", temp);
-            sleep_time = time_per_frame - temp;
-            // printf ("sleep time: %d\n", sleep_time);
-            if (sleep_time > 0) {
-                usleep (sleep_time);
-            } 
+			// do stuff
+			if (admin_cerver->update) admin_cerver->update (cu);
 
-            // count fps
-            clock_gettime (CLOCK_MONOTONIC_RAW, &end);
-            delta_time = (end.tv_nsec - start.tv_nsec) / 1000000;
-            delta_ticks += delta_time;
-            fps++;
-            // printf ("delta ticks: %ld\n", delta_ticks);
-            if (delta_ticks >= 1000) {
-                // printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
-                delta_ticks = 0;
-                fps = 0;
-            }
-        }
+			// limit the fps
+			clock_gettime (CLOCK_MONOTONIC_RAW, &middle);
+			temp = (middle.tv_nsec - start.tv_nsec) / 1000;
+			// printf ("temp: %d\n", temp);
+			sleep_time = time_per_frame - temp;
+			// printf ("sleep time: %d\n", sleep_time);
+			if (sleep_time > 0) {
+				usleep (sleep_time);
+			}
 
-        cerver_update_delete (cu);
+			// count fps
+			clock_gettime (CLOCK_MONOTONIC_RAW, &end);
+			delta_time = (end.tv_nsec - start.tv_nsec) / 1000000;
+			delta_ticks += delta_time;
+			fps++;
+			// printf ("delta ticks: %ld\n", delta_ticks);
+			if (delta_ticks >= 1000) {
+				// printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
+				delta_ticks = 0;
+				fps = 0;
+			}
+		}
 
-        if (admin_cerver->update_args) {
-            if (admin_cerver->delete_update_args) {
-                admin_cerver->delete_update_args (admin_cerver->update_args);
-            }
-        }
+		cerver_update_delete (cu);
 
-        #ifdef ADMIN_DEBUG
-        cerver_log_success (
-            "Cerver's %s admin_cerver_update () has ended!",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
-    }
+		if (admin_cerver->update_args) {
+			if (admin_cerver->delete_update_args) {
+				admin_cerver->delete_update_args (admin_cerver->update_args);
+			}
+		}
+
+		#ifdef ADMIN_DEBUG
+		cerver_log_success (
+			"Cerver's %s admin_cerver_update () has ended!",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
@@ -982,300 +982,300 @@ static void admin_cerver_update (void *args) {
 // executes methods every x seconds
 static void admin_cerver_update_interval (void *args) {
 
-    if (args) {
-        AdminCerver *admin_cerver = (AdminCerver *) args;
-        
-        #ifdef ADMIN_DEBUG
-        cerver_log_success (
-            "Cerver's %s admin_cerver_update_interval () has started!",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
+	if (args) {
+		AdminCerver *admin_cerver = (AdminCerver *) args;
 
-        CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_interval_args);
+		#ifdef ADMIN_DEBUG
+		cerver_log_success (
+			"Cerver's %s admin_cerver_update_interval () has started!",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
 
-        while (admin_cerver->cerver->isRunning) {
-            if (admin_cerver->update_interval) admin_cerver->update_interval (cu);
+		CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_interval_args);
 
-            sleep (admin_cerver->update_interval_secs);
-        }
+		while (admin_cerver->cerver->isRunning) {
+			if (admin_cerver->update_interval) admin_cerver->update_interval (cu);
 
-        cerver_update_delete (cu);
+			sleep (admin_cerver->update_interval_secs);
+		}
 
-        if (admin_cerver->update_interval_args) {
-            if (admin_cerver->delete_update_interval_args) {
-                admin_cerver->delete_update_interval_args (admin_cerver->update_interval_args);
-            }
-        }
+		cerver_update_delete (cu);
 
-        #ifdef ADMIN_DEBUG
-        cerver_log_success (
-            "Cerver's %s admin_cerver_update_interval () has ended!",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
-    }
+		if (admin_cerver->update_interval_args) {
+			if (admin_cerver->delete_update_interval_args) {
+				admin_cerver->delete_update_interval_args (admin_cerver->update_interval_args);
+			}
+		}
+
+		#ifdef ADMIN_DEBUG
+		cerver_log_success (
+			"Cerver's %s admin_cerver_update_interval () has ended!",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
 // inits admin cerver's internal structures & values
 static u8 admin_cerver_start_internal (AdminCerver *admin_cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver) {
-        admin_cerver->fds = (struct pollfd *) calloc (admin_cerver->max_n_fds, sizeof (struct pollfd));
-        if (admin_cerver->fds) {
-            memset (admin_cerver->fds, 0, sizeof (struct pollfd) * admin_cerver->max_n_fds);
+	if (admin_cerver) {
+		admin_cerver->fds = (struct pollfd *) calloc (admin_cerver->max_n_fds, sizeof (struct pollfd));
+		if (admin_cerver->fds) {
+			memset (admin_cerver->fds, 0, sizeof (struct pollfd) * admin_cerver->max_n_fds);
 
-            for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
-                admin_cerver->fds[i].fd = -1;
+			for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
+				admin_cerver->fds[i].fd = -1;
 
-            admin_cerver->current_n_fds = 0;
+			admin_cerver->current_n_fds = 0;
 
-            admin_cerver->poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-            pthread_mutex_init (admin_cerver->poll_lock, NULL);
+			admin_cerver->poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+			pthread_mutex_init (admin_cerver->poll_lock, NULL);
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 admin_cerver_app_handler_start (AdminCerver *admin_cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->app_packet_handler) {
-            if (!admin_cerver->app_packet_handler->direct_handle) {
-                if (!handler_start (admin_cerver->app_packet_handler)) {
-                    #ifdef ADMIN_DEBUG
-                    cerver_log_success (
-                        "Admin cerver %s app_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (admin_cerver) {
+		if (admin_cerver->app_packet_handler) {
+			if (!admin_cerver->app_packet_handler->direct_handle) {
+				if (!handler_start (admin_cerver->app_packet_handler)) {
+					#ifdef ADMIN_DEBUG
+					cerver_log_success (
+						"Admin cerver %s app_packet_handler has started!",
+						admin_cerver->cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start ADMIN cerver %s app_packet_handler!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to start ADMIN cerver %s app_packet_handler!",
+						admin_cerver->cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            #ifdef ADMIN_DEBUG
-            cerver_log_warning (
-                "Admin cerver %s does not have an app_packet_handler",
-                admin_cerver->cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef ADMIN_DEBUG
+			cerver_log_warning (
+				"Admin cerver %s does not have an app_packet_handler",
+				admin_cerver->cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 admin_cerver_app_error_handler_start (AdminCerver *admin_cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->app_error_packet_handler) {
-            if (!admin_cerver->app_error_packet_handler->direct_handle) {
-                if (!handler_start (admin_cerver->app_error_packet_handler)) {
-                    #ifdef ADMIN_DEBUG
-                    cerver_log_success (
-                        "Admin cerver %s app_error_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (admin_cerver) {
+		if (admin_cerver->app_error_packet_handler) {
+			if (!admin_cerver->app_error_packet_handler->direct_handle) {
+				if (!handler_start (admin_cerver->app_error_packet_handler)) {
+					#ifdef ADMIN_DEBUG
+					cerver_log_success (
+						"Admin cerver %s app_error_packet_handler has started!",
+						admin_cerver->cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start ADMIN cerver %s app_error_packet_handler!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to start ADMIN cerver %s app_error_packet_handler!",
+						admin_cerver->cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            #ifdef ADMIN_DEBUG
-            cerver_log_warning (
-                "Admin cerver %s does not have an app_error_packet_handler",
-                admin_cerver->cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef ADMIN_DEBUG
+			cerver_log_warning (
+				"Admin cerver %s does not have an app_error_packet_handler",
+				admin_cerver->cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 admin_cerver_custom_handler_start (AdminCerver *admin_cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->custom_packet_handler) {
-            if (!admin_cerver->custom_packet_handler->direct_handle) {
-                if (!handler_start (admin_cerver->custom_packet_handler)) {
-                    #ifdef ADMIN_DEBUG
-                    cerver_log_success (
-                        "Admin cerver %s custom_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (admin_cerver) {
+		if (admin_cerver->custom_packet_handler) {
+			if (!admin_cerver->custom_packet_handler->direct_handle) {
+				if (!handler_start (admin_cerver->custom_packet_handler)) {
+					#ifdef ADMIN_DEBUG
+					cerver_log_success (
+						"Admin cerver %s custom_packet_handler has started!",
+						admin_cerver->cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start ADMIN cerver %s custom_packet_handler!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to start ADMIN cerver %s custom_packet_handler!",
+						admin_cerver->cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            // #ifdef ADMIN_DEBUG
-            // cerver_log_warning (
-            //     "Cerver %s does not have a custom_packet_handler",
-            // 	admin_cerver->cerver->info->name->str
-            // );
-            // #endif
-        }
-    }
+		else {
+			// #ifdef ADMIN_DEBUG
+			// cerver_log_warning (
+			//     "Cerver %s does not have a custom_packet_handler",
+			// 	admin_cerver->cerver->info->name->str
+			// );
+			// #endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 admin_cerver_handlers_start (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        #ifdef ADMIN_DEBUG
-        cerver_log_debug (
-            "Initializing cerver %s admin handlers...",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
+	if (admin_cerver) {
+		#ifdef ADMIN_DEBUG
+		cerver_log_debug (
+			"Initializing cerver %s admin handlers...",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
 
-        admin_cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (admin_cerver->handlers_lock, NULL);
+		admin_cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (admin_cerver->handlers_lock, NULL);
 
-        errors |= admin_cerver_app_handler_start (admin_cerver);
+		errors |= admin_cerver_app_handler_start (admin_cerver);
 
-        errors |= admin_cerver_app_error_handler_start (admin_cerver);
+		errors |= admin_cerver_app_error_handler_start (admin_cerver);
 
-        errors |= admin_cerver_custom_handler_start (admin_cerver);
+		errors |= admin_cerver_custom_handler_start (admin_cerver);
 
-        if (!errors) {
-            #ifdef ADMIN_DEBUG
-            cerver_log_debug (
-                "Done initializing cerver %s admin handlers!",
-                admin_cerver->cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		if (!errors) {
+			#ifdef ADMIN_DEBUG
+			cerver_log_debug (
+				"Done initializing cerver %s admin handlers!",
+				admin_cerver->cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 admin_cerver_start_poll (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (!thread_create_detachable (
-            &cerver->admin_thread_id,
-            admin_poll,
-            cerver
-        )) {
-            retval = 0;		// success
-        }
+	if (cerver) {
+		if (!thread_create_detachable (
+			&cerver->admin_thread_id,
+			admin_poll,
+			cerver
+		)) {
+			retval = 0;		// success
+		}
 
-        else {
-            cerver_log_error (
-                "Failed to create admin_poll () thread in cerver %s!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"Failed to create admin_poll () thread in cerver %s!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 u8 admin_cerver_start (AdminCerver *admin_cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver) {
-        if (!admin_cerver_start_internal (admin_cerver)) {
-            if (admin_cerver->update) {
-                if (thread_create_detachable (
-                    &admin_cerver->update_thread_id,
-                    (void *(*) (void *)) admin_cerver_update,
-                    admin_cerver
-                )) {
-                    cerver_log_error (
-                        "Failed to create cerver %s ADMIN UPDATE thread!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                }
-            }
+	if (admin_cerver) {
+		if (!admin_cerver_start_internal (admin_cerver)) {
+			if (admin_cerver->update) {
+				if (thread_create_detachable (
+					&admin_cerver->update_thread_id,
+					(void *(*) (void *)) admin_cerver_update,
+					admin_cerver
+				)) {
+					cerver_log_error (
+						"Failed to create cerver %s ADMIN UPDATE thread!",
+						admin_cerver->cerver->info->name->str
+					);
+				}
+			}
 
-            if (admin_cerver->update_interval) {
-                if (thread_create_detachable (
-                    &admin_cerver->update_interval_thread_id,
-                    (void *(*) (void *)) admin_cerver_update_interval,
-                    admin_cerver
-                )) {
-                    cerver_log_error (
-                        "Failed to create cerver %s ADMIN UPDATE INTERVAL thread!",
-                        admin_cerver->cerver->info->name->str
-                    );
-                }
-            }
+			if (admin_cerver->update_interval) {
+				if (thread_create_detachable (
+					&admin_cerver->update_interval_thread_id,
+					(void *(*) (void *)) admin_cerver_update_interval,
+					admin_cerver
+				)) {
+					cerver_log_error (
+						"Failed to create cerver %s ADMIN UPDATE INTERVAL thread!",
+						admin_cerver->cerver->info->name->str
+					);
+				}
+			}
 
-            if (!admin_cerver_handlers_start (admin_cerver)) {
-                if (!admin_cerver_start_poll (admin_cerver->cerver)) {
-                    retval = 0;
-                }
-            }
+			if (!admin_cerver_handlers_start (admin_cerver)) {
+				if (!admin_cerver_start_poll (admin_cerver->cerver)) {
+					retval = 0;
+				}
+			}
 
-            else {
-                cerver_log_error (
-                    "admin_cerver_start () - failed to start cerver %s admin handlers!",
-                    admin_cerver->cerver->info->name->str
-                );
-            }
-        }
+			else {
+				cerver_log_error (
+					"admin_cerver_start () - failed to start cerver %s admin handlers!",
+					admin_cerver->cerver->info->name->str
+				);
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "admin_cerver_start () - failed to start cerver %s admin internal!",
-                admin_cerver->cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"admin_cerver_start () - failed to start cerver %s admin internal!",
+				admin_cerver->cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1285,135 +1285,135 @@ u8 admin_cerver_start (AdminCerver *admin_cerver) {
 
 static u8 admin_cerver_app_handler_destroy (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->app_packet_handler) {
-            if (!admin_cerver->app_packet_handler->direct_handle) {
-                // stop app handler
-                bsem_post_all (admin_cerver->app_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (admin_cerver) {
+		if (admin_cerver->app_packet_handler) {
+			if (!admin_cerver->app_packet_handler->direct_handle) {
+				// stop app handler
+				bsem_post_all (admin_cerver->app_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 admin_cerver_app_error_handler_destroy (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->app_error_packet_handler) {
-            if (!admin_cerver->app_error_packet_handler->direct_handle) {
-                // stop app error handler
-                bsem_post_all (admin_cerver->app_error_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (admin_cerver) {
+		if (admin_cerver->app_error_packet_handler) {
+			if (!admin_cerver->app_error_packet_handler->direct_handle) {
+				// stop app error handler
+				bsem_post_all (admin_cerver->app_error_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 admin_cerver_custom_handler_destroy (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        if (admin_cerver->custom_packet_handler) {
-            if (!admin_cerver->custom_packet_handler->direct_handle) {
-                // stop custom handler
-                bsem_post_all (admin_cerver->custom_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (admin_cerver) {
+		if (admin_cerver->custom_packet_handler) {
+			if (!admin_cerver->custom_packet_handler->direct_handle) {
+				// stop custom handler
+				bsem_post_all (admin_cerver->custom_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 // correctly destroy admin cerver's custom handlers
 static u8 admin_cerver_handlers_end (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        #ifdef ADMIN_DEBUG
-        cerver_log_debug (
-            "Stopping handlers in cerver %s admin...",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
+	if (admin_cerver) {
+		#ifdef ADMIN_DEBUG
+		cerver_log_debug (
+			"Stopping handlers in cerver %s admin...",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
 
-        errors |= admin_cerver_app_handler_destroy (admin_cerver);
+		errors |= admin_cerver_app_handler_destroy (admin_cerver);
 
-        errors |= admin_cerver_app_error_handler_destroy (admin_cerver);
+		errors |= admin_cerver_app_error_handler_destroy (admin_cerver);
 
-        errors |= admin_cerver_custom_handler_destroy (admin_cerver);
+		errors |= admin_cerver_custom_handler_destroy (admin_cerver);
 
-        // poll remaining handlers
-        while (admin_cerver->num_handlers_alive) {
-            if (admin_cerver->app_packet_handler)
-                bsem_post_all (admin_cerver->app_packet_handler->job_queue->has_jobs);
+		// poll remaining handlers
+		while (admin_cerver->num_handlers_alive) {
+			if (admin_cerver->app_packet_handler)
+				bsem_post_all (admin_cerver->app_packet_handler->job_queue->has_jobs);
 
-            if (admin_cerver->app_error_packet_handler)
-                bsem_post_all (admin_cerver->app_error_packet_handler->job_queue->has_jobs);
+			if (admin_cerver->app_error_packet_handler)
+				bsem_post_all (admin_cerver->app_error_packet_handler->job_queue->has_jobs);
 
-            if (admin_cerver->custom_packet_handler)
-                bsem_post_all (admin_cerver->custom_packet_handler->job_queue->has_jobs);
-            
-            sleep (1);
-        }
-    }
+			if (admin_cerver->custom_packet_handler)
+				bsem_post_all (admin_cerver->custom_packet_handler->job_queue->has_jobs);
 
-    return errors;
+			sleep (1);
+		}
+	}
+
+	return errors;
 
 }
 
 static u8 admin_cerver_disconnect_admins (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        if (dlist_size (admin_cerver->admins)) {
-            // send a cerver teardown packet to all clients connected to cerver
-            Packet *packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_TEARDOWN, NULL, 0);
-            if (packet) {
-                errors |= admin_cerver_broadcast_to_admins (admin_cerver, packet);
-                packet_delete (packet);
-            }
-        }
-    }
+	if (admin_cerver) {
+		if (dlist_size (admin_cerver->admins)) {
+			// send a cerver teardown packet to all clients connected to cerver
+			Packet *packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_TEARDOWN, NULL, 0);
+			if (packet) {
+				errors |= admin_cerver_broadcast_to_admins (admin_cerver, packet);
+				packet_delete (packet);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 u8 admin_cerver_end (AdminCerver *admin_cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (admin_cerver) {
-        #ifdef ADMIN_DEBUG
-        cerver_log_debug (
-            "Staring cerver %s admin teardown...",
-            admin_cerver->cerver->info->name->str
-        );
-        #endif
+	if (admin_cerver) {
+		#ifdef ADMIN_DEBUG
+		cerver_log_debug (
+			"Staring cerver %s admin teardown...",
+			admin_cerver->cerver->info->name->str
+		);
+		#endif
 
-        errors |= admin_cerver_handlers_end (admin_cerver);
+		errors |= admin_cerver_handlers_end (admin_cerver);
 
-        errors |= admin_cerver_disconnect_admins (admin_cerver);
+		errors |= admin_cerver_disconnect_admins (admin_cerver);
 
-        cerver_log_success (
-            "Cerver %s admin teardown was successful!",
-            admin_cerver->cerver->info->name->str
-        );
-    }
+		cerver_log_success (
+			"Cerver %s admin teardown was successful!",
+			admin_cerver->cerver->info->name->str
+		);
+	}
 
-    return errors;
+	return errors;
 
 }
 
@@ -1424,245 +1424,245 @@ u8 admin_cerver_end (AdminCerver *admin_cerver) {
 // handles a packet of type PACKET_TYPE_CLIENT
 static void admin_cerver_client_packet_handler (Packet *packet) {
 
-    if (packet->header) {
-        switch (packet->header->request_type) {
-            // the client is going to close its current connection
-            // but will remain in the cerver if it has another connection active
-            // if not, it will be dropped
-            case CLIENT_PACKET_TYPE_CLOSE_CONNECTION: {
-                #ifdef ADMIN_DEBUG
-                cerver_log_debug (
-                    "Admin with client %ld requested to close the connection",
-                    packet->client->id
-                );
-                #endif
+	if (packet->header) {
+		switch (packet->header->request_type) {
+			// the client is going to close its current connection
+			// but will remain in the cerver if it has another connection active
+			// if not, it will be dropped
+			case CLIENT_PACKET_TYPE_CLOSE_CONNECTION: {
+				#ifdef ADMIN_DEBUG
+				cerver_log_debug (
+					"Admin with client %ld requested to close the connection",
+					packet->client->id
+				);
+				#endif
 
-                admin_remove_connection_by_sock_fd (
-                    packet->cerver->admin,
-                    admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd),
-                    packet->connection->socket->sock_fd
-                );
-            } break;
+				admin_remove_connection_by_sock_fd (
+					packet->cerver->admin,
+					admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd),
+					packet->connection->socket->sock_fd
+				);
+			} break;
 
-            // the client is going to disconnect and will close all of its active connections
-            // so drop it from the server
-            case CLIENT_PACKET_TYPE_DISCONNECT: {
-                admin_cerver_drop_admin (
-                    packet->cerver->admin,
-                    admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd)
-                );
+			// the client is going to disconnect and will close all of its active connections
+			// so drop it from the server
+			case CLIENT_PACKET_TYPE_DISCONNECT: {
+				admin_cerver_drop_admin (
+					packet->cerver->admin,
+					admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd)
+				);
 
-                cerver_event_trigger (
-                    CERVER_EVENT_ADMIN_DISCONNECTED,
-                    packet->cerver,
-                    NULL, NULL
-                );
-            } break;
+				cerver_event_trigger (
+					CERVER_EVENT_ADMIN_DISCONNECTED,
+					packet->cerver,
+					NULL, NULL
+				);
+			} break;
 
-            default: {
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
-                    "admin_cerver_client_packet_handler () - Got an unknown client packet in cerver %s",
-                    packet->cerver->info->name->str
-                );
-                #endif
-            } break;
-        }
-    }
+			default: {
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+					"admin_cerver_client_packet_handler () - Got an unknown client packet in cerver %s",
+					packet->cerver->info->name->str
+				);
+				#endif
+			} break;
+		}
+	}
 
 }
 
 // handles a request made from the admin
 static void admin_cerver_request_packet_handler (Packet *packet) {
 
-    // TODO:
+	// TODO:
 
 }
 
 // handles an PACKET_TYPE_APP packet type
 static void admin_app_packet_handler (Packet *packet) {
 
-    if (packet->cerver->admin->app_packet_handler) {
-        if (packet->cerver->admin->app_packet_handler->direct_handle) {
-            // printf ("app_packet_handler - direct handle!\n");
-            packet->cerver->admin->app_packet_handler->handler (packet);
-            if (packet->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet);
-        }
+	if (packet->cerver->admin->app_packet_handler) {
+		if (packet->cerver->admin->app_packet_handler->direct_handle) {
+			// printf ("app_packet_handler - direct handle!\n");
+			packet->cerver->admin->app_packet_handler->handler (packet);
+			if (packet->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->cerver->admin->app_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to cerver's %s ADMIN app_packet_handler!",
-                    packet->cerver->info->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->cerver->admin->app_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to cerver's %s ADMIN app_packet_handler!",
+					packet->cerver->info->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        #ifdef ADMIN_DEBUG
-        cerver_log_warning (
-            "Cerver %s ADMIN does not have an app_packet_handler!",
-            packet->cerver->info->name->str
-        );
-        #endif
-    }
+	else {
+		#ifdef ADMIN_DEBUG
+		cerver_log_warning (
+			"Cerver %s ADMIN does not have an app_packet_handler!",
+			packet->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
 // handles an PACKET_TYPE_APP_ERROR packet type
 static void admin_app_error_packet_handler (Packet *packet) {
 
-    if (packet->cerver->admin->app_error_packet_handler) {
-        if (packet->cerver->admin->app_error_packet_handler->direct_handle) {
-            // printf ("app_error_packet_handler - direct handle!\n");
-            packet->cerver->admin->app_error_packet_handler->handler (packet);
-            if (packet->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet);
-        }
+	if (packet->cerver->admin->app_error_packet_handler) {
+		if (packet->cerver->admin->app_error_packet_handler->direct_handle) {
+			// printf ("app_error_packet_handler - direct handle!\n");
+			packet->cerver->admin->app_error_packet_handler->handler (packet);
+			if (packet->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->cerver->admin->app_error_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to cerver's %s ADMIN app_error_packet_handler!",
-                    packet->cerver->info->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->cerver->admin->app_error_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to cerver's %s ADMIN app_error_packet_handler!",
+					packet->cerver->info->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        #ifdef ADMIN_DEBUG
-        cerver_log_warning (
-            "Cerver %s ADMIN does not have an app_error_packet_handler!",
-            packet->cerver->info->name->str
-        );
-        #endif
-    }
+	else {
+		#ifdef ADMIN_DEBUG
+		cerver_log_warning (
+			"Cerver %s ADMIN does not have an app_error_packet_handler!",
+			packet->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
 // handles a PACKET_TYPE_CUSTOM packet type
 static void admin_custom_packet_handler (Packet *packet) {
 
-    if (packet->cerver->admin->custom_packet_handler) {
-        if (packet->cerver->admin->custom_packet_handler->direct_handle) {
-            // printf ("custom_packet_handler - direct handle!\n");
-            packet->cerver->admin->custom_packet_handler->handler (packet);
-            if (packet->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet);
-        }
+	if (packet->cerver->admin->custom_packet_handler) {
+		if (packet->cerver->admin->custom_packet_handler->direct_handle) {
+			// printf ("custom_packet_handler - direct handle!\n");
+			packet->cerver->admin->custom_packet_handler->handler (packet);
+			if (packet->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->cerver->admin->custom_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to cerver's %s ADMIN custom_packet_handler!",
-                    packet->cerver->info->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->cerver->admin->custom_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to cerver's %s ADMIN custom_packet_handler!",
+					packet->cerver->info->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        #ifdef ADMIN_DEBUG
-        cerver_log_warning (
-            "Cerver %s ADMIN does not have an custom_packet_handler!",
-            packet->cerver->info->name->str
-        );
-        #endif
-    }
+	else {
+		#ifdef ADMIN_DEBUG
+		cerver_log_warning (
+			"Cerver %s ADMIN does not have an custom_packet_handler!",
+			packet->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
 // handles a packet from an admin
 void admin_packet_handler (Packet *packet) {
 
-    if (packet) {
-        bool good = true;
-        if (packet->cerver->check_packets) {
-            // we expect the packet version in the packet's data
-            if (packet->data) {
-                packet->version = (PacketVersion *) packet->data_ptr;
-                packet->data_ptr += sizeof (PacketVersion);
-                good = packet_check (packet);
-            }
+	if (packet) {
+		bool good = true;
+		if (packet->cerver->check_packets) {
+			// we expect the packet version in the packet's data
+			if (packet->data) {
+				packet->version = (PacketVersion *) packet->data_ptr;
+				packet->data_ptr += sizeof (PacketVersion);
+				good = packet_check (packet);
+			}
 
-            else {
-                cerver_log_error ("admin_packet_handler () - No packet version to check!");
-                good = false;
-            }
-        }
+			else {
+				cerver_log_error ("admin_packet_handler () - No packet version to check!");
+				good = false;
+			}
+		}
 
-        if (good) {
-            switch (packet->header->packet_type) {
-                case PACKET_TYPE_CLIENT:
-                    packet->cerver->admin->stats->received_packets->n_client_packets += 1;
-                    packet->client->stats->received_packets->n_client_packets += 1;
-                    packet->connection->stats->received_packets->n_client_packets += 1; 
-                    admin_cerver_client_packet_handler (packet); 
-                    packet_delete (packet);
-                    break;
+		if (good) {
+			switch (packet->header->packet_type) {
+				case PACKET_TYPE_CLIENT:
+					packet->cerver->admin->stats->received_packets->n_client_packets += 1;
+					packet->client->stats->received_packets->n_client_packets += 1;
+					packet->connection->stats->received_packets->n_client_packets += 1;
+					admin_cerver_client_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles a request made from the admin
-                case PACKET_TYPE_REQUEST:
-                    packet->cerver->admin->stats->received_packets->n_request_packets += 1;
-                    packet->client->stats->received_packets->n_request_packets += 1;
-                    packet->connection->stats->received_packets->n_request_packets += 1; 
-                    admin_cerver_request_packet_handler (packet); 
-                    packet_delete (packet);
-                    break;
+				// handles a request made from the admin
+				case PACKET_TYPE_REQUEST:
+					packet->cerver->admin->stats->received_packets->n_request_packets += 1;
+					packet->client->stats->received_packets->n_request_packets += 1;
+					packet->connection->stats->received_packets->n_request_packets += 1;
+					admin_cerver_request_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                case PACKET_TYPE_APP:
-                    packet->cerver->admin->stats->received_packets->n_app_packets += 1;
-                    packet->client->stats->received_packets->n_app_packets += 1;
-                    packet->connection->stats->received_packets->n_app_packets += 1;
-                    admin_app_packet_handler (packet); 
-                    break;
+				case PACKET_TYPE_APP:
+					packet->cerver->admin->stats->received_packets->n_app_packets += 1;
+					packet->client->stats->received_packets->n_app_packets += 1;
+					packet->connection->stats->received_packets->n_app_packets += 1;
+					admin_app_packet_handler (packet);
+					break;
 
-                case PACKET_TYPE_APP_ERROR: 
-                    packet->cerver->admin->stats->received_packets->n_app_error_packets += 1;
-                    packet->client->stats->received_packets->n_app_error_packets += 1;
-                    packet->connection->stats->received_packets->n_app_error_packets += 1;
-                    admin_app_error_packet_handler (packet); 
-                    break;
+				case PACKET_TYPE_APP_ERROR:
+					packet->cerver->admin->stats->received_packets->n_app_error_packets += 1;
+					packet->client->stats->received_packets->n_app_error_packets += 1;
+					packet->connection->stats->received_packets->n_app_error_packets += 1;
+					admin_app_error_packet_handler (packet);
+					break;
 
-                case PACKET_TYPE_CUSTOM: 
-                    packet->cerver->admin->stats->received_packets->n_custom_packets += 1;
-                    packet->client->stats->received_packets->n_custom_packets += 1;
-                    packet->connection->stats->received_packets->n_custom_packets += 1;
-                    admin_custom_packet_handler (packet); 
-                    break;
+				case PACKET_TYPE_CUSTOM:
+					packet->cerver->admin->stats->received_packets->n_custom_packets += 1;
+					packet->client->stats->received_packets->n_custom_packets += 1;
+					packet->connection->stats->received_packets->n_custom_packets += 1;
+					admin_custom_packet_handler (packet);
+					break;
 
-                default: {
-                    packet->cerver->admin->stats->received_packets->n_bad_packets += 1;
-                    packet->client->stats->received_packets->n_bad_packets += 1;
-                    packet->connection->stats->received_packets->n_bad_packets += 1;
-                    #ifdef ADMIN_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_PACKET,
-                        "Got a packet of unknown type in cerver %s admin handler", 
-                        packet->cerver->info->name->str
-                    );
-                    #endif
-                    packet_delete (packet);
-                } break;
-            }
-        }
-    }
+				default: {
+					packet->cerver->admin->stats->received_packets->n_bad_packets += 1;
+					packet->client->stats->received_packets->n_bad_packets += 1;
+					packet->connection->stats->received_packets->n_bad_packets += 1;
+					#ifdef ADMIN_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+						"Got a packet of unknown type in cerver %s admin handler",
+						packet->cerver->info->name->str
+					);
+					#endif
+					packet_delete (packet);
+				} break;
+			}
+		}
+	}
 
 }
 
@@ -1673,25 +1673,25 @@ void admin_packet_handler (Packet *packet) {
 // get a free index in the admin cerver poll fds array
 static i32 admin_cerver_poll_get_free_idx (AdminCerver *admin_cerver) {
 
-    if (admin_cerver) {
-        for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
-            if (admin_cerver->fds[i].fd == -1) return i;
+	if (admin_cerver) {
+		for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
+			if (admin_cerver->fds[i].fd == -1) return i;
 
-    }
-    
-    return -1;
+	}
+
+	return -1;
 
 }
 
 // get the idx of the connection sock fd in the admin cerver poll fds
 static i32 admin_cerver_poll_get_idx_by_sock_fd (AdminCerver *admin_cerver, i32 sock_fd) {
 
-    if (admin_cerver) {
-        for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
-            if (admin_cerver->fds[i].fd == sock_fd) return i;
-    }
+	if (admin_cerver) {
+		for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
+			if (admin_cerver->fds[i].fd == sock_fd) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
@@ -1699,53 +1699,53 @@ static i32 admin_cerver_poll_get_idx_by_sock_fd (AdminCerver *admin_cerver, i32 
 // returns 0 on success, 1 on error
 u8 admin_cerver_poll_register_connection (AdminCerver *admin_cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver && connection) {
-        pthread_mutex_lock (admin_cerver->poll_lock);
+	if (admin_cerver && connection) {
+		pthread_mutex_lock (admin_cerver->poll_lock);
 
-        i32 idx = admin_cerver_poll_get_free_idx (admin_cerver);
-        if (idx >= 0) {
-            admin_cerver->fds[idx].fd = connection->socket->sock_fd;
-            admin_cerver->fds[idx].events = POLLIN;
-            admin_cerver->current_n_fds++;
+		i32 idx = admin_cerver_poll_get_free_idx (admin_cerver);
+		if (idx >= 0) {
+			admin_cerver->fds[idx].fd = connection->socket->sock_fd;
+			admin_cerver->fds[idx].events = POLLIN;
+			admin_cerver->current_n_fds++;
 
-            admin_cerver->stats->current_connections++;
-            admin_cerver->stats->total_admin_connections++;
+			admin_cerver->stats->current_connections++;
+			admin_cerver->stats->total_admin_connections++;
 
-            #ifdef ADMIN_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
-                "Added sock fd <%d> to cerver %s ADMIN poll, idx: %i", 
-                connection->socket->sock_fd, admin_cerver->cerver->info->name->str, idx
-            );
-            #endif
+			#ifdef ADMIN_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+				"Added sock fd <%d> to cerver %s ADMIN poll, idx: %i",
+				connection->socket->sock_fd, admin_cerver->cerver->info->name->str, idx
+			);
+			#endif
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
-                "Cerver %s ADMIN current connections: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+				"Cerver %s ADMIN current connections: %ld",
+				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+			);
+			#endif
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else if (idx < 0) {
-            #ifdef ADMIN_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
-                "Cerver %s ADMIN poll is full!", 
-                admin_cerver->cerver->info->name->str
-            );
-            #endif
-        }
+		else if (idx < 0) {
+			#ifdef ADMIN_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+				"Cerver %s ADMIN poll is full!",
+				admin_cerver->cerver->info->name->str
+			);
+			#endif
+		}
 
-        pthread_mutex_unlock (admin_cerver->poll_lock);
-    }
+		pthread_mutex_unlock (admin_cerver->poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1753,52 +1753,52 @@ u8 admin_cerver_poll_register_connection (AdminCerver *admin_cerver, Connection 
 // returns 0 on success, 1 on error
 u8 admin_cerver_poll_unregister_sock_fd (AdminCerver *admin_cerver, const i32 sock_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (admin_cerver) {
-        pthread_mutex_lock (admin_cerver->poll_lock);
+	if (admin_cerver) {
+		pthread_mutex_lock (admin_cerver->poll_lock);
 
-        i32 idx = admin_cerver_poll_get_idx_by_sock_fd (admin_cerver, sock_fd);
-        if (idx >= 0) {
-            admin_cerver->fds[idx].fd = -1;
-            admin_cerver->fds[idx].events = -1;
-            admin_cerver->current_n_fds--;
+		i32 idx = admin_cerver_poll_get_idx_by_sock_fd (admin_cerver, sock_fd);
+		if (idx >= 0) {
+			admin_cerver->fds[idx].fd = -1;
+			admin_cerver->fds[idx].events = -1;
+			admin_cerver->current_n_fds--;
 
-            admin_cerver->stats->current_connections--;
+			admin_cerver->stats->current_connections--;
 
-            #ifdef ADMIN_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
-                "Removed sock fd <%d> from cerver %s ADMIN poll, idx: %d",
-                sock_fd, admin_cerver->cerver->info->name->str, idx
-            );
-            #endif
+			#ifdef ADMIN_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+				"Removed sock fd <%d> from cerver %s ADMIN poll, idx: %d",
+				sock_fd, admin_cerver->cerver->info->name->str, idx
+			);
+			#endif
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
-                "Cerver %s ADMIN current connections: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+				"Cerver %s ADMIN current connections: %ld",
+				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+			);
+			#endif
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            // #ifdef ADMIN_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
-                "Sock fd <%d> was NOT found in cerver %s ADMIN poll!",
-                sock_fd, admin_cerver->cerver->info->name->str
-            );
-            // #endif
-        }
+		else {
+			// #ifdef ADMIN_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+				"Sock fd <%d> was NOT found in cerver %s ADMIN poll!",
+				sock_fd, admin_cerver->cerver->info->name->str
+			);
+			// #endif
+		}
 
-        pthread_mutex_unlock (admin_cerver->poll_lock);
-    }
+		pthread_mutex_unlock (admin_cerver->poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1806,143 +1806,143 @@ u8 admin_cerver_poll_unregister_sock_fd (AdminCerver *admin_cerver, const i32 so
 // returns 0 on success, 1 on error
 static u8 admin_cerver_poll_unregister_connection (AdminCerver *admin_cerver, Connection *connection) {
 
-    return (admin_cerver && connection) ?
-        admin_cerver_poll_unregister_sock_fd (admin_cerver, connection->socket->sock_fd) : 1;
+	return (admin_cerver && connection) ?
+		admin_cerver_poll_unregister_sock_fd (admin_cerver, connection->socket->sock_fd) : 1;
 
 }
 
 static inline void admin_poll_handle_actual (Cerver *cerver, const u32 idx, CerverReceive *cr) {
 
-    switch (cerver->admin->fds[idx].revents) {
-        // A connection setup has been completed or new data arrived
-        case POLLIN: {
-            // printf ("admin_poll_handle () - Receive fd: %d\n", cerver->admin->fds[idx].fd);
-                
-            // if (cerver->thpool) {
-                // pthread_mutex_lock (socket->mutex);
+	switch (cerver->admin->fds[idx].revents) {
+		// A connection setup has been completed or new data arrived
+		case POLLIN: {
+			// printf ("admin_poll_handle () - Receive fd: %d\n", cerver->admin->fds[idx].fd);
 
-                // handle received packets using multiple threads
-                // if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
-                //     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!", 
-                //         cerver->info->name->str);
-                //     if (s) {
-                //         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                //         free (s);
-                //     }
-                // }
+			// if (cerver->thpool) {
+				// pthread_mutex_lock (socket->mutex);
 
-                // 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
-                // and the received buffer handler method is the one that is called 
-                // inside the thread pool - using this method we were able to get a correct behaviour
-                // however, we still may have room form improvement as we original though ->
-                // by performing reading also inside the thpool
-                // cerver_receive (cr);
+				// handle received packets using multiple threads
+				// if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
+				//     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!",
+				//         cerver->info->name->str);
+				//     if (s) {
+				//         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
+				//         free (s);
+				//     }
+				// }
 
-                // pthread_mutex_unlock (socket->mutex);
-            // }
+				// 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
+				// and the received buffer handler method is the one that is called
+				// inside the thread pool - using this method we were able to get a correct behaviour
+				// however, we still may have room form improvement as we original though ->
+				// by performing reading also inside the thpool
+				// cerver_receive (cr);
 
-            // else {
-                // handle all received packets in the same thread
-                cerver_receive (cr);
-            // }
-        } break;
+				// pthread_mutex_unlock (socket->mutex);
+			// }
 
-        default: {
-            if (cerver->admin->fds[idx].revents != 0) {
-                // handle as failed any other signal
-                // to avoid hanging up at 100% or getting a segfault
-                cerver_switch_receive_handle_failed (cr);
-            }
-        } break;
-    }
+			// else {
+				// handle all received packets in the same thread
+				cerver_receive (cr);
+			// }
+		} break;
+
+		default: {
+			if (cerver->admin->fds[idx].revents != 0) {
+				// handle as failed any other signal
+				// to avoid hanging up at 100% or getting a segfault
+				cerver_switch_receive_handle_failed (cr);
+			}
+		} break;
+	}
 
 }
 
 static inline void admin_poll_handle (Cerver *cerver) {
 
-    if (cerver) {
-        pthread_mutex_lock (cerver->admin->poll_lock);
+	if (cerver) {
+		pthread_mutex_lock (cerver->admin->poll_lock);
 
-        // one or more fd(s) are readable, need to determine which ones they are
-        for (u32 idx = 0; idx < cerver->admin->max_n_fds; idx++) {
-            if (cerver->admin->fds[idx].fd != -1) {
-                CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_ADMIN, cerver, cerver->admin->fds[idx].fd);
-                if (cr) {
-                    admin_poll_handle_actual (cerver, idx, cr);
-                }
-            }
-        }
+		// one or more fd(s) are readable, need to determine which ones they are
+		for (u32 idx = 0; idx < cerver->admin->max_n_fds; idx++) {
+			if (cerver->admin->fds[idx].fd != -1) {
+				CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_ADMIN, cerver, cerver->admin->fds[idx].fd);
+				if (cr) {
+					admin_poll_handle_actual (cerver, idx, cr);
+				}
+			}
+		}
 
-        pthread_mutex_unlock (cerver->admin->poll_lock);
-    }
+		pthread_mutex_unlock (cerver->admin->poll_lock);
+	}
 
 }
 
 // handles packets from the admin clients
 static void *admin_poll (void *cerver_ptr) {
 
-    if (cerver_ptr) {
-        Cerver *cerver = (Cerver *) cerver_ptr;
-        AdminCerver *admin_cerver = cerver->admin;
+	if (cerver_ptr) {
+		Cerver *cerver = (Cerver *) cerver_ptr;
+		AdminCerver *admin_cerver = cerver->admin;
 
-        cerver_log (
-            LOG_TYPE_SUCCESS, LOG_TYPE_ADMIN,
-            "Cerver %s ADMIN poll has started!",
-            cerver->info->name->str
-        );
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_ADMIN,
+			"Cerver %s ADMIN poll has started!",
+			cerver->info->name->str
+		);
 
-        char *thread_name = c_string_create ("%s-admin", cerver->info->name->str);
-        if (thread_name) {
-            thread_set_name (thread_name);
-            free (thread_name);
-        }
+		char *thread_name = c_string_create ("%s-admin", cerver->info->name->str);
+		if (thread_name) {
+			thread_set_name (thread_name);
+			free (thread_name);
+		}
 
-        int poll_retval = 0;
-        while (cerver->isRunning) {
-            poll_retval = poll (
-                admin_cerver->fds,
-                admin_cerver->max_n_fds,
-                admin_cerver->poll_timeout
-            );
+		int poll_retval = 0;
+		while (cerver->isRunning) {
+			poll_retval = poll (
+				admin_cerver->fds,
+				admin_cerver->max_n_fds,
+				admin_cerver->poll_timeout
+			);
 
-            switch (poll_retval) {
-                case -1: {
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
-                        "Cerver %s ADMIN poll has failed!",
-                        cerver->info->name->str
-                    );
+			switch (poll_retval) {
+				case -1: {
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+						"Cerver %s ADMIN poll has failed!",
+						cerver->info->name->str
+					);
 
-                    perror ("Error");
-                    cerver->isRunning = false;
-                } break;
+					perror ("Error");
+					cerver->isRunning = false;
+				} break;
 
-                case 0: {
-                    // #ifdef ADMIN_DEBUG
-                    // cerver_log (
-                    //     LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
-                    //     "Cerver %s ADMIN poll timeout", cerver->info->name->str
-                    // );
-                    // #endif
-                } break;
+				case 0: {
+					// #ifdef ADMIN_DEBUG
+					// cerver_log (
+					//     LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+					//     "Cerver %s ADMIN poll timeout", cerver->info->name->str
+					// );
+					// #endif
+				} break;
 
-                default: {
-                    admin_poll_handle (cerver);
-                } break;
-            }
-        }
+				default: {
+					admin_poll_handle (cerver);
+				} break;
+			}
+		}
 
-        #ifdef ADMIN_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
-            "Cerver %s ADMIN poll has stopped!", cerver->info->name->str
-        );
-        #endif
-    }
+		#ifdef ADMIN_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+			"Cerver %s ADMIN poll has stopped!", cerver->info->name->str
+		);
+		#endif
+	}
 
-    else cerver_log (LOG_TYPE_ERROR, LOG_TYPE_ADMIN, "Can't handle admins on a NULL cerver!");
+	else cerver_log (LOG_TYPE_ERROR, LOG_TYPE_ADMIN, "Can't handle admins on a NULL cerver!");
 
-    return NULL;
+	return NULL;
 
 }
 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -92,27 +92,27 @@ static void admin_cerver_packet_send_update_stats (AdminCerverStats *stats,
     stats->total_bytes_sent += sent;
 
     switch (packet_type) {
-        case CERVER_PACKET: stats->sent_packets->n_cerver_packets += 1; break;
+        case PACKET_TYPE_NONE: break;
 
-        case CLIENT_PACKET: break;
+        case PACKET_TYPE_CERVER: stats->sent_packets->n_cerver_packets += 1; break;
 
-        case ERROR_PACKET: stats->sent_packets->n_error_packets += 1; break;
+        case PACKET_TYPE_CLIENT: break;
 
-        case AUTH_PACKET: stats->sent_packets->n_auth_packets += 1; break;
+        case PACKET_TYPE_ERROR: stats->sent_packets->n_error_packets += 1; break;
 
-        case REQUEST_PACKET: stats->sent_packets->n_request_packets += 1; break;
+        case PACKET_TYPE_REQUEST: stats->sent_packets->n_request_packets += 1; break;
 
-        case GAME_PACKET: stats->sent_packets->n_game_packets += 1; break;
+        case PACKET_TYPE_AUTH: stats->sent_packets->n_auth_packets += 1; break;
 
-        case APP_PACKET: stats->sent_packets->n_app_packets += 1; break;
+        case PACKET_TYPE_GAME: stats->sent_packets->n_game_packets += 1; break;
 
-        case APP_ERROR_PACKET: stats->sent_packets->n_app_error_packets += 1; break;
+        case PACKET_TYPE_APP: stats->sent_packets->n_app_packets += 1; break;
 
-        case CUSTOM_PACKET: stats->sent_packets->n_custom_packets += 1; break;
+        case PACKET_TYPE_APP_ERROR: stats->sent_packets->n_app_error_packets += 1; break;
 
-        case TEST_PACKET: stats->sent_packets->n_test_packets += 1; break;
+        case PACKET_TYPE_CUSTOM: stats->sent_packets->n_custom_packets += 1; break;
 
-        case DONT_CHECK_TYPE: break;
+        case PACKET_TYPE_TEST: stats->sent_packets->n_test_packets += 1; break;
 
         default: stats->sent_packets->n_unknown_packets += 1; break;
     }
@@ -125,39 +125,39 @@ static void admin_cerver_packet_send_update_stats (AdminCerverStats *stats,
 
 Admin *admin_new (void) {
 
-	Admin *admin = (Admin *) malloc (sizeof (Admin));
-	if (admin) {
+    Admin *admin = (Admin *) malloc (sizeof (Admin));
+    if (admin) {
         admin->admin_cerver = NULL;
 
-		admin->id = NULL;
+        admin->id = NULL;
 
-		admin->client = NULL;
+        admin->client = NULL;
 
-		admin->data = NULL;
-		admin->delete_data = NULL;
+        admin->data = NULL;
+        admin->delete_data = NULL;
 
-		admin->bad_packets = 0;
-	}
+        admin->bad_packets = 0;
+    }
 
-	return admin;
+    return admin;
 
 }
 
 void admin_delete (void *admin_ptr) {
 
-	if (admin_ptr) {
-		Admin *admin = (Admin *) admin_ptr;
+    if (admin_ptr) {
+        Admin *admin = (Admin *) admin_ptr;
 
-		str_delete (admin->id);
+        str_delete (admin->id);
 
-		client_delete (admin->client);
+        client_delete (admin->client);
 
-		if (admin->data) {
-			if (admin->delete_data) admin->delete_data (admin->data);
-		}
+        if (admin->data) {
+            if (admin->delete_data) admin->delete_data (admin->data);
+        }
 
-		free (admin);
-	}
+        free (admin);
+    }
 
 }
 
@@ -176,34 +176,34 @@ Admin *admin_create (void) {
 
 Admin *admin_create_with_client (Client *client) {
 
-	Admin *admin = NULL;
+    Admin *admin = NULL;
 
-	if (client) {
-		admin = admin_create ();
-		if (admin) admin->client = client;
-	}
+    if (client) {
+        admin = admin_create ();
+        if (admin) admin->client = client;
+    }
 
-	return admin;
+    return admin;
 
 }
 
 int admin_comparator_by_id (const void *a, const void *b) {
 
-	if (a && b) return strcmp (((Admin *) a)->id->str, ((Admin *) b)->id->str);
+    if (a && b) return strcmp (((Admin *) a)->id->str, ((Admin *) b)->id->str);
 
-	else if (a && !b) return -1;
-	else if (!a && b) return 1;
-	return 0;
+    else if (a && !b) return -1;
+    else if (!a && b) return 1;
+    return 0;
 
 }
 
 // sets dedicated admin data and a way to delete it, if NULL, it won't be deleted
 void admin_set_data (Admin *admin, void *data, Action delete_data) {
 
-	if (admin) {
-		admin->data = data;
-		admin->delete_data = delete_data;
-	}
+    if (admin) {
+        admin->data = data;
+        admin->delete_data = delete_data;
+    }
 
 }
 
@@ -229,29 +229,29 @@ static Connection *admin_connection_get_by_sock_fd (Admin *admin, const i32 sock
 // gets an admin by a matching connection in its client with the specified sock fd
 Admin *admin_get_by_sock_fd (AdminCerver *admin_cerver, const i32 sock_fd) {
 
-	Admin *retval = NULL;
+    Admin *retval = NULL;
 
-	if (admin_cerver) {
-		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+    if (admin_cerver) {
+        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
             if (admin_connection_get_by_sock_fd ((Admin *) le->data, sock_fd)) {
                 retval = (Admin *) le->data;
                 break;
             }
-		}
-	}
+        }
+    }
 
-	return retval;
+    return retval;
 
 }
 
 // gets an admin by a matching client's session id
 Admin *admin_get_by_session_id (AdminCerver *admin_cerver, const char *session_id) {
 
-	Admin *retval = NULL;
+    Admin *retval = NULL;
 
-	if (admin_cerver) {
+    if (admin_cerver) {
         Admin *admin = NULL;
-		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
             admin = (Admin *) le->data;
             if (admin->client->session_id) {
                 if (!strcmp (admin->client->session_id->str, session_id)) {
@@ -259,10 +259,10 @@ Admin *admin_get_by_session_id (AdminCerver *admin_cerver, const char *session_i
                     break;
                 }
             }
-		}
-	}
+        }
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -278,13 +278,12 @@ u8 admin_remove_connection_by_sock_fd (AdminCerver *admin_cerver, Admin *admin, 
         switch (admin->client->connections->size) {
             case 0: {
                 #ifdef ADMIN_DEBUG
-                char *s = c_string_create ("admin_remove_connection_by_sock_fd () - Admin client with id " 
+                cerver_log (
+                    LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+                    "admin_remove_connection_by_sock_fd () - Admin client with id " 
                     "%ld does not have ANY connection - removing him from cerver...",
-                    admin->client->id);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_ADMIN, s);
-                    free (s);
-                }
+                    admin->client->id
+                );
                 #endif
                 
                 admin_cerver_unregister_admin (admin_cerver, admin);
@@ -343,13 +342,12 @@ u8 admin_remove_connection_by_sock_fd (AdminCerver *admin_cerver, Admin *admin, 
 
                 else {
                     #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("admin_remove_connection_by_sock_fd () - Admin client with id " 
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+                        "admin_remove_connection_by_sock_fd () - Admin client with id " 
                         "%ld does not have a connection related to sock fd %d",
-                        admin->client->id, sock_fd);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_ADMIN, s);
-                        free (s);
-                    }
+                        admin->client->id, sock_fd
+                    );
                     #endif
                 }
             } break;
@@ -364,10 +362,10 @@ u8 admin_remove_connection_by_sock_fd (AdminCerver *admin_cerver, Admin *admin, 
 // returns 0 on success, 1 on error
 u8 admin_send_packet (Admin *admin, Packet *packet) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin && packet) {
-		// printf (
+    if (admin && packet) {
+        // printf (
         //     "admin client: %ld -- sock fd: %d\n", 
         //     admin->client->id, 
         //     ((Connection *) dlist_start (admin->client->connections))->socket->sock_fd
@@ -393,9 +391,9 @@ u8 admin_send_packet (Admin *admin, Packet *packet) {
         else {
             cerver_log_error ("Failed to send packet to admin!");
         }
-	}
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -403,15 +401,15 @@ u8 admin_send_packet (Admin *admin, Packet *packet) {
 // returns 0 on success, 1 on error
 u8 admin_send_packet_split (Admin *admin, Packet *packet) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin && packet) {
-		size_t sent = 0;
+    if (admin && packet) {
+        size_t sent = 0;
         if (!packet_send_to_split (
             packet, &sent,
             NULL,
             admin->client, 
-			(Connection *) dlist_start (admin->client->connections)->data,
+            (Connection *) dlist_start (admin->client->connections)->data,
             NULL
         )) {
             // printf ("admin_send_packet_split () - Sent to admin: %ld\n", sent);
@@ -424,9 +422,9 @@ u8 admin_send_packet_split (Admin *admin, Packet *packet) {
         else {
             cerver_log_error ("admin_send_packet_split () - Failed to send packet!");
         } 
-	}
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -435,9 +433,9 @@ u8 admin_send_packet_split (Admin *admin, Packet *packet) {
 u8 admin_send_packet_pieces (Admin *admin, Packet *packet,
     void **pieces, size_t *sizes, u32 n_pieces) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin && packet) {
+    if (admin && packet) {
         packet_set_network_values (
             packet, 
             NULL, 
@@ -462,9 +460,9 @@ u8 admin_send_packet_pieces (Admin *admin, Packet *packet,
         else {
             cerver_log_error ("admin_send_packet_in_pieces () - Failed to send packet!");
         }
-	}
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -474,35 +472,35 @@ u8 admin_send_packet_pieces (Admin *admin, Packet *packet,
 
 AdminCerver *admin_cerver_new (void) {
 
-	AdminCerver *admin_cerver = (AdminCerver *) malloc (sizeof (AdminCerver));
-	if (admin_cerver) {
-		admin_cerver->cerver = NULL;
+    AdminCerver *admin_cerver = (AdminCerver *) malloc (sizeof (AdminCerver));
+    if (admin_cerver) {
+        admin_cerver->cerver = NULL;
 
-		admin_cerver->admins = NULL;
+        admin_cerver->admins = NULL;
 
         admin_cerver->authenticate = NULL;
 
-		admin_cerver->max_admins = DEFAULT_MAX_ADMINS;
-		admin_cerver->max_admin_connections = DEFAULT_MAX_ADMIN_CONNECTIONS;
+        admin_cerver->max_admins = DEFAULT_MAX_ADMINS;
+        admin_cerver->max_admin_connections = DEFAULT_MAX_ADMIN_CONNECTIONS;
 
-		admin_cerver->n_bad_packets_limit = DEFAULT_N_BAD_PACKETS_LIMIT;
+        admin_cerver->n_bad_packets_limit = DEFAULT_N_BAD_PACKETS_LIMIT;
 
-		admin_cerver->fds = NULL;
-		admin_cerver->max_n_fds = DEFAULT_ADMIN_MAX_N_FDS;
-		admin_cerver->current_n_fds = 0;
-		admin_cerver->poll_timeout = DEFAULT_ADMIN_POLL_TIMEOUT;
+        admin_cerver->fds = NULL;
+        admin_cerver->max_n_fds = DEFAULT_ADMIN_MAX_N_FDS;
+        admin_cerver->current_n_fds = 0;
+        admin_cerver->poll_timeout = DEFAULT_ADMIN_POLL_TIMEOUT;
 
-		admin_cerver->app_packet_handler = NULL;
-		admin_cerver->app_error_packet_handler = NULL;
-		admin_cerver->custom_packet_handler = NULL;
+        admin_cerver->app_packet_handler = NULL;
+        admin_cerver->app_error_packet_handler = NULL;
+        admin_cerver->custom_packet_handler = NULL;
 
-		admin_cerver->num_handlers_alive = 0;
-		admin_cerver->num_handlers_working = 0;
-		admin_cerver->handlers_lock = NULL;
+        admin_cerver->num_handlers_alive = 0;
+        admin_cerver->num_handlers_working = 0;
+        admin_cerver->handlers_lock = NULL;
 
-		admin_cerver->app_packet_handler_delete_packet = true;
-		admin_cerver->app_error_packet_handler_delete_packet = true;
-		admin_cerver->custom_packet_handler_delete_packet = true;
+        admin_cerver->app_packet_handler_delete_packet = true;
+        admin_cerver->app_error_packet_handler_delete_packet = true;
+        admin_cerver->custom_packet_handler_delete_packet = true;
 
         admin_cerver->update_thread_id = 0;
         admin_cerver->update = NULL;
@@ -516,51 +514,51 @@ AdminCerver *admin_cerver_new (void) {
         admin_cerver->delete_update_interval_args = NULL;
         admin_cerver->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
 
-		admin_cerver->stats = NULL;
-	}
+        admin_cerver->stats = NULL;
+    }
 
-	return admin_cerver;
+    return admin_cerver;
 
 }
 
 void admin_cerver_delete (AdminCerver *admin_cerver) {
 
-	if (admin_cerver) {
-		dlist_delete (admin_cerver->admins);
+    if (admin_cerver) {
+        dlist_delete (admin_cerver->admins);
 
-		if (admin_cerver->fds) free (admin_cerver->fds);
+        if (admin_cerver->fds) free (admin_cerver->fds);
 
         if (admin_cerver->poll_lock) {
             pthread_mutex_destroy (admin_cerver->poll_lock);
             free (admin_cerver->poll_lock);
         }
 
-		handler_delete (admin_cerver->app_packet_handler);
+        handler_delete (admin_cerver->app_packet_handler);
         handler_delete (admin_cerver->app_error_packet_handler);
         handler_delete (admin_cerver->custom_packet_handler);
 
-		if (admin_cerver->handlers_lock) {
+        if (admin_cerver->handlers_lock) {
             pthread_mutex_destroy (admin_cerver->handlers_lock);
             free (admin_cerver->handlers_lock);
         }
 
-		admin_cerver_stats_delete (admin_cerver->stats);
+        admin_cerver_stats_delete (admin_cerver->stats);
 
-		free (admin_cerver);
-	}
+        free (admin_cerver);
+    }
 
 }
 
 AdminCerver *admin_cerver_create (void) {
 
-	AdminCerver *admin_cerver = admin_cerver_new ();
-	if (admin_cerver) {
-		admin_cerver->admins = dlist_init (admin_delete, admin_comparator_by_id);
+    AdminCerver *admin_cerver = admin_cerver_new ();
+    if (admin_cerver) {
+        admin_cerver->admins = dlist_init (admin_delete, admin_comparator_by_id);
 
-		admin_cerver->stats = admin_cerver_stats_new ();
-	}
+        admin_cerver->stats = admin_cerver_stats_new ();
+    }
 
-	return admin_cerver;
+    return admin_cerver;
 
 }
 
@@ -575,14 +573,14 @@ void admin_cerver_set_authenticate (AdminCerver *admin_cerver, delegate authenti
 // sets the max numbers of admins allowed at any given time
 void admin_cerver_set_max_admins (AdminCerver *admin_cerver, u8 max_admins) {
 
-	if (admin_cerver) admin_cerver->max_admins = max_admins;
+    if (admin_cerver) admin_cerver->max_admins = max_admins;
 
 }
 
 // sets the max number of connections allowed per admin
 void admin_cerver_set_max_admin_connections (AdminCerver *admin_cerver, u8 max_admin_connections) {
 
-	if (admin_cerver) admin_cerver->max_admin_connections = max_admin_connections;
+    if (admin_cerver) admin_cerver->max_admin_connections = max_admin_connections;
 
 }
 
@@ -592,27 +590,27 @@ void admin_cerver_set_max_admin_connections (AdminCerver *admin_cerver, u8 max_a
 // -1 to use defaults (5 and 20)
 void admin_cerver_set_bad_packets_limit (AdminCerver *admin_cerver, i32 n_bad_packets_limit) {
 
-	if (admin_cerver) {
-		admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ? n_bad_packets_limit : DEFAULT_N_BAD_PACKETS_LIMIT;
-	}
+    if (admin_cerver) {
+        admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ? n_bad_packets_limit : DEFAULT_N_BAD_PACKETS_LIMIT;
+    }
 
 }
 
 // sets the max number of poll fds for the admin cerver
 void admin_cerver_set_max_fds (AdminCerver *admin_cerver, u32 max_n_fds) {
 
-	if (admin_cerver) admin_cerver->max_n_fds = max_n_fds;
+    if (admin_cerver) admin_cerver->max_n_fds = max_n_fds;
 
 }
 
 // sets a custom poll time out to use for admins
 void admin_cerver_set_poll_timeout (AdminCerver *admin_cerver, u32 poll_timeout) {
 
-	if (admin_cerver) admin_cerver->poll_timeout = poll_timeout;
+    if (admin_cerver) admin_cerver->poll_timeout = poll_timeout;
 
 }
 
-// sets customs APP_PACKET and APP_ERROR_PACKET packet types handlers
+// sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 void admin_cerver_set_app_handlers (AdminCerver *admin_cerver, Handler *app_handler, Handler *app_error_handler) {
 
     if (admin_cerver) {
@@ -631,7 +629,7 @@ void admin_cerver_set_app_handlers (AdminCerver *admin_cerver, Handler *app_hand
 
 }
 
-// sets option to automatically delete APP_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_APP packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 void admin_cerver_set_app_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
@@ -640,7 +638,7 @@ void admin_cerver_set_app_handler_delete (AdminCerver *admin_cerver, bool delete
 
 }
 
-// sets option to automatically delete APP_ERROR_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 void admin_cerver_set_app_error_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
@@ -649,7 +647,7 @@ void admin_cerver_set_app_error_handler_delete (AdminCerver *admin_cerver, bool 
 
 }
 
-// sets a CUSTOM_PACKET packet type handler
+// sets a PACKET_TYPE_CUSTOM packet type handler
 void admin_cerver_set_custom_handler (AdminCerver *admin_cerver, Handler *custom_handler) {
 
     if (admin_cerver) {
@@ -662,7 +660,7 @@ void admin_cerver_set_custom_handler (AdminCerver *admin_cerver, Handler *custom
 
 }
 
-// sets option to automatically delete CUSTOM_PACKET packets after use
+// sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
 // if set to false, user must delete the packets manualy 
 // by the default, packets are deleted by cerver
 void admin_cerver_set_custom_handler_delete (AdminCerver *admin_cerver, bool delete_packet) {
@@ -763,18 +761,18 @@ u8 admin_cerver_get_current_admins (AdminCerver *admin_cerver) {
 // returns 0 on success, 1 on error
 u8 admin_cerver_broadcast_to_admins (AdminCerver *admin_cerver, Packet *packet) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin_cerver && packet) {
-		u8 errors = 0;
-		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-			errors |= admin_send_packet ((Admin *) le->data, packet);
-		}
+    if (admin_cerver && packet) {
+        u8 errors = 0;
+        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+            errors |= admin_send_packet ((Admin *) le->data, packet);
+        }
 
-		retval = errors;
-	}
+        retval = errors;
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -782,19 +780,19 @@ u8 admin_cerver_broadcast_to_admins (AdminCerver *admin_cerver, Packet *packet) 
 // returns 0 on success, 1 on error
 u8 admin_cerver_broadcast_to_admins_split (AdminCerver *admin_cerver, Packet *packet) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin_cerver && packet) {
-		u8 errors = 0;
+    if (admin_cerver && packet) {
+        u8 errors = 0;
 
-		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-			errors |= admin_send_packet_split ((Admin *) le->data, packet);
-		}
+        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+            errors |= admin_send_packet_split ((Admin *) le->data, packet);
+        }
 
-		retval = errors;
-	}
+        retval = errors;
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -803,18 +801,18 @@ u8 admin_cerver_broadcast_to_admins_split (AdminCerver *admin_cerver, Packet *pa
 u8 admin_cerver_broadcast_to_admins_pieces (AdminCerver *admin_cerver, Packet *packet, 
     void **pieces, size_t *sizes, u32 n_pieces) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin_cerver && packet) {
-		u8 errors = 0;
-		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-			errors |= admin_send_packet_pieces ((Admin *) le->data, packet, pieces, sizes, n_pieces);
-		}
+    if (admin_cerver && packet) {
+        u8 errors = 0;
+        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+            errors |= admin_send_packet_pieces ((Admin *) le->data, packet, pieces, sizes, n_pieces);
+        }
 
-		retval = errors;
-	}
+        retval = errors;
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -838,12 +836,11 @@ u8 admin_cerver_register_admin (AdminCerver *admin_cerver, Admin *admin) {
             admin_cerver->stats->total_n_admins += 1;
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s ADMIN current connected admins: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_ADMIN, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+                "Cerver %s ADMIN current connected admins: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+            );
             #endif
 
             retval = 0;     // success
@@ -872,12 +869,11 @@ u8 admin_cerver_unregister_admin (AdminCerver *admin_cerver, Admin *admin) {
             admin_cerver->stats->current_connected_admins -= 1;
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s ADMIN current connected admins: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_ADMIN, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+                "Cerver %s ADMIN current connected admins: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+            );
             #endif
 
             retval = 0;
@@ -917,12 +913,10 @@ static void admin_cerver_update (void *args) {
         AdminCerver *admin_cerver = (AdminCerver *) args;
         
         #ifdef ADMIN_DEBUG
-        char *s = c_string_create ("Cerver's %s admin_cerver_update () has started!",
-            admin_cerver->cerver->info->name->str);
-        if (s) {
-            cerver_log_success (s);
-            free (s);
-        }
+        cerver_log_success (
+            "Cerver's %s admin_cerver_update () has started!",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
 
         CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_args);
@@ -975,12 +969,10 @@ static void admin_cerver_update (void *args) {
         }
 
         #ifdef ADMIN_DEBUG
-        s = c_string_create ("Cerver's %s admin_cerver_update () has ended!",
-            admin_cerver->cerver->info->name->str);
-        if (s) {
-            cerver_log_success (s);
-            free (s);
-        }
+        cerver_log_success (
+            "Cerver's %s admin_cerver_update () has ended!",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
     }
 
@@ -994,12 +986,10 @@ static void admin_cerver_update_interval (void *args) {
         AdminCerver *admin_cerver = (AdminCerver *) args;
         
         #ifdef ADMIN_DEBUG
-        char *s = c_string_create ("Cerver's %s admin_cerver_update_interval () has started!",
-            admin_cerver->cerver->info->name->str);
-        if (s) {
-            cerver_log_success (s);
-            free (s);
-        }
+        cerver_log_success (
+            "Cerver's %s admin_cerver_update_interval () has started!",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
 
         CerverUpdate *cu = cerver_update_new (admin_cerver->cerver, admin_cerver->update_interval_args);
@@ -1019,12 +1009,10 @@ static void admin_cerver_update_interval (void *args) {
         }
 
         #ifdef ADMIN_DEBUG
-        s = c_string_create ("Cerver's %s admin_cerver_update_interval () has ended!",
-            admin_cerver->cerver->info->name->str);
-        if (s) {
-            cerver_log_success (s);
-            free (s);
-        }
+        cerver_log_success (
+            "Cerver's %s admin_cerver_update_interval () has ended!",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
     }
 
@@ -1036,20 +1024,20 @@ static u8 admin_cerver_start_internal (AdminCerver *admin_cerver) {
     u8 retval = 1;
 
     if (admin_cerver) {
-		admin_cerver->fds = (struct pollfd *) calloc (admin_cerver->max_n_fds, sizeof (struct pollfd));
-		if (admin_cerver->fds) {
-			memset (admin_cerver->fds, 0, sizeof (struct pollfd) * admin_cerver->max_n_fds);
+        admin_cerver->fds = (struct pollfd *) calloc (admin_cerver->max_n_fds, sizeof (struct pollfd));
+        if (admin_cerver->fds) {
+            memset (admin_cerver->fds, 0, sizeof (struct pollfd) * admin_cerver->max_n_fds);
 
-			for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
-				admin_cerver->fds[i].fd = -1;
+            for (u32 i = 0; i < admin_cerver->max_n_fds; i++)
+                admin_cerver->fds[i].fd = -1;
 
-			admin_cerver->current_n_fds = 0;
+            admin_cerver->current_n_fds = 0;
 
             admin_cerver->poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
             pthread_mutex_init (admin_cerver->poll_lock, NULL);
 
             retval = 0;
-		}
+        }
     }
 
     return retval;
@@ -1065,35 +1053,29 @@ static u8 admin_cerver_app_handler_start (AdminCerver *admin_cerver) {
             if (!admin_cerver->app_packet_handler->direct_handle) {
                 if (!handler_start (admin_cerver->app_packet_handler)) {
                     #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("Admin cerver %s app_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_success (s);
-                        free (s);
-                    }
+                    cerver_log_success (
+                        "Admin cerver %s app_packet_handler has started!",
+                        admin_cerver->cerver->info->name->str
+                    );
                     #endif
                 }
 
                 else {
-                    char *s = c_string_create ("Failed to start ADMIN cerver %s app_packet_handler!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "Failed to start ADMIN cerver %s app_packet_handler!",
+                        admin_cerver->cerver->info->name->str
+                    );
                 }
             }
         }
 
         else {
-			#ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Admin cerver %s does not have an app_packet_handler",
-				admin_cerver->cerver->info->name->str);
-			if (s) {
-				cerver_log_warning (s);
-				free (s);
-			}
-			#endif
+            #ifdef ADMIN_DEBUG
+            cerver_log_warning (
+                "Admin cerver %s does not have an app_packet_handler",
+                admin_cerver->cerver->info->name->str
+            );
+            #endif
         }
     }
 
@@ -1110,35 +1092,29 @@ static u8 admin_cerver_app_error_handler_start (AdminCerver *admin_cerver) {
             if (!admin_cerver->app_error_packet_handler->direct_handle) {
                 if (!handler_start (admin_cerver->app_error_packet_handler)) {
                     #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("Admin cerver %s app_error_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_success (s);
-                        free (s);
-                    }
+                    cerver_log_success (
+                        "Admin cerver %s app_error_packet_handler has started!",
+                        admin_cerver->cerver->info->name->str
+                    );
                     #endif
                 }
 
                 else {
-                    char *s = c_string_create ("Failed to start ADMIN cerver %s app_error_packet_handler!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "Failed to start ADMIN cerver %s app_error_packet_handler!",
+                        admin_cerver->cerver->info->name->str
+                    );
                 }
             }
         }
 
         else {
-			#ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Admin cerver %s does not have an app_error_packet_handler",
-				admin_cerver->cerver->info->name->str);
-			if (s) {
-				cerver_log_warning (s);
-				free (s);
-			}
-			#endif
+            #ifdef ADMIN_DEBUG
+            cerver_log_warning (
+                "Admin cerver %s does not have an app_error_packet_handler",
+                admin_cerver->cerver->info->name->str
+            );
+            #endif
         }
     }
 
@@ -1155,35 +1131,29 @@ static u8 admin_cerver_custom_handler_start (AdminCerver *admin_cerver) {
             if (!admin_cerver->custom_packet_handler->direct_handle) {
                 if (!handler_start (admin_cerver->custom_packet_handler)) {
                     #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("Admin cerver %s custom_packet_handler has started!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_success (s);
-                        free (s);
-                    }
+                    cerver_log_success (
+                        "Admin cerver %s custom_packet_handler has started!",
+                        admin_cerver->cerver->info->name->str
+                    );
                     #endif
                 }
 
                 else {
-                    char *s = c_string_create ("Failed to start ADMIN cerver %s custom_packet_handler!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "Failed to start ADMIN cerver %s custom_packet_handler!",
+                        admin_cerver->cerver->info->name->str
+                    );
                 }
             }
         }
 
         else {
-			// #ifdef ADMIN_DEBUG
-            // char *s = c_string_create ("Cerver %s does not have a custom_packet_handler",
-			// 	admin_cerver->cerver->info->name->str);
-			// if (s) {
-			// 	cerver_log_warning (s);
-			// 	free (s);
-			// }
-			// #endif
+            // #ifdef ADMIN_DEBUG
+            // cerver_log_warning (
+            //     "Cerver %s does not have a custom_packet_handler",
+            // 	admin_cerver->cerver->info->name->str
+            // );
+            // #endif
         }
     }
 
@@ -1197,12 +1167,10 @@ static u8 admin_cerver_handlers_start (AdminCerver *admin_cerver) {
 
     if (admin_cerver) {
         #ifdef ADMIN_DEBUG
-        char *s = c_string_create ("Initializing cerver %s admin handlers...",
-            admin_cerver->cerver->info->name->str);
-        if (s) {
-            cerver_log_debug (s);
-            free (s);
-        }
+        cerver_log_debug (
+            "Initializing cerver %s admin handlers...",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
 
         admin_cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
@@ -1216,12 +1184,10 @@ static u8 admin_cerver_handlers_start (AdminCerver *admin_cerver) {
 
         if (!errors) {
             #ifdef ADMIN_DEBUG
-            s = c_string_create ("Done initializing cerver %s admin handlers!",
-                admin_cerver->cerver->info->name->str);
-            if (s) {
-                cerver_log_debug (s);
-                free (s);
-            }
+            cerver_log_debug (
+                "Done initializing cerver %s admin handlers!",
+                admin_cerver->cerver->info->name->str
+            );
             #endif
         }
     }
@@ -1232,49 +1198,45 @@ static u8 admin_cerver_handlers_start (AdminCerver *admin_cerver) {
 
 static u8 admin_cerver_start_poll (Cerver *cerver) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (cerver) {
-		if (!thread_create_detachable (
-		    &cerver->admin_thread_id,
-		    admin_poll,
-		    cerver
-		)) {
-		    retval = 0;		// success
-		}
+    if (cerver) {
+        if (!thread_create_detachable (
+            &cerver->admin_thread_id,
+            admin_poll,
+            cerver
+        )) {
+            retval = 0;		// success
+        }
 
-		else {
-			char *s = c_string_create ("Failed to create admin_poll () thread in cerver %s!",
-		        cerver->info->name->str);
-		    if (s) {
-		        cerver_log_error (s);
-		        free (s);
-		    }
-		}
-	}
+        else {
+            cerver_log_error (
+                "Failed to create admin_poll () thread in cerver %s!",
+                cerver->info->name->str
+            );
+        }
+    }
 
-	return retval;
+    return retval;
 
 }
 
 u8 admin_cerver_start (AdminCerver *admin_cerver) {
 
-	u8 retval = 1;
+    u8 retval = 1;
 
-	if (admin_cerver) {
-		if (!admin_cerver_start_internal (admin_cerver)) {
+    if (admin_cerver) {
+        if (!admin_cerver_start_internal (admin_cerver)) {
             if (admin_cerver->update) {
                 if (thread_create_detachable (
                     &admin_cerver->update_thread_id,
                     (void *(*) (void *)) admin_cerver_update,
                     admin_cerver
                 )) {
-                    char *s = c_string_create ("Failed to create cerver %s ADMIN UPDATE thread!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "Failed to create cerver %s ADMIN UPDATE thread!",
+                        admin_cerver->cerver->info->name->str
+                    );
                 }
             }
 
@@ -1284,42 +1246,36 @@ u8 admin_cerver_start (AdminCerver *admin_cerver) {
                     (void *(*) (void *)) admin_cerver_update_interval,
                     admin_cerver
                 )) {
-                    char *s = c_string_create ("Failed to create cerver %s ADMIN UPDATE INTERVAL thread!",
-                        admin_cerver->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "Failed to create cerver %s ADMIN UPDATE INTERVAL thread!",
+                        admin_cerver->cerver->info->name->str
+                    );
                 }
             }
 
-			if (!admin_cerver_handlers_start (admin_cerver)) {
-				if (!admin_cerver_start_poll (admin_cerver->cerver)) {
-					retval = 0;
-				}
-			}
+            if (!admin_cerver_handlers_start (admin_cerver)) {
+                if (!admin_cerver_start_poll (admin_cerver->cerver)) {
+                    retval = 0;
+                }
+            }
 
-			else {
-				char *status = c_string_create ("admin_cerver_start () - failed to start cerver %s admin handlers!",
-					admin_cerver->cerver->info->name->str);
-				if (status) {
-					cerver_log_error (status);
-					free (status);
-				}
-			}
-		}
+            else {
+                cerver_log_error (
+                    "admin_cerver_start () - failed to start cerver %s admin handlers!",
+                    admin_cerver->cerver->info->name->str
+                );
+            }
+        }
 
-		else {
-			char *status = c_string_create ("admin_cerver_start () - failed to start cerver %s admin internal!",
-				admin_cerver->cerver->info->name->str);
-			if (status) {
-				cerver_log_error (status);
-				free (status);
-			}
-		}
-	}
+        else {
+            cerver_log_error (
+                "admin_cerver_start () - failed to start cerver %s admin internal!",
+                admin_cerver->cerver->info->name->str
+            );
+        }
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -1385,12 +1341,10 @@ static u8 admin_cerver_handlers_end (AdminCerver *admin_cerver) {
 
     if (admin_cerver) {
         #ifdef ADMIN_DEBUG
-        char *status = c_string_create ("Stopping handlers in cerver %s admin...",
-            admin_cerver->cerver->info->name->str);
-        if (status) {
-            cerver_log_debug (status);
-            free (status);
-        }
+        cerver_log_debug (
+            "Stopping handlers in cerver %s admin...",
+            admin_cerver->cerver->info->name->str
+        );
         #endif
 
         errors |= admin_cerver_app_handler_destroy (admin_cerver);
@@ -1420,52 +1374,46 @@ static u8 admin_cerver_handlers_end (AdminCerver *admin_cerver) {
 
 static u8 admin_cerver_disconnect_admins (AdminCerver *admin_cerver) {
 
-	u8 errors = 0;
+    u8 errors = 0;
 
-	if (admin_cerver) {
-		if (dlist_size (admin_cerver->admins)) {
-			// send a cerver teardown packet to all clients connected to cerver
-            Packet *packet = packet_generate_request (CERVER_PACKET, CERVER_TEARDOWN, NULL, 0);
+    if (admin_cerver) {
+        if (dlist_size (admin_cerver->admins)) {
+            // send a cerver teardown packet to all clients connected to cerver
+            Packet *packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_TEARDOWN, NULL, 0);
             if (packet) {
                 errors |= admin_cerver_broadcast_to_admins (admin_cerver, packet);
                 packet_delete (packet);
             }
-		}
-	}
+        }
+    }
 
-	return errors;
+    return errors;
 
 }
 
 u8 admin_cerver_end (AdminCerver *admin_cerver) {
 
-	u8 errors = 0;
+    u8 errors = 0;
 
-	if (admin_cerver) {
-		char *status = NULL;
+    if (admin_cerver) {
+        #ifdef ADMIN_DEBUG
+        cerver_log_debug (
+            "Staring cerver %s admin teardown...",
+            admin_cerver->cerver->info->name->str
+        );
+        #endif
 
-		#ifdef ADMIN_DEBUG
-		status = c_string_create ("Staring cerver %s admin teardown...",
-			admin_cerver->cerver->info->name->str);
-		if (status) {
-			cerver_log_debug (status);
-			free (status);
-		}
-		#endif
+        errors |= admin_cerver_handlers_end (admin_cerver);
 
-		errors |= admin_cerver_handlers_end (admin_cerver);
+        errors |= admin_cerver_disconnect_admins (admin_cerver);
 
-		errors |= admin_cerver_disconnect_admins (admin_cerver);
+        cerver_log_success (
+            "Cerver %s admin teardown was successful!",
+            admin_cerver->cerver->info->name->str
+        );
+    }
 
-		status = c_string_create ("Cerver %s admin teardown was successful!",
-			admin_cerver->cerver->info->name->str);
-		if (status) {
-			cerver_log_success (status);
-			free (status);
-		}
-	}
-
-	return errors;
+    return errors;
 
 }
 
@@ -1473,185 +1421,169 @@ u8 admin_cerver_end (AdminCerver *admin_cerver) {
 
 #pragma region handler
 
+// handles a packet of type PACKET_TYPE_CLIENT
+static void admin_cerver_client_packet_handler (Packet *packet) {
+
+    if (packet->header) {
+        switch (packet->header->request_type) {
+            // the client is going to close its current connection
+            // but will remain in the cerver if it has another connection active
+            // if not, it will be dropped
+            case CLIENT_PACKET_TYPE_CLOSE_CONNECTION: {
+                #ifdef ADMIN_DEBUG
+                cerver_log_debug (
+                    "Admin with client %ld requested to close the connection",
+                    packet->client->id
+                );
+                #endif
+
+                admin_remove_connection_by_sock_fd (
+                    packet->cerver->admin,
+                    admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd),
+                    packet->connection->socket->sock_fd
+                );
+            } break;
+
+            // the client is going to disconnect and will close all of its active connections
+            // so drop it from the server
+            case CLIENT_PACKET_TYPE_DISCONNECT: {
+                admin_cerver_drop_admin (
+                    packet->cerver->admin,
+                    admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd)
+                );
+
+                cerver_event_trigger (
+                    CERVER_EVENT_ADMIN_DISCONNECTED,
+                    packet->cerver,
+                    NULL, NULL
+                );
+            } break;
+
+            default: {
+                #ifdef CERVER_DEBUG
+                cerver_log (
+                    LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+                    "admin_cerver_client_packet_handler () - Got an unknown client packet in cerver %s",
+                    packet->cerver->info->name->str
+                );
+                #endif
+            } break;
+        }
+    }
+
+}
+
 // handles a request made from the admin
 static void admin_cerver_request_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->header) {
-            switch (packet->header->request_type) {
-                // the client is going to close its current connection
-                // but will remain in the cerver if it has another connection active
-                // if not, it will be dropped
-                case CLIENT_CLOSE_CONNECTION: {
-                    #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("Admin with client %ld requested to close the connection",
-                        packet->client->id);
-                    if (s) {
-                        cerver_log_debug (s);
-                        free (s);
-                    }
-                    #endif
-
-                    admin_remove_connection_by_sock_fd (
-                        packet->cerver->admin,
-                        admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd),
-                        packet->connection->socket->sock_fd
-                    );
-                } break;
-
-                // the client is going to disconnect and will close all of its active connections
-                // so drop it from the server
-                case CLIENT_DISCONNET: {
-                    admin_cerver_drop_admin (
-                        packet->cerver->admin,
-                        admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd)
-                    );
-
-                    cerver_event_trigger (
-                        CERVER_EVENT_ADMIN_DISCONNECTED,
-                        packet->cerver,
-                        NULL, NULL
-                    );
-                } break;
-
-                default: {
-                    #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Got an unknown request in cerver %s",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, s);
-                        free (s);
-                    }
-                    #endif
-                } break;
-            }
-        }
-    }
+    // TODO:
 
 }
 
-// handles an APP_PACKET packet type
+// handles an PACKET_TYPE_APP packet type
 static void admin_app_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->admin->app_packet_handler) {
-            if (packet->cerver->admin->app_packet_handler->direct_handle) {
-                // printf ("app_packet_handler - direct handle!\n");
-                packet->cerver->admin->app_packet_handler->handler (packet);
-                if (packet->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet);
-            }
-
-            else {
-                // add the packet to the handler's job queueu to be handled
-                // as soon as the handler is available
-                if (job_queue_push (
-                    packet->cerver->admin->app_packet_handler->job_queue,
-                    job_create (NULL, packet)
-                )) {
-                    char *s = c_string_create ("Failed to push a new job to cerver's %s ADMIN app_packet_handler!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
-                }
-            }
+    if (packet->cerver->admin->app_packet_handler) {
+        if (packet->cerver->admin->app_packet_handler->direct_handle) {
+            // printf ("app_packet_handler - direct handle!\n");
+            packet->cerver->admin->app_packet_handler->handler (packet);
+            if (packet->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet);
         }
 
         else {
-            #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Cerver %s ADMIN does not have an app_packet_handler!",
-                packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_warning (s);
-                free (s);
+            // add the packet to the handler's job queueu to be handled
+            // as soon as the handler is available
+            if (job_queue_push (
+                packet->cerver->admin->app_packet_handler->job_queue,
+                job_create (NULL, packet)
+            )) {
+                cerver_log_error (
+                    "Failed to push a new job to cerver's %s ADMIN app_packet_handler!",
+                    packet->cerver->info->name->str
+                );
             }
-            #endif
         }
+    }
+
+    else {
+        #ifdef ADMIN_DEBUG
+        cerver_log_warning (
+            "Cerver %s ADMIN does not have an app_packet_handler!",
+            packet->cerver->info->name->str
+        );
+        #endif
     }
 
 }
 
-// handles an APP_ERROR_PACKET packet type
+// handles an PACKET_TYPE_APP_ERROR packet type
 static void admin_app_error_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->admin->app_error_packet_handler) {
-            if (packet->cerver->admin->app_error_packet_handler->direct_handle) {
-                // printf ("app_error_packet_handler - direct handle!\n");
-                packet->cerver->admin->app_error_packet_handler->handler (packet);
-                if (packet->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet);
-            }
-
-            else {
-                // add the packet to the handler's job queueu to be handled
-                // as soon as the handler is available
-                if (job_queue_push (
-                    packet->cerver->admin->app_error_packet_handler->job_queue,
-                    job_create (NULL, packet)
-                )) {
-                    char *s = c_string_create ("Failed to push a new job to cerver's %s ADMIN app_error_packet_handler!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
-                }
-            }
+    if (packet->cerver->admin->app_error_packet_handler) {
+        if (packet->cerver->admin->app_error_packet_handler->direct_handle) {
+            // printf ("app_error_packet_handler - direct handle!\n");
+            packet->cerver->admin->app_error_packet_handler->handler (packet);
+            if (packet->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet);
         }
 
         else {
-            #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Cerver %s ADMIN does not have an app_error_packet_handler!",
-                packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_warning (s);
-                free (s);
+            // add the packet to the handler's job queueu to be handled
+            // as soon as the handler is available
+            if (job_queue_push (
+                packet->cerver->admin->app_error_packet_handler->job_queue,
+                job_create (NULL, packet)
+            )) {
+                cerver_log_error (
+                    "Failed to push a new job to cerver's %s ADMIN app_error_packet_handler!",
+                    packet->cerver->info->name->str
+                );
             }
-            #endif
         }
+    }
+
+    else {
+        #ifdef ADMIN_DEBUG
+        cerver_log_warning (
+            "Cerver %s ADMIN does not have an app_error_packet_handler!",
+            packet->cerver->info->name->str
+        );
+        #endif
     }
 
 }
 
-// handles a CUSTOM_PACKET packet type
+// handles a PACKET_TYPE_CUSTOM packet type
 static void admin_custom_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->admin->custom_packet_handler) {
-            if (packet->cerver->admin->custom_packet_handler->direct_handle) {
-                // printf ("custom_packet_handler - direct handle!\n");
-                packet->cerver->admin->custom_packet_handler->handler (packet);
-                if (packet->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet);
-            }
-
-            else {
-                // add the packet to the handler's job queueu to be handled
-                // as soon as the handler is available
-                if (job_queue_push (
-                    packet->cerver->admin->custom_packet_handler->job_queue,
-                    job_create (NULL, packet)
-                )) {
-                    char *s = c_string_create ("Failed to push a new job to cerver's %s ADMIN custom_packet_handler!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
-                }
-            }
+    if (packet->cerver->admin->custom_packet_handler) {
+        if (packet->cerver->admin->custom_packet_handler->direct_handle) {
+            // printf ("custom_packet_handler - direct handle!\n");
+            packet->cerver->admin->custom_packet_handler->handler (packet);
+            if (packet->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet);
         }
 
         else {
-            #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Cerver %s ADMIN does not have an custom_packet_handler!",
-                packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_warning (s);
-                free (s);
+            // add the packet to the handler's job queueu to be handled
+            // as soon as the handler is available
+            if (job_queue_push (
+                packet->cerver->admin->custom_packet_handler->job_queue,
+                job_create (NULL, packet)
+            )) {
+                cerver_log_error (
+                    "Failed to push a new job to cerver's %s ADMIN custom_packet_handler!",
+                    packet->cerver->info->name->str
+                );
             }
-            #endif
         }
+    }
+
+    else {
+        #ifdef ADMIN_DEBUG
+        cerver_log_warning (
+            "Cerver %s ADMIN does not have an custom_packet_handler!",
+            packet->cerver->info->name->str
+        );
+        #endif
     }
 
 }
@@ -1677,8 +1609,16 @@ void admin_packet_handler (Packet *packet) {
 
         if (good) {
             switch (packet->header->packet_type) {
+                case PACKET_TYPE_CLIENT:
+                    packet->cerver->admin->stats->received_packets->n_client_packets += 1;
+                    packet->client->stats->received_packets->n_client_packets += 1;
+                    packet->connection->stats->received_packets->n_client_packets += 1; 
+                    admin_cerver_client_packet_handler (packet); 
+                    packet_delete (packet);
+                    break;
+
                 // handles a request made from the admin
-                case REQUEST_PACKET:
+                case PACKET_TYPE_REQUEST:
                     packet->cerver->admin->stats->received_packets->n_request_packets += 1;
                     packet->client->stats->received_packets->n_request_packets += 1;
                     packet->connection->stats->received_packets->n_request_packets += 1; 
@@ -1686,21 +1626,21 @@ void admin_packet_handler (Packet *packet) {
                     packet_delete (packet);
                     break;
 
-                case APP_PACKET:
+                case PACKET_TYPE_APP:
                     packet->cerver->admin->stats->received_packets->n_app_packets += 1;
                     packet->client->stats->received_packets->n_app_packets += 1;
                     packet->connection->stats->received_packets->n_app_packets += 1;
                     admin_app_packet_handler (packet); 
                     break;
 
-                case APP_ERROR_PACKET: 
+                case PACKET_TYPE_APP_ERROR: 
                     packet->cerver->admin->stats->received_packets->n_app_error_packets += 1;
                     packet->client->stats->received_packets->n_app_error_packets += 1;
                     packet->connection->stats->received_packets->n_app_error_packets += 1;
                     admin_app_error_packet_handler (packet); 
                     break;
 
-                case CUSTOM_PACKET: 
+                case PACKET_TYPE_CUSTOM: 
                     packet->cerver->admin->stats->received_packets->n_custom_packets += 1;
                     packet->client->stats->received_packets->n_custom_packets += 1;
                     packet->connection->stats->received_packets->n_custom_packets += 1;
@@ -1712,12 +1652,11 @@ void admin_packet_handler (Packet *packet) {
                     packet->client->stats->received_packets->n_bad_packets += 1;
                     packet->connection->stats->received_packets->n_bad_packets += 1;
                     #ifdef ADMIN_DEBUG
-                    char *s = c_string_create ("Got a packet of unknown type in cerver %s admin handler", 
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+                        "Got a packet of unknown type in cerver %s admin handler", 
+                        packet->cerver->info->name->str
+                    );
                     #endif
                     packet_delete (packet);
                 } break;
@@ -1775,21 +1714,19 @@ u8 admin_cerver_poll_register_connection (AdminCerver *admin_cerver, Connection 
             admin_cerver->stats->total_admin_connections++;
 
             #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Added sock fd <%d> to cerver %s ADMIN poll, idx: %i", 
-                connection->socket->sock_fd, admin_cerver->cerver->info->name->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_ADMIN, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+                "Added sock fd <%d> to cerver %s ADMIN poll, idx: %i", 
+                connection->socket->sock_fd, admin_cerver->cerver->info->name->str, idx
+            );
             #endif
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s ADMIN current connections: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_ADMIN, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+                "Cerver %s ADMIN current connections: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+            );
             #endif
 
             retval = 0;
@@ -1797,12 +1734,11 @@ u8 admin_cerver_poll_register_connection (AdminCerver *admin_cerver, Connection 
 
         else if (idx < 0) {
             #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Cerver %s ADMIN poll is full!", 
-                admin_cerver->cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_ADMIN, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+                "Cerver %s ADMIN poll is full!", 
+                admin_cerver->cerver->info->name->str
+            );
             #endif
         }
 
@@ -1831,21 +1767,19 @@ u8 admin_cerver_poll_unregister_sock_fd (AdminCerver *admin_cerver, const i32 so
             admin_cerver->stats->current_connections--;
 
             #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Removed sock fd <%d> from cerver %s ADMIN poll, idx: %d",
-                sock_fd, admin_cerver->cerver->info->name->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_ADMIN, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+                "Removed sock fd <%d> from cerver %s ADMIN poll, idx: %d",
+                sock_fd, admin_cerver->cerver->info->name->str, idx
+            );
             #endif
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s ADMIN current connections: %ld", 
-                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_ADMIN, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
+                "Cerver %s ADMIN current connections: %ld", 
+                admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+            );
             #endif
 
             retval = 0;
@@ -1853,12 +1787,11 @@ u8 admin_cerver_poll_unregister_sock_fd (AdminCerver *admin_cerver, const i32 so
 
         else {
             // #ifdef ADMIN_DEBUG
-            char *s = c_string_create ("Sock fd <%d> was NOT found in cerver %s ADMIN poll!",
-                sock_fd, admin_cerver->cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_ADMIN, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_ADMIN,
+                "Sock fd <%d> was NOT found in cerver %s ADMIN poll!",
+                sock_fd, admin_cerver->cerver->info->name->str
+            );
             // #endif
         }
 
@@ -1950,13 +1883,13 @@ static void *admin_poll (void *cerver_ptr) {
 
     if (cerver_ptr) {
         Cerver *cerver = (Cerver *) cerver_ptr;
-		AdminCerver *admin_cerver = cerver->admin;
+        AdminCerver *admin_cerver = cerver->admin;
 
-        char *status = c_string_create ("Cerver %s ADMIN poll has started!", cerver->info->name->str);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_ADMIN, status);
-            free (status);
-        }
+        cerver_log (
+            LOG_TYPE_SUCCESS, LOG_TYPE_ADMIN,
+            "Cerver %s ADMIN poll has started!",
+            cerver->info->name->str
+        );
 
         char *thread_name = c_string_create ("%s-admin", cerver->info->name->str);
         if (thread_name) {
@@ -1967,18 +1900,18 @@ static void *admin_poll (void *cerver_ptr) {
         int poll_retval = 0;
         while (cerver->isRunning) {
             poll_retval = poll (
-				admin_cerver->fds,
-				admin_cerver->max_n_fds,
-				admin_cerver->poll_timeout
-			);
+                admin_cerver->fds,
+                admin_cerver->max_n_fds,
+                admin_cerver->poll_timeout
+            );
 
             switch (poll_retval) {
                 case -1: {
-                    char *status = c_string_create ("Cerver %s ADMIN poll has failed!", cerver->info->name->str);
-                    if (status) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_ADMIN, status);
-                        free (status);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+                        "Cerver %s ADMIN poll has failed!",
+                        cerver->info->name->str
+                    );
 
                     perror ("Error");
                     cerver->isRunning = false;
@@ -1986,11 +1919,10 @@ static void *admin_poll (void *cerver_ptr) {
 
                 case 0: {
                     // #ifdef ADMIN_DEBUG
-                    // char *status = c_string_create ("Cerver %s ADMIN poll timeout", cerver->info->name->str);
-                    // if (status) {
-                    //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_ADMIN, status);
-                    //     free (status);
-                    // }
+                    // cerver_log (
+                    //     LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+                    //     "Cerver %s ADMIN poll timeout", cerver->info->name->str
+                    // );
                     // #endif
                 } break;
 
@@ -2001,15 +1933,14 @@ static void *admin_poll (void *cerver_ptr) {
         }
 
         #ifdef ADMIN_DEBUG
-        status = c_string_create ("Cerver %s ADMIN poll has stopped!", cerver->info->name->str);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_ADMIN, status);
-            free (status);
-        }
+        cerver_log (
+            LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
+            "Cerver %s ADMIN poll has stopped!", cerver->info->name->str
+        );
         #endif
     }
 
-    else cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_ADMIN, "Can't handle admins on a NULL cerver!");
+    else cerver_log (LOG_TYPE_ERROR, LOG_TYPE_ADMIN, "Can't handle admins on a NULL cerver!");
 
     return NULL;
 

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -131,7 +131,7 @@ static void auth_send_success_packet (const Cerver *cerver,
     SToken *token, size_t token_size) {
 
     if (cerver && connection) {
-        Packet *success_packet = packet_generate_request (AUTH_PACKET, AUTH_PACKET_TYPE_SUCCESS, token, token_size);
+        Packet *success_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_SUCCESS, token, token_size);
         if (success_packet) {
             packet_set_network_values (success_packet, (Cerver *) cerver, (Client *) client, (Connection *) connection, NULL);
             packet_send (success_packet, 0, NULL, false);
@@ -140,12 +140,10 @@ static void auth_send_success_packet (const Cerver *cerver,
 
         else {
             #ifdef AUTH_DEBUG
-            char *status = c_string_create ("Failed to create success auth packet in cerver %s",
-                cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, status);
-                free (status);
-            }
+            cerver_log_error (
+                "Failed to create success auth packet in cerver %s",
+                cerver->info->name->str
+            );
             #endif
         }
     }
@@ -175,23 +173,20 @@ static Client *auth_create_new_client (Packet *packet, AuthData *auth_data) {
                 char *session_id = (char *) packet->cerver->session_id_generator (session_data);
                 if (session_id) {
                     #ifdef AUTH_DEBUG
-                    char *s = c_string_create ("Generated client <%ld> session id: <%s>", 
-                        client->id, session_id);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+                        "Generated client <%ld> session id: <%s>", 
+                        client->id, session_id
+                    );
                     #endif
                     client_set_session_id (client, session_id);
                 }
 
                 else {
-                    char *s = c_string_create ("auth_create_new_client () - failed to generate client's <%ld> session id!",
-                        client->id);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
+                    cerver_log_error (
+                        "auth_create_new_client () - failed to generate client's <%ld> session id!",
+                        client->id
+                    );
 
                     client_connection_remove (client, packet->connection);
                     
@@ -231,8 +226,7 @@ static void auth_failed (Cerver *cerver, Connection *connection, const char *err
         connection->auth_tries--;
         if (connection->auth_tries <= 0) {
             #ifdef AUTH_DEBUG
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, 
-                "Connection reached max auth tries, dropping now...");
+            cerver_log_debug ("Connection reached max auth tries, dropping now...");
             #endif
             on_hold_connection_drop (cerver, connection);
         }
@@ -251,12 +245,11 @@ static u8 auth_with_token_admin (const Packet *packet, const AuthData *auth_data
         // if we found a client, register the new connection to him
         if (admin) {
             #ifdef AUTH_DEBUG
-            char *status = c_string_create ("Found an ADMIN with session id <%s> in cerver %s.",
-                auth_data->token->str, packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+                "Found an ADMIN with session id <%s> in cerver %s.",
+                auth_data->token->str, packet->cerver->info->name->str
+            );
             #endif
 
             if (!connection_register_to_client (admin->client, packet->connection)) {
@@ -265,12 +258,10 @@ static u8 auth_with_token_admin (const Packet *packet, const AuthData *auth_data
         }
 
         else {
-            char *status = c_string_create ("Failed to get ADMIN with matching session id <%s> in cerver %s",
-                auth_data->token->str, packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_error (status);
-                free (status);
-            }
+            cerver_log_error (
+                "Failed to get ADMIN with matching session id <%s> in cerver %s",
+                auth_data->token->str, packet->cerver->info->name->str
+            );
 
             // if not, the token is invalid!
             auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
@@ -298,12 +289,11 @@ static u8 auth_with_token_normal (const Packet *packet, const AuthData *auth_dat
         // if we found a client, register the new connection to him
         if (client) {
             #ifdef AUTH_DEBUG
-            char *status = c_string_create ("Found a CLIENT with session id <%s> in cerver %s.",
-                auth_data->token->str, packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+                "Found a CLIENT with session id <%s> in cerver %s.",
+                auth_data->token->str, packet->cerver->info->name->str
+            );
             #endif
 
             if (!connection_register_to_client (client, packet->connection)) {
@@ -314,12 +304,10 @@ static u8 auth_with_token_normal (const Packet *packet, const AuthData *auth_dat
         }
 
         else {
-            char *status = c_string_create ("Failed to get CLIENT with matching session id <%s> in cerver %s",
-                auth_data->token->str, packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_error (status);
-                free (status);
-            }
+            cerver_log_error (
+                "Failed to get CLIENT with matching session id <%s> in cerver %s",
+                auth_data->token->str, packet->cerver->info->name->str
+            );
 
             // if not, the token is invalid!
             auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
@@ -369,12 +357,11 @@ static u8 auth_with_defined_method (Packet *packet, delegate authenticate, AuthD
         if (auth_method) {
             if (!authenticate (auth_method)) {
                 #ifdef AUTH_DEBUG
-                char *status = c_string_create ("Client authenticated successfully to cerver %s",
-                    packet->cerver->info->name->str);
-                if (status) {
-                    cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT, status);
-                    free (status);
-                }
+                cerver_log (
+                    LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+                    "Client authenticated successfully to cerver %s",
+                    packet->cerver->info->name->str
+                );
                 #endif
 
                 *client = auth_create_new_client (packet, auth_data);
@@ -385,12 +372,11 @@ static u8 auth_with_defined_method (Packet *packet, delegate authenticate, AuthD
 
             else {
                 #ifdef AUTH_DEBUG
-                char *status = c_string_create ("Client failed to authenticate to cerver %s",
-                    packet->cerver->info->name->str);
-                if (status) {
-                    cerver_log_msg (stderr, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, status);
-                    free (status);
-                }
+                cerver_log (
+                    LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+                    "Client failed to authenticate to cerver %s",
+                    packet->cerver->info->name->str
+                );
                 #endif
 
                 auth_failed (
@@ -482,12 +468,11 @@ static u8 auth_try_common (Packet *packet, delegate authenticate, Client **clien
         // failed to get auth data form packet
         else {
             #ifdef AUTH_DEBUG
-            char *status = c_string_create ("Failed to get auth data from packet in cerver %s",
-                packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+                "Failed to get auth data from packet in cerver %s",
+                packet->cerver->info->name->str
+            );
             #endif
 
             auth_failed (packet->cerver, packet->connection, "Missing auth data!");
@@ -567,16 +552,17 @@ static void auth_try (Packet *packet) {
                     }
 
                     else {
-                        char *status = c_string_create ("admin_auth_try () - failed to register a new admin to cerver %s",
-                            packet->cerver->info->name->str);
-                        if (status) {
-                            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_ADMIN, status);
-                            free (status);
-                        }
+                        cerver_log (
+                            LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+                            "admin_auth_try () - failed to register a new admin to cerver %s",
+                            packet->cerver->info->name->str
+                        );
 
                         // send an error packet to the client
-                        error_packet_generate_and_send (CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
-                            packet->cerver, client, packet->connection);
+                        error_packet_generate_and_send (
+                            CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
+                            packet->cerver, client, packet->connection
+                        );
 
                         // close the client's only connection and delete the client
                         client_connection_drop (
@@ -611,12 +597,11 @@ static void auth_try (Packet *packet) {
 
         // no authentication method -- clients are not able to authenticate with to the cerver!
         else {
-            char *status = c_string_create ("Cerver %s does not have an authenticate method!",
-                packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+                "Cerver %s does not have an authenticate method!",
+                packet->cerver->info->name->str
+            );
 
             // close the on hold connection assocaited with sock fd 
             // and remove it from the cerver
@@ -671,16 +656,17 @@ static void admin_auth_try (Packet *packet) {
                         }
 
                         else {
-                            char *status = c_string_create ("admin_auth_try () - failed to register a new admin to cerver %s",
-                                packet->cerver->info->name->str);
-                            if (status) {
-                                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_ADMIN, status);
-                                free (status);
-                            }
+                            cerver_log (
+                                LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+                                "admin_auth_try () - failed to register a new admin to cerver %s",
+                                packet->cerver->info->name->str
+                            );
 
                             // send an error packet to the client
-                            error_packet_generate_and_send (CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
-                                packet->cerver, client, packet->connection);
+                            error_packet_generate_and_send (
+                                CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
+                                packet->cerver, client, packet->connection
+                            );
 
                             // close the admin's client only connection and delete the admin
                             client_connection_drop (
@@ -715,12 +701,11 @@ static void admin_auth_try (Packet *packet) {
 
             // no authentication method -- clients are not able to authenticate with the cerver!
             else {
-                char *status = c_string_create ("Cerver %s ADMIN does not have an authenticate method!",
-                    packet->cerver->info->name->str);
-                if (status) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-                    free (status);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+                    "Cerver %s ADMIN does not have an authenticate method!",
+                    packet->cerver->info->name->str
+                );
 
                 // close the on hold connection assocaited with sock fd 
                 // and remove it from the cerver
@@ -729,12 +714,10 @@ static void admin_auth_try (Packet *packet) {
         }
 
         else {
-            char *status = c_string_create ("admin_auth_try () - Cerver %s does NOT support ADMINS!",
-                packet->cerver->info->name->str);
-            if (status) {
-                cerver_log_warning (status);
-                free (status);
-            }
+            cerver_log_warning (
+                "admin_auth_try () - Cerver %s does NOT support ADMINS!",
+                packet->cerver->info->name->str
+            );
 
             on_hold_connection_drop (packet->cerver, packet->connection);
         }
@@ -775,8 +758,10 @@ static void cerver_auth_packet_handler (Packet *packet) {
 
                 default: {
                     #ifdef AUTH_DEBUG
-                    cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, 
-                        "cerver_auth_packet_hanlder () -- got an unknwown request type");
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_PACKET, 
+                        "cerver_auth_packet_hanlder () -- got an unknwown request type"
+                    );
                     #endif
 
                     cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
@@ -816,19 +801,18 @@ void on_hold_packet_handler (void *packet_ptr) {
         if (good) {
             switch (packet->header->packet_type) {
                 // handles authentication packets
-                case AUTH_PACKET: cerver_auth_packet_handler (packet); break;
+                case PACKET_TYPE_AUTH: cerver_auth_packet_handler (packet); break;
 
                 // acknowledge the client we have received his test packet
-                case TEST_PACKET: cerver_test_packet_handler (packet); break;
+                case PACKET_TYPE_TEST: cerver_test_packet_handler (packet); break;
 
                 default: {
                     #ifdef AUTH_DEBUG
-                    char *status = c_string_create ("Got an ON HOLD packet of unknown type in cerver %s.", 
-                        packet->cerver->info->name->str);
-                    if (status) {
-                        cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, status);
-                        free (status);
-                    }
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+                        "Got an ON HOLD packet of unknown type in cerver %s.", 
+                        packet->cerver->info->name->str
+                    );
                     #endif
 
                     cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
@@ -993,21 +977,19 @@ static u8 on_hold_poll_register_connection (Cerver *cerver, Connection *connecti
             cerver->stats->current_n_hold_connections++;
 
             #ifdef AUTH_DEBUG
-            char *s = c_string_create ("Added sock fd <%d> to cerver %s ON HOLD poll, idx: %i", 
-                connection->socket->sock_fd, cerver->info->name->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+                "Added sock fd <%d> to cerver %s ON HOLD poll, idx: %i", 
+                connection->socket->sock_fd, cerver->info->name->str, idx
+            );
             #endif
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s current ON HOLD connections: %ld", 
-                cerver->info->name->str, cerver->stats->current_n_hold_connections);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_CERVER, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_CERVER,
+                "Cerver %s current ON HOLD connections: %ld", 
+                cerver->info->name->str, cerver->stats->current_n_hold_connections
+            );
             #endif
 
             retval = 0;
@@ -1015,12 +997,11 @@ static u8 on_hold_poll_register_connection (Cerver *cerver, Connection *connecti
 
         else if (idx < 0) {
             #ifdef AUTH_DEBUG
-            char *s = c_string_create ("Cerver %s ON HOLD poll is full!", 
-                cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+                "Cerver %s ON HOLD poll is full!", 
+                cerver->info->name->str
+            );
             #endif
         }
 
@@ -1049,21 +1030,19 @@ u8 on_hold_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
             cerver->stats->current_n_hold_connections--;
 
             #ifdef AUTH_DEBUG
-            char *s = c_string_create ("Removed sock fd <%d> from cerver %s ON HOLD poll, idx: %d",
-                sock_fd, cerver->info->name->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+                "Removed sock fd <%d> from cerver %s ON HOLD poll, idx: %d",
+                sock_fd, cerver->info->name->str, idx
+            );
             #endif
 
             #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s current ON HOLD connections: %ld", 
-                cerver->info->name->str, cerver->stats->current_n_hold_connections);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_CERVER, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_CERVER, LOG_TYPE_CERVER,
+                "Cerver %s current ON HOLD connections: %ld", 
+                cerver->info->name->str, cerver->stats->current_n_hold_connections
+            );
             #endif
 
             retval = 0;
@@ -1071,12 +1050,11 @@ u8 on_hold_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 
         else {
             // #ifdef AUTH_DEBUG
-            char *s = c_string_create ("Sock fd <%d> was NOT found in cerver %s ON HOLD poll!",
-                sock_fd, cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+                "Sock fd <%d> was NOT found in cerver %s ON HOLD poll!",
+                sock_fd, cerver->info->name->str
+            );
             // #endif
         }
 
@@ -1171,11 +1149,10 @@ void *on_hold_poll (void *cerver_ptr) {
     if (cerver_ptr) {
         Cerver *cerver = (Cerver *) cerver_ptr;
 
-        char *status = c_string_create ("Cerver %s ON HOLD poll has started!", cerver->info->name->str);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, status);
-            free (status);
-        }
+        cerver_log (
+            LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+            "Cerver %s ON HOLD poll has started!", cerver->info->name->str
+        );
 
         char *thread_name = c_string_create ("%s-on-hold", cerver->info->name->str);
         if (thread_name) {
@@ -1184,7 +1161,7 @@ void *on_hold_poll (void *cerver_ptr) {
         }
 
         #ifdef AUTH_DEBUG
-        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections to put on hold...");
+        cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections to put on hold...");
         #endif
 
         int poll_retval = 0;
@@ -1193,11 +1170,10 @@ void *on_hold_poll (void *cerver_ptr) {
 
             switch (poll_retval) {
                 case -1: {
-                    char *status = c_string_create ("Cerver %s ON HOLD poll has failed!", cerver->info->name->str);
-                    if (status) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-                        free (status);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+                        "Cerver %s ON HOLD poll has failed!", cerver->info->name->str
+                    );
 
                     perror ("Error");
                     cerver->isRunning = false;
@@ -1205,11 +1181,10 @@ void *on_hold_poll (void *cerver_ptr) {
 
                 case 0: {
                     // #ifdef AUTH_DEBUG
-                    // char *status = c_string_create ("Cerver %s ON HOLD poll timeout", cerver->info->name->str);
-                    // if (status) {
-                    //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-                    //     free (status);
-                    // }
+                    // cerver_log (
+                    //     LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+                    //     "Cerver %s ON HOLD poll timeout", cerver->info->name->str
+                    // );
                     // #endif
                 } break;
 
@@ -1220,15 +1195,19 @@ void *on_hold_poll (void *cerver_ptr) {
         }
 
         #ifdef AUTH_DEBUG
-        status = c_string_create ("Cerver %s ON HOLD poll has stopped!", cerver->info->name->str);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
-            free (status);
-        }
+        cerver_log (
+            LOG_TYPE_CERVER, LOG_TYPE_NONE,
+            "Cerver %s ON HOLD poll has stopped!", cerver->info->name->str
+        );
         #endif
     }
 
-    else cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Can't handle ON HOLD clients on a NULL cerver!");
+    else {
+        cerver_log (
+            LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+            "Can't handle ON HOLD clients on a NULL cerver!"
+        );
+    }
 
     return NULL;
 

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -34,51 +34,51 @@ static u8 on_hold_poll_unregister_connection (Cerver *cerver, Connection *connec
 
 static AuthData *auth_data_new (void) {
 
-    AuthData *auth_data = (AuthData *) malloc (sizeof (AuthData));
-    if (auth_data) {
-        auth_data->token = NULL;
+	AuthData *auth_data = (AuthData *) malloc (sizeof (AuthData));
+	if (auth_data) {
+		auth_data->token = NULL;
 
-        auth_data->auth_data = NULL;
-        auth_data->auth_data_size = 0;
+		auth_data->auth_data = NULL;
+		auth_data->auth_data_size = 0;
 
-        auth_data->data = NULL;
-        auth_data->delete_data = NULL;
-    }
+		auth_data->data = NULL;
+		auth_data->delete_data = NULL;
+	}
 
-    return auth_data;
+	return auth_data;
 
 }
 
 static AuthData *auth_data_create (const char *token, void *data, size_t auth_data_size) {
 
-    AuthData *auth_data = auth_data_new ();
-    if (auth_data) {
-        auth_data->token = token ? str_new (token) : NULL;
-        if (data) {
-            auth_data->auth_data = malloc (auth_data_size);
-            if (auth_data->auth_data) {
-                memcpy (auth_data->auth_data, data, auth_data_size);
-                auth_data->auth_data_size = auth_data_size;
-            }
+	AuthData *auth_data = auth_data_new ();
+	if (auth_data) {
+		auth_data->token = token ? str_new (token) : NULL;
+		if (data) {
+			auth_data->auth_data = malloc (auth_data_size);
+			if (auth_data->auth_data) {
+				memcpy (auth_data->auth_data, data, auth_data_size);
+				auth_data->auth_data_size = auth_data_size;
+			}
 
-            else {
-                free (auth_data);
-                auth_data = NULL;
-            }
-        }
-    }
+			else {
+				free (auth_data);
+				auth_data = NULL;
+			}
+		}
+	}
 
-    return auth_data;
+	return auth_data;
 
 }
 
 static void auth_data_delete (AuthData *auth_data) {
 
-    if (auth_data) {
-        str_delete (auth_data->token);
-        if (auth_data->auth_data) free (auth_data->auth_data);
-        free (auth_data);
-    }
+	if (auth_data) {
+		str_delete (auth_data->token);
+		if (auth_data->auth_data) free (auth_data->auth_data);
+		free (auth_data);
+	}
 
 }
 
@@ -88,37 +88,37 @@ static void auth_data_delete (AuthData *auth_data) {
 
 static AuthMethod *auth_method_new (void) {
 
-    AuthMethod *auth_method = (AuthMethod *) malloc (sizeof (AuthMethod));
-    if (auth_method) {
-        auth_method->packet = NULL;
-        auth_method->auth_data = NULL;
+	AuthMethod *auth_method = (AuthMethod *) malloc (sizeof (AuthMethod));
+	if (auth_method) {
+		auth_method->packet = NULL;
+		auth_method->auth_data = NULL;
 
-        auth_method->error_message = NULL;
-    }
+		auth_method->error_message = NULL;
+	}
 
-    return auth_method;
+	return auth_method;
 
 }
 
 static AuthMethod *auth_method_create (Packet *packet, AuthData *auth_data) {
 
-    AuthMethod *auth_method = auth_method_new ();
-    if (auth_method) {
-        auth_method->packet = packet;
-        auth_method->auth_data = auth_data;
-    }
+	AuthMethod *auth_method = auth_method_new ();
+	if (auth_method) {
+		auth_method->packet = packet;
+		auth_method->auth_data = auth_data;
+	}
 
-    return auth_method;
+	return auth_method;
 
 }
 
 static void auth_method_delete (AuthMethod *auth_method) {
 
-    if (auth_method) {
-        str_delete (auth_method->error_message);
+	if (auth_method) {
+		str_delete (auth_method->error_message);
 
-        free (auth_method);
-    }
+		free (auth_method);
+	}
 
 }
 
@@ -126,83 +126,83 @@ static void auth_method_delete (AuthMethod *auth_method) {
 
 #pragma region auth
 
-static void auth_send_success_packet (const Cerver *cerver, 
-    const Client *client, const Connection *connection,
-    SToken *token, size_t token_size) {
+static void auth_send_success_packet (const Cerver *cerver,
+	const Client *client, const Connection *connection,
+	SToken *token, size_t token_size) {
 
-    if (cerver && connection) {
-        Packet *success_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_SUCCESS, token, token_size);
-        if (success_packet) {
-            packet_set_network_values (success_packet, (Cerver *) cerver, (Client *) client, (Connection *) connection, NULL);
-            packet_send (success_packet, 0, NULL, false);
-            packet_delete (success_packet);
-        }
+	if (cerver && connection) {
+		Packet *success_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_SUCCESS, token, token_size);
+		if (success_packet) {
+			packet_set_network_values (success_packet, (Cerver *) cerver, (Client *) client, (Connection *) connection, NULL);
+			packet_send (success_packet, 0, NULL, false);
+			packet_delete (success_packet);
+		}
 
-        else {
-            #ifdef AUTH_DEBUG
-            cerver_log_error (
-                "Failed to create success auth packet in cerver %s",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef AUTH_DEBUG
+			cerver_log_error (
+				"Failed to create success auth packet in cerver %s",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
 }
 
 // creates a new client and registers the connection to it
 static Client *auth_create_new_client (Packet *packet, AuthData *auth_data) {
 
-    Client *client = NULL;
+	Client *client = NULL;
 
-    if (packet) {
-        client = client_create ();
-        if (client) {
-            connection_register_to_client (client, packet->connection);
+	if (packet) {
+		client = client_create ();
+		if (client) {
+			connection_register_to_client (client, packet->connection);
 
-            // client_set_data (client, auth_data->data, auth_data->delete_data);
+			// client_set_data (client, auth_data->data, auth_data->delete_data);
 
-            // if the cerver is configured to use sessions, we need to generate a new session id with the
-            // session id generator method and add it to the client
-            // this client has the first connection associated with the id & auth data
-            // any new connections that authenticates using the session id (token), 
-            // will be added to this client
-            if (packet->cerver->use_sessions) {
-                SessionData *session_data = session_data_new (packet, auth_data, client);
+			// if the cerver is configured to use sessions, we need to generate a new session id with the
+			// session id generator method and add it to the client
+			// this client has the first connection associated with the id & auth data
+			// any new connections that authenticates using the session id (token),
+			// will be added to this client
+			if (packet->cerver->use_sessions) {
+				SessionData *session_data = session_data_new (packet, auth_data, client);
 
-                char *session_id = (char *) packet->cerver->session_id_generator (session_data);
-                if (session_id) {
-                    #ifdef AUTH_DEBUG
-                    cerver_log (
-                        LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                        "Generated client <%ld> session id: <%s>", 
-                        client->id, session_id
-                    );
-                    #endif
-                    client_set_session_id (client, session_id);
-                }
+				char *session_id = (char *) packet->cerver->session_id_generator (session_data);
+				if (session_id) {
+					#ifdef AUTH_DEBUG
+					cerver_log (
+						LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+						"Generated client <%ld> session id: <%s>",
+						client->id, session_id
+					);
+					#endif
+					client_set_session_id (client, session_id);
+				}
 
-                else {
-                    cerver_log_error (
-                        "auth_create_new_client () - failed to generate client's <%ld> session id!",
-                        client->id
-                    );
+				else {
+					cerver_log_error (
+						"auth_create_new_client () - failed to generate client's <%ld> session id!",
+						client->id
+					);
 
-                    client_connection_remove (client, packet->connection);
-                    
-                    // remove the connection from on hold structures to stop receiving data
-                    on_hold_connection_drop (packet->cerver, packet->connection);
+					client_connection_remove (client, packet->connection);
 
-                    client_delete (client);
-                    client = NULL;
-                }
+					// remove the connection from on hold structures to stop receiving data
+					on_hold_connection_drop (packet->cerver, packet->connection);
 
-                session_data_delete (session_data);
-            }
-        }
-    }
+					client_delete (client);
+					client = NULL;
+				}
 
-    return client;
+				session_data_delete (session_data);
+			}
+		}
+	}
+
+	return client;
 
 }
 
@@ -210,117 +210,117 @@ static Client *auth_create_new_client (Packet *packet, AuthData *auth_data) {
 // if the connection's max auth tries has been reached, it will be dropped
 static void auth_failed (Cerver *cerver, Connection *connection, const char *error_message) {
 
-    if (cerver && connection) {
-        // send failed auth packet to client
-        Packet *error_packet = error_packet_generate (
-            CERVER_ERROR_FAILED_AUTH, 
-            error_message
-        );
+	if (cerver && connection) {
+		// send failed auth packet to client
+		Packet *error_packet = error_packet_generate (
+			CERVER_ERROR_FAILED_AUTH,
+			error_message
+		);
 
-        if (error_packet) {
-            packet_set_network_values (error_packet, cerver, NULL, connection, NULL);
-            packet_send (error_packet, 0, NULL, false);
-            packet_delete (error_packet);
-        }
+		if (error_packet) {
+			packet_set_network_values (error_packet, cerver, NULL, connection, NULL);
+			packet_send (error_packet, 0, NULL, false);
+			packet_delete (error_packet);
+		}
 
-        connection->auth_tries--;
-        if (connection->auth_tries <= 0) {
-            #ifdef AUTH_DEBUG
-            cerver_log_debug ("Connection reached max auth tries, dropping now...");
-            #endif
-            on_hold_connection_drop (cerver, connection);
-        }
-    }
+		connection->auth_tries--;
+		if (connection->auth_tries <= 0) {
+			#ifdef AUTH_DEBUG
+			cerver_log_debug ("Connection reached max auth tries, dropping now...");
+			#endif
+			on_hold_connection_drop (cerver, connection);
+		}
+	}
 
 }
 
 static u8 auth_with_token_admin (const Packet *packet, const AuthData *auth_data) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && auth_data) {
-        // if we get a token, we search for an admin with the same token
-        Admin *admin = admin_get_by_session_id (packet->cerver->admin, auth_data->token->str);
+	if (packet && auth_data) {
+		// if we get a token, we search for an admin with the same token
+		Admin *admin = admin_get_by_session_id (packet->cerver->admin, auth_data->token->str);
 
-        // if we found a client, register the new connection to him
-        if (admin) {
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                "Found an ADMIN with session id <%s> in cerver %s.",
-                auth_data->token->str, packet->cerver->info->name->str
-            );
-            #endif
+		// if we found a client, register the new connection to him
+		if (admin) {
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+				"Found an ADMIN with session id <%s> in cerver %s.",
+				auth_data->token->str, packet->cerver->info->name->str
+			);
+			#endif
 
-            if (!connection_register_to_client (admin->client, packet->connection)) {
-                retval = 0;
-            }
-        }
+			if (!connection_register_to_client (admin->client, packet->connection)) {
+				retval = 0;
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "Failed to get ADMIN with matching session id <%s> in cerver %s",
-                auth_data->token->str, packet->cerver->info->name->str
-            );
+		else {
+			cerver_log_error (
+				"Failed to get ADMIN with matching session id <%s> in cerver %s",
+				auth_data->token->str, packet->cerver->info->name->str
+			);
 
-            // if not, the token is invalid!
-            auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
+			// if not, the token is invalid!
+			auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
 
-            cerver_event_trigger (
-                CERVER_EVENT_ADMIN_FAILED_AUTH,
-                packet->cerver,
-                NULL, packet->connection
-            );
-        }
-    }
+			cerver_event_trigger (
+				CERVER_EVENT_ADMIN_FAILED_AUTH,
+				packet->cerver,
+				NULL, packet->connection
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 auth_with_token_normal (const Packet *packet, const AuthData *auth_data) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && auth_data) {
-        // if we get a token, we search for a client with the same token
-        Client *client = client_get_by_session_id (packet->cerver, auth_data->token->str);
+	if (packet && auth_data) {
+		// if we get a token, we search for a client with the same token
+		Client *client = client_get_by_session_id (packet->cerver, auth_data->token->str);
 
-        // if we found a client, register the new connection to him
-        if (client) {
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                "Found a CLIENT with session id <%s> in cerver %s.",
-                auth_data->token->str, packet->cerver->info->name->str
-            );
-            #endif
+		// if we found a client, register the new connection to him
+		if (client) {
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+				"Found a CLIENT with session id <%s> in cerver %s.",
+				auth_data->token->str, packet->cerver->info->name->str
+			);
+			#endif
 
-            if (!connection_register_to_client (client, packet->connection)) {
-                if (!connection_register_to_cerver (packet->cerver, client, packet->connection)) {
-                    retval = 0;
-                }
-            }
-        }
+			if (!connection_register_to_client (client, packet->connection)) {
+				if (!connection_register_to_cerver (packet->cerver, client, packet->connection)) {
+					retval = 0;
+				}
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "Failed to get CLIENT with matching session id <%s> in cerver %s",
-                auth_data->token->str, packet->cerver->info->name->str
-            );
+		else {
+			cerver_log_error (
+				"Failed to get CLIENT with matching session id <%s> in cerver %s",
+				auth_data->token->str, packet->cerver->info->name->str
+			);
 
-            // if not, the token is invalid!
-            auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
+			// if not, the token is invalid!
+			auth_failed (packet->cerver, packet->connection, "Session id is invalid!");
 
-            cerver_event_trigger (
-                CERVER_EVENT_CLIENT_FAILED_AUTH,
-                packet->cerver,
-                client, packet->connection
-            );
-        }
-    }
+			cerver_event_trigger (
+				CERVER_EVENT_CLIENT_FAILED_AUTH,
+				packet->cerver,
+				client, packet->connection
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -330,19 +330,19 @@ static u8 auth_with_token_normal (const Packet *packet, const AuthData *auth_dat
 // returns 0 on success, 1 on error
 static u8 auth_with_token (const Packet *packet, const AuthData *auth_data, bool admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && auth_data) {
-        if (admin) {
-            retval = auth_with_token_admin (packet, auth_data);
-        }
+	if (packet && auth_data) {
+		if (admin) {
+			retval = auth_with_token_admin (packet, auth_data);
+		}
 
-        else {
-            retval = auth_with_token_normal (packet, auth_data);
-        }
-    }
+		else {
+			retval = auth_with_token_normal (packet, auth_data);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -350,152 +350,152 @@ static u8 auth_with_token (const Packet *packet, const AuthData *auth_data, bool
 // returns 0 on success, 1 on error
 static u8 auth_with_defined_method (Packet *packet, delegate authenticate, AuthData *auth_data, Client **client, bool admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && auth_data) {
-        AuthMethod *auth_method = auth_method_create (packet, auth_data);
-        if (auth_method) {
-            if (!authenticate (auth_method)) {
-                #ifdef AUTH_DEBUG
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-                    "Client authenticated successfully to cerver %s",
-                    packet->cerver->info->name->str
-                );
-                #endif
+	if (packet && auth_data) {
+		AuthMethod *auth_method = auth_method_create (packet, auth_data);
+		if (auth_method) {
+			if (!authenticate (auth_method)) {
+				#ifdef AUTH_DEBUG
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+					"Client authenticated successfully to cerver %s",
+					packet->cerver->info->name->str
+				);
+				#endif
 
-                *client = auth_create_new_client (packet, auth_data);
-                if (*client) {
-                    retval = 0;
-                }
-            }
+				*client = auth_create_new_client (packet, auth_data);
+				if (*client) {
+					retval = 0;
+				}
+			}
 
-            else {
-                #ifdef AUTH_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                    "Client failed to authenticate to cerver %s",
-                    packet->cerver->info->name->str
-                );
-                #endif
+			else {
+				#ifdef AUTH_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+					"Client failed to authenticate to cerver %s",
+					packet->cerver->info->name->str
+				);
+				#endif
 
-                auth_failed (
-                    packet->cerver, packet->connection, 
-                    auth_method->error_message ? auth_method->error_message->str : NULL
-                );
+				auth_failed (
+					packet->cerver, packet->connection,
+					auth_method->error_message ? auth_method->error_message->str : NULL
+				);
 
-                if (admin) {
-                    cerver_event_trigger (
-                        CERVER_EVENT_ADMIN_FAILED_AUTH,
-                        packet->cerver,
-                        NULL, packet->connection
-                    );
-                }
+				if (admin) {
+					cerver_event_trigger (
+						CERVER_EVENT_ADMIN_FAILED_AUTH,
+						packet->cerver,
+						NULL, packet->connection
+					);
+				}
 
-                else {
-                    cerver_event_trigger (
-                        CERVER_EVENT_CLIENT_FAILED_AUTH,
-                        packet->cerver,
-                        NULL, packet->connection
-                    );
-                }
-            }   
+				else {
+					cerver_event_trigger (
+						CERVER_EVENT_CLIENT_FAILED_AUTH,
+						packet->cerver,
+						NULL, packet->connection
+					);
+				}
+			}
 
-            auth_method_delete (auth_method);
-        }
-    }
+			auth_method_delete (auth_method);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // strip out the auth data from the packet
 static AuthData *auth_strip_auth_data (Packet *packet) {
 
-    AuthData *auth_data = NULL;
+	AuthData *auth_data = NULL;
 
-    if (packet) {
-        // check we have a big enough packet
-        if (packet->data_size > 0) {
-            char *end = (char *) packet->data;
+	if (packet) {
+		// check we have a big enough packet
+		if (packet->data_size > 0) {
+			char *end = (char *) packet->data;
 
-            // check if we have a token
-            if (packet->data_size == (sizeof (SToken))) {
-                // SToken *s_token = (SToken *) (end);
-                auth_data = auth_data_create (end, NULL, 0);
-            }
+			// check if we have a token
+			if (packet->data_size == (sizeof (SToken))) {
+				// SToken *s_token = (SToken *) (end);
+				auth_data = auth_data_create (end, NULL, 0);
+			}
 
-            // we have custom data credentials
-            else {
-                size_t data_size = packet->data_size;
-                auth_data = auth_data_create (NULL, end, data_size);
-            }
-        }
-    }
+			// we have custom data credentials
+			else {
+				size_t data_size = packet->data_size;
+				auth_data = auth_data_create (NULL, end, data_size);
+			}
+		}
+	}
 
-    return auth_data;
+	return auth_data;
 
 }
 
 static u8 auth_try_common (Packet *packet, delegate authenticate, Client **client, bool admin) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet) {
-        // strip out the auth data from the packet
-        AuthData *auth_data = auth_strip_auth_data (packet);
-        if (auth_data) {
-            // check that the cerver supports sessions
-            if (packet->cerver->use_sessions) {
-                if (auth_data->token) {
-                    retval = auth_with_token (packet, auth_data, admin);
-                }
+	if (packet) {
+		// strip out the auth data from the packet
+		AuthData *auth_data = auth_strip_auth_data (packet);
+		if (auth_data) {
+			// check that the cerver supports sessions
+			if (packet->cerver->use_sessions) {
+				if (auth_data->token) {
+					retval = auth_with_token (packet, auth_data, admin);
+				}
 
-                else {
-                    // if not, we authenticate using the user defined method
-                    retval = auth_with_defined_method (packet, authenticate, auth_data, client, admin);
-                }
-            }
+				else {
+					// if not, we authenticate using the user defined method
+					retval = auth_with_defined_method (packet, authenticate, auth_data, client, admin);
+				}
+			}
 
-            else {
-                // if not, we authenticate using the user defined method
-                retval = auth_with_defined_method (packet, authenticate, auth_data, client, admin);
-            }
+			else {
+				// if not, we authenticate using the user defined method
+				retval = auth_with_defined_method (packet, authenticate, auth_data, client, admin);
+			}
 
-            auth_data_delete (auth_data);
-        }
+			auth_data_delete (auth_data);
+		}
 
-        // failed to get auth data form packet
-        else {
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to get auth data from packet in cerver %s",
-                packet->cerver->info->name->str
-            );
-            #endif
+		// failed to get auth data form packet
+		else {
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to get auth data from packet in cerver %s",
+				packet->cerver->info->name->str
+			);
+			#endif
 
-            auth_failed (packet->cerver, packet->connection, "Missing auth data!");
+			auth_failed (packet->cerver, packet->connection, "Missing auth data!");
 
-            if (admin) {
-                cerver_event_trigger (
-                    CERVER_EVENT_ADMIN_FAILED_AUTH,
-                    packet->cerver,
-                    NULL, packet->connection
-                );
-            }
+			if (admin) {
+				cerver_event_trigger (
+					CERVER_EVENT_ADMIN_FAILED_AUTH,
+					packet->cerver,
+					NULL, packet->connection
+				);
+			}
 
-            else {
-                cerver_event_trigger (
-                    CERVER_EVENT_CLIENT_FAILED_AUTH,
-                    packet->cerver,
-                    NULL, packet->connection
-                );
-            }
-        }
-    }
+			else {
+				cerver_event_trigger (
+					CERVER_EVENT_CLIENT_FAILED_AUTH,
+					packet->cerver,
+					NULL, packet->connection
+				);
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -504,224 +504,224 @@ static u8 auth_try_common (Packet *packet, delegate authenticate, Client **clien
 // try to authenticate a connection using the values he sent to use
 static void auth_try (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->authenticate) {
-            Client *client = NULL;
-            if (!auth_try_common (packet, packet->cerver->authenticate, &client, false)) {
-                // remove from on hold structures & poll array
-                on_hold_connection_remove (packet->cerver, packet->connection);
+	if (packet) {
+		if (packet->cerver->authenticate) {
+			Client *client = NULL;
+			if (!auth_try_common (packet, packet->cerver->authenticate, &client, false)) {
+				// remove from on hold structures & poll array
+				on_hold_connection_remove (packet->cerver, packet->connection);
 
-                // reset connection's bad packets counter
-                packet->connection->bad_packets = 0;
+				// reset connection's bad packets counter
+				packet->connection->bad_packets = 0;
 
-                if (client) {
-                    // register the new client & its connection to the cerver main structures & poll
-                    if (!client_register_to_cerver (packet->cerver, client)) {
-                        // if we are successfull, send success packet
-                        if (packet->cerver->use_sessions) {
-                            SToken token = { 0 };
-                            memcpy (token.token, client->session_id->str, TOKEN_SIZE);
-                            token.token[strlen (token.token)] = '\0';
-                            
-                            auth_send_success_packet (
-                                packet->cerver, 
-                                client, packet->connection,
-                                &token, sizeof (SToken)
-                            );
-                        }
+				if (client) {
+					// register the new client & its connection to the cerver main structures & poll
+					if (!client_register_to_cerver (packet->cerver, client)) {
+						// if we are successfull, send success packet
+						if (packet->cerver->use_sessions) {
+							SToken token = { 0 };
+							memcpy (token.token, client->session_id->str, TOKEN_SIZE);
+							token.token[strlen (token.token)] = '\0';
 
-                        else {
-                            auth_send_success_packet (
-                                packet->cerver, 
-                                client, packet->connection,
-                                NULL, 0
-                            );
-                        }
+							auth_send_success_packet (
+								packet->cerver,
+								client, packet->connection,
+								&token, sizeof (SToken)
+							);
+						}
 
-                        cerver_event_trigger (
-                            CERVER_EVENT_CLIENT_SUCCESS_AUTH,
-                            packet->cerver,
-                            client, packet->connection
-                        );
+						else {
+							auth_send_success_packet (
+								packet->cerver,
+								client, packet->connection,
+								NULL, 0
+							);
+						}
 
-                        cerver_event_trigger (
-                            CERVER_EVENT_CLIENT_CONNECTED,
-                            packet->cerver,
-                            client, packet->connection
-                        );
-                    }
+						cerver_event_trigger (
+							CERVER_EVENT_CLIENT_SUCCESS_AUTH,
+							packet->cerver,
+							client, packet->connection
+						);
 
-                    else {
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
-                            "admin_auth_try () - failed to register a new admin to cerver %s",
-                            packet->cerver->info->name->str
-                        );
+						cerver_event_trigger (
+							CERVER_EVENT_CLIENT_CONNECTED,
+							packet->cerver,
+							client, packet->connection
+						);
+					}
 
-                        // send an error packet to the client
-                        error_packet_generate_and_send (
-                            CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
-                            packet->cerver, client, packet->connection
-                        );
+					else {
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+							"admin_auth_try () - failed to register a new admin to cerver %s",
+							packet->cerver->info->name->str
+						);
 
-                        // close the client's only connection and delete the client
-                        client_connection_drop (
-                            packet->cerver, 
-                            client, 
-                            (Connection *) client->connections->start->data
-                        );
+						// send an error packet to the client
+						error_packet_generate_and_send (
+							CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
+							packet->cerver, client, packet->connection
+						);
 
-                        client_delete (client);
-                    }
-                }
+						// close the client's only connection and delete the client
+						client_connection_drop (
+							packet->cerver,
+							client,
+							(Connection *) client->connections->start->data
+						);
 
-                // added connection to client with matching id (token)
-                else {
-                    Client *match = client_get_by_sock_fd (packet->cerver, packet->connection->socket->sock_fd);
-                    if (match) {
-                        // add connection's sock fd to cerver's main poll array
-                        connection_register_to_cerver_poll (packet->cerver, packet->connection);
+						client_delete (client);
+					}
+				}
 
-                        // send success auth packet to client
-                        auth_send_success_packet (packet->cerver, match, packet->connection, NULL, 0);
+				// added connection to client with matching id (token)
+				else {
+					Client *match = client_get_by_sock_fd (packet->cerver, packet->connection->socket->sock_fd);
+					if (match) {
+						// add connection's sock fd to cerver's main poll array
+						connection_register_to_cerver_poll (packet->cerver, packet->connection);
 
-                        cerver_event_trigger (
-                            CERVER_EVENT_CLIENT_NEW_CONNECTION,
-                            packet->cerver,
-                            match, packet->connection
-                        );
-                    }
-                }
-            }
-        }
+						// send success auth packet to client
+						auth_send_success_packet (packet->cerver, match, packet->connection, NULL, 0);
 
-        // no authentication method -- clients are not able to authenticate with to the cerver!
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Cerver %s does not have an authenticate method!",
-                packet->cerver->info->name->str
-            );
+						cerver_event_trigger (
+							CERVER_EVENT_CLIENT_NEW_CONNECTION,
+							packet->cerver,
+							match, packet->connection
+						);
+					}
+				}
+			}
+		}
 
-            // close the on hold connection assocaited with sock fd 
-            // and remove it from the cerver
-            on_hold_connection_drop (packet->cerver, packet->connection);
-        }
-    }
+		// no authentication method -- clients are not able to authenticate with to the cerver!
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver %s does not have an authenticate method!",
+				packet->cerver->info->name->str
+			);
+
+			// close the on hold connection assocaited with sock fd
+			// and remove it from the cerver
+			on_hold_connection_drop (packet->cerver, packet->connection);
+		}
+	}
 
 }
 
 static void admin_auth_try (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->admin) {
-            if (packet->cerver->admin->authenticate) {
-                Client *client = NULL;
-                if (!auth_try_common (packet, packet->cerver->admin->authenticate, &client, true)) {
-                    // remove from on hold structures & poll array
-                    on_hold_connection_remove (packet->cerver, packet->connection);
+	if (packet) {
+		if (packet->cerver->admin) {
+			if (packet->cerver->admin->authenticate) {
+				Client *client = NULL;
+				if (!auth_try_common (packet, packet->cerver->admin->authenticate, &client, true)) {
+					// remove from on hold structures & poll array
+					on_hold_connection_remove (packet->cerver, packet->connection);
 
-                    // reset connection's bad packets counter
-                    packet->connection->bad_packets = 0;
+					// reset connection's bad packets counter
+					packet->connection->bad_packets = 0;
 
-                    if (client) {
-                        // create a new admin with client and register it to the admin
-                        Admin *admin = admin_create_with_client (client);
-                        if (!admin_cerver_register_admin (packet->cerver->admin, admin)) {
-                            // if we are successfull, send success packet
-                            if (packet->cerver->use_sessions) {
-                                SToken token = { 0 };
-                                memcpy (token.token, client->session_id->str, TOKEN_SIZE);
-                                
-                                auth_send_success_packet (
-                                    packet->cerver, 
-                                    client, packet->connection,
-                                    &token, sizeof (SToken)
-                                );
-                            }
+					if (client) {
+						// create a new admin with client and register it to the admin
+						Admin *admin = admin_create_with_client (client);
+						if (!admin_cerver_register_admin (packet->cerver->admin, admin)) {
+							// if we are successfull, send success packet
+							if (packet->cerver->use_sessions) {
+								SToken token = { 0 };
+								memcpy (token.token, client->session_id->str, TOKEN_SIZE);
 
-                            else {
-                                auth_send_success_packet (
-                                    packet->cerver, 
-                                    client, packet->connection,
-                                    NULL, 0
-                                );
-                            }
+								auth_send_success_packet (
+									packet->cerver,
+									client, packet->connection,
+									&token, sizeof (SToken)
+								);
+							}
 
-                            cerver_event_trigger (
-                                CERVER_EVENT_ADMIN_CONNECTED,
-                                packet->cerver,
-                                client, packet->connection
-                            );
-                        }
+							else {
+								auth_send_success_packet (
+									packet->cerver,
+									client, packet->connection,
+									NULL, 0
+								);
+							}
 
-                        else {
-                            cerver_log (
-                                LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
-                                "admin_auth_try () - failed to register a new admin to cerver %s",
-                                packet->cerver->info->name->str
-                            );
+							cerver_event_trigger (
+								CERVER_EVENT_ADMIN_CONNECTED,
+								packet->cerver,
+								client, packet->connection
+							);
+						}
 
-                            // send an error packet to the client
-                            error_packet_generate_and_send (
-                                CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
-                                packet->cerver, client, packet->connection
-                            );
+						else {
+							cerver_log (
+								LOG_TYPE_ERROR, LOG_TYPE_ADMIN,
+								"admin_auth_try () - failed to register a new admin to cerver %s",
+								packet->cerver->info->name->str
+							);
 
-                            // close the admin's client only connection and delete the admin
-                            client_connection_drop (
-                                packet->cerver, 
-                                admin->client, 
-                                (Connection *) admin->client->connections->start->data
-                            );
+							// send an error packet to the client
+							error_packet_generate_and_send (
+								CERVER_ERROR_CERVER_ERROR, "Internal cerver error!",
+								packet->cerver, client, packet->connection
+							);
 
-                            admin_delete (admin);
-                        }
-                    }
+							// close the admin's client only connection and delete the admin
+							client_connection_drop (
+								packet->cerver,
+								admin->client,
+								(Connection *) admin->client->connections->start->data
+							);
 
-                    // added connection to client with matching id (token)
-                    else {
-                        Admin *admin = admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd);
-                        if (admin) {
-                            // register the new connection to the cerver admin's poll array
-                            admin_cerver_poll_register_connection (packet->cerver->admin, packet->connection);
+							admin_delete (admin);
+						}
+					}
 
-                            // send success auth packet to client
-                            auth_send_success_packet (packet->cerver, admin->client, packet->connection, NULL, 0);
+					// added connection to client with matching id (token)
+					else {
+						Admin *admin = admin_get_by_sock_fd (packet->cerver->admin, packet->connection->socket->sock_fd);
+						if (admin) {
+							// register the new connection to the cerver admin's poll array
+							admin_cerver_poll_register_connection (packet->cerver->admin, packet->connection);
 
-                            cerver_event_trigger (
-                                CERVER_EVENT_ADMIN_NEW_CONNECTION,
-                                packet->cerver,
-                                client, packet->connection
-                            );
-                        }
-                    }
-                }
-            }
+							// send success auth packet to client
+							auth_send_success_packet (packet->cerver, admin->client, packet->connection, NULL, 0);
 
-            // no authentication method -- clients are not able to authenticate with the cerver!
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Cerver %s ADMIN does not have an authenticate method!",
-                    packet->cerver->info->name->str
-                );
+							cerver_event_trigger (
+								CERVER_EVENT_ADMIN_NEW_CONNECTION,
+								packet->cerver,
+								client, packet->connection
+							);
+						}
+					}
+				}
+			}
 
-                // close the on hold connection assocaited with sock fd 
-                // and remove it from the cerver
-                on_hold_connection_drop (packet->cerver, packet->connection);
-            }
-        }
+			// no authentication method -- clients are not able to authenticate with the cerver!
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Cerver %s ADMIN does not have an authenticate method!",
+					packet->cerver->info->name->str
+				);
 
-        else {
-            cerver_log_warning (
-                "admin_auth_try () - Cerver %s does NOT support ADMINS!",
-                packet->cerver->info->name->str
-            );
+				// close the on hold connection assocaited with sock fd
+				// and remove it from the cerver
+				on_hold_connection_drop (packet->cerver, packet->connection);
+			}
+		}
 
-            on_hold_connection_drop (packet->cerver, packet->connection);
-        }
-    }
+		else {
+			cerver_log_warning (
+				"admin_auth_try () - Cerver %s does NOT support ADMINS!",
+				packet->cerver->info->name->str
+			);
+
+			on_hold_connection_drop (packet->cerver, packet->connection);
+		}
+	}
 
 }
 
@@ -731,102 +731,102 @@ static void admin_auth_try (Packet *packet) {
 
 static void cerver_on_hold_handle_max_bad_packets (Cerver *cerver, Connection *connection) {
 
-    if (cerver && connection) {
-        connection->bad_packets += 1;
+	if (cerver && connection) {
+		connection->bad_packets += 1;
 
-        if (connection->bad_packets >= cerver->on_hold_max_bad_packets) {
-            #ifdef AUTH_DEBUG
-            cerver_log_debug ("ON HOLD Connection has reached max bad packets, dropping...");
-            #endif
+		if (connection->bad_packets >= cerver->on_hold_max_bad_packets) {
+			#ifdef AUTH_DEBUG
+			cerver_log_debug ("ON HOLD Connection has reached max bad packets, dropping...");
+			#endif
 
-            on_hold_connection_drop (cerver, connection);
-        }
-    }
+			on_hold_connection_drop (cerver, connection);
+		}
+	}
 
 }
 
 // handle an auth packet
 static void cerver_auth_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->header && (packet->data_size > 0)) {
-            switch (packet->header->request_type) {
-                // the client sent use its data to authenticate itself
-                case AUTH_PACKET_TYPE_CLIENT_AUTH: auth_try (packet); break;
+	if (packet) {
+		if (packet->header && (packet->data_size > 0)) {
+			switch (packet->header->request_type) {
+				// the client sent use its data to authenticate itself
+				case AUTH_PACKET_TYPE_CLIENT_AUTH: auth_try (packet); break;
 
-                case AUTH_PACKET_TYPE_ADMIN_AUTH: admin_auth_try (packet); break;
+				case AUTH_PACKET_TYPE_ADMIN_AUTH: admin_auth_try (packet); break;
 
-                default: {
-                    #ifdef AUTH_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_PACKET, 
-                        "cerver_auth_packet_hanlder () -- got an unknwown request type"
-                    );
-                    #endif
+				default: {
+					#ifdef AUTH_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+						"cerver_auth_packet_hanlder () -- got an unknwown request type"
+					);
+					#endif
 
-                    cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
-                } break;
-            }
-        }
+					cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+				} break;
+			}
+		}
 
-        else {
-            // bad packet
-            cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
-        }
-    }
+		else {
+			// bad packet
+			cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+		}
+	}
 
 }
 
 // handles an packet from an on hold connection
 void on_hold_packet_handler (void *packet_ptr) {
 
-    if (packet_ptr) {
-        Packet *packet = (Packet *) packet_ptr;
+	if (packet_ptr) {
+		Packet *packet = (Packet *) packet_ptr;
 
-        bool good = true;
-        if (packet->cerver->on_hold_check_packets) {
-            // we expect the packet version in the packet's data
-            if (packet->data) {
-                packet->version = (PacketVersion *) packet->data_ptr;
-                packet->data_ptr += sizeof (PacketVersion);
-                good = packet_check (packet);
-            }
+		bool good = true;
+		if (packet->cerver->on_hold_check_packets) {
+			// we expect the packet version in the packet's data
+			if (packet->data) {
+				packet->version = (PacketVersion *) packet->data_ptr;
+				packet->data_ptr += sizeof (PacketVersion);
+				good = packet_check (packet);
+			}
 
-            else {
-                cerver_log_error ("on_hold_packet_handler () - No packet version to check!");
-                good = false;
-            }
-        }
+			else {
+				cerver_log_error ("on_hold_packet_handler () - No packet version to check!");
+				good = false;
+			}
+		}
 
-        if (good) {
-            switch (packet->header->packet_type) {
-                // handles authentication packets
-                case PACKET_TYPE_AUTH: cerver_auth_packet_handler (packet); break;
+		if (good) {
+			switch (packet->header->packet_type) {
+				// handles authentication packets
+				case PACKET_TYPE_AUTH: cerver_auth_packet_handler (packet); break;
 
-                // acknowledge the client we have received his test packet
-                case PACKET_TYPE_TEST: cerver_test_packet_handler (packet); break;
+				// acknowledge the client we have received his test packet
+				case PACKET_TYPE_TEST: cerver_test_packet_handler (packet); break;
 
-                default: {
-                    #ifdef AUTH_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_PACKET,
-                        "Got an ON HOLD packet of unknown type in cerver %s.", 
-                        packet->cerver->info->name->str
-                    );
-                    #endif
+				default: {
+					#ifdef AUTH_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+						"Got an ON HOLD packet of unknown type in cerver %s.",
+						packet->cerver->info->name->str
+					);
+					#endif
 
-                    cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
-                } break;
-            }
-        }
+					cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+				} break;
+			}
+		}
 
-        else {
-            // bad packet
-            cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
-        }
+		else {
+			// bad packet
+			cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+		}
 
-        packet_delete (packet);
-    }
+		packet_delete (packet);
+	}
 
 }
 
@@ -839,31 +839,31 @@ void on_hold_packet_handler (void *packet_ptr) {
 // returns 0 on success, 1 on error
 u8 on_hold_connection (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        if (cerver->on_hold_connections) {
-            if (!on_hold_poll_register_connection (cerver, connection)) {
-                avl_insert_node (cerver->on_hold_connections, connection);
+	if (cerver && connection) {
+		if (cerver->on_hold_connections) {
+			if (!on_hold_poll_register_connection (cerver, connection)) {
+				avl_insert_node (cerver->on_hold_connections, connection);
 
-                const void *key = &connection->socket->sock_fd;
-                if (!htab_insert (cerver->on_hold_connection_sock_fd_map, 
-                    key, sizeof (i32),
-                    connection, sizeof (Connection)
-                )) {
-                    cerver_log_debug ("on_hold_connection () - inserted connection in on_hold_connection_sock_fd_map htab");
+				const void *key = &connection->socket->sock_fd;
+				if (!htab_insert (cerver->on_hold_connection_sock_fd_map,
+					key, sizeof (i32),
+					connection, sizeof (Connection)
+				)) {
+					cerver_log_debug ("on_hold_connection () - inserted connection in on_hold_connection_sock_fd_map htab");
 
-                    retval = 0;     // success
-                }
+					retval = 0;     // success
+				}
 
-                else {
-                    cerver_log_error ("on_hold_connection () - failed to insert connection in on_hold_connection_sock_fd_map htab!");
-                }
-            }
-        }
-    }
+				else {
+					cerver_log_error ("on_hold_connection () - failed to insert connection in on_hold_connection_sock_fd_map htab!");
+				}
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -871,65 +871,65 @@ u8 on_hold_connection (Cerver *cerver, Connection *connection) {
 // returns 0 on success, 1 on error
 static u8 on_hold_connection_remove (const Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        if (!on_hold_poll_unregister_connection ((Cerver *) cerver, connection)) {
-            // remove the connection associated to the sock fd
-            Connection *query = connection_new ();
-            query->socket = socket_new ();
-            if (query->socket) query->socket->sock_fd = connection->socket->sock_fd;
+	if (cerver && connection) {
+		if (!on_hold_poll_unregister_connection ((Cerver *) cerver, connection)) {
+			// remove the connection associated to the sock fd
+			Connection *query = connection_new ();
+			query->socket = socket_new ();
+			if (query->socket) query->socket->sock_fd = connection->socket->sock_fd;
 
-            if (avl_remove_node (cerver->on_hold_connections, query)) {
-                cerver_log_debug ("on_hold_connection_remove () - removed connection from on_hold_connections avl");
-            }
+			if (avl_remove_node (cerver->on_hold_connections, query)) {
+				cerver_log_debug ("on_hold_connection_remove () - removed connection from on_hold_connections avl");
+			}
 
-            else {
-                cerver_log_error ("on_hold_connection_remove () - failed to remove connection from on_hold_connections avl!");
-            }
+			else {
+				cerver_log_error ("on_hold_connection_remove () - failed to remove connection from on_hold_connections avl!");
+			}
 
-            // remove connection from on hold map
-            const void *key = &connection->socket->sock_fd;
-            if (htab_remove (cerver->on_hold_connection_sock_fd_map, key, sizeof (i32))) {
-                cerver_log_debug ("on_hold_connection_remove () - removed connection from on_hold_connection_sock_fd_map htab");
-            }
+			// remove connection from on hold map
+			const void *key = &connection->socket->sock_fd;
+			if (htab_remove (cerver->on_hold_connection_sock_fd_map, key, sizeof (i32))) {
+				cerver_log_debug ("on_hold_connection_remove () - removed connection from on_hold_connection_sock_fd_map htab");
+			}
 
-            else {
-                cerver_log_error ("on_hold_connection_remove () - failed to remove connection from on_hold_connection_sock_fd_map htab!");
-            }
+			else {
+				cerver_log_error ("on_hold_connection_remove () - failed to remove connection from on_hold_connection_sock_fd_map htab!");
+			}
 
-            connection_delete (query);
+			connection_delete (query);
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // closes the on hold connection and removes it from the cerver
 void on_hold_connection_drop (const Cerver *cerver, Connection *connection) {
 
-    if (cerver && connection) {
-        // remove the connection from the on hold structures
-        on_hold_connection_remove (cerver, connection);
+	if (cerver && connection) {
+		// remove the connection from the on hold structures
+		on_hold_connection_remove (cerver, connection);
 
-        // close the connection socket
-        connection_end (connection);
+		// close the connection socket
+		connection_end (connection);
 
-        cerver_sockets_pool_push ((Cerver *) cerver, connection->socket);
-        connection->socket = NULL;
+		cerver_sockets_pool_push ((Cerver *) cerver, connection->socket);
+		connection->socket = NULL;
 
-        // we can now safely delete the connection
-        connection_delete (connection);
+		// we can now safely delete the connection
+		connection_delete (connection);
 
-        cerver_event_trigger (
-            CERVER_EVENT_ON_HOLD_DROPPED,
-            cerver,
-            NULL, NULL
-        );
-    }
+		cerver_event_trigger (
+			CERVER_EVENT_ON_HOLD_DROPPED,
+			cerver,
+			NULL, NULL
+		);
+	}
 
 }
 
@@ -939,23 +939,23 @@ void on_hold_connection_drop (const Cerver *cerver, Connection *connection) {
 
 static i32 on_hold_get_free_idx (Cerver *cerver) {
 
-    if (cerver) {
-        for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
-            if (cerver->hold_fds[i].fd == -1) return i;
-    }
+	if (cerver) {
+		for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
+			if (cerver->hold_fds[i].fd == -1) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
 static i32 on_hold_poll_get_idx_by_sock_fd (const Cerver *cerver, i32 sock_fd) {
 
-    if (cerver) {
-        for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
-            if (cerver->hold_fds[i].fd == sock_fd) return i;
-    }
+	if (cerver) {
+		for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
+			if (cerver->hold_fds[i].fd == sock_fd) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
@@ -963,52 +963,52 @@ static i32 on_hold_poll_get_idx_by_sock_fd (const Cerver *cerver, i32 sock_fd) {
 // returns 0 on success, 1 on error
 static u8 on_hold_poll_register_connection (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        // pthread_mutex_lock (cerver->on_hold_poll_lock);
+	if (cerver && connection) {
+		// pthread_mutex_lock (cerver->on_hold_poll_lock);
 
-        i32 idx = on_hold_get_free_idx (cerver);
-        if (idx >= 0) {
-            cerver->hold_fds[idx].fd = connection->socket->sock_fd;
-            cerver->hold_fds[idx].events = POLLIN;
-            cerver->current_on_hold_nfds++;
+		i32 idx = on_hold_get_free_idx (cerver);
+		if (idx >= 0) {
+			cerver->hold_fds[idx].fd = connection->socket->sock_fd;
+			cerver->hold_fds[idx].events = POLLIN;
+			cerver->current_on_hold_nfds++;
 
-            cerver->stats->current_n_hold_connections++;
+			cerver->stats->current_n_hold_connections++;
 
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Added sock fd <%d> to cerver %s ON HOLD poll, idx: %i", 
-                connection->socket->sock_fd, cerver->info->name->str, idx
-            );
-            #endif
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Added sock fd <%d> to cerver %s ON HOLD poll, idx: %i",
+				connection->socket->sock_fd, cerver->info->name->str, idx
+			);
+			#endif
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_CERVER,
-                "Cerver %s current ON HOLD connections: %ld", 
-                cerver->info->name->str, cerver->stats->current_n_hold_connections
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_CERVER,
+				"Cerver %s current ON HOLD connections: %ld",
+				cerver->info->name->str, cerver->stats->current_n_hold_connections
+			);
+			#endif
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else if (idx < 0) {
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-                "Cerver %s ON HOLD poll is full!", 
-                cerver->info->name->str
-            );
-            #endif
-        }
+		else if (idx < 0) {
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+				"Cerver %s ON HOLD poll is full!",
+				cerver->info->name->str
+			);
+			#endif
+		}
 
-        // pthread_mutex_unlock (cerver->on_hold_poll_lock);
-    }
+		// pthread_mutex_unlock (cerver->on_hold_poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1016,52 +1016,52 @@ static u8 on_hold_poll_register_connection (Cerver *cerver, Connection *connecti
 // returns 0 on success, 1 on error
 u8 on_hold_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        // pthread_mutex_lock (cerver->on_hold_poll_lock);
+	if (cerver) {
+		// pthread_mutex_lock (cerver->on_hold_poll_lock);
 
-        i32 idx = on_hold_poll_get_idx_by_sock_fd (cerver, sock_fd);
-        if (idx >= 0) {
-            cerver->hold_fds[idx].fd = -1;
-            cerver->hold_fds[idx].events = -1;
-            cerver->current_on_hold_nfds--;
+		i32 idx = on_hold_poll_get_idx_by_sock_fd (cerver, sock_fd);
+		if (idx >= 0) {
+			cerver->hold_fds[idx].fd = -1;
+			cerver->hold_fds[idx].events = -1;
+			cerver->current_on_hold_nfds--;
 
-            cerver->stats->current_n_hold_connections--;
+			cerver->stats->current_n_hold_connections--;
 
-            #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Removed sock fd <%d> from cerver %s ON HOLD poll, idx: %d",
-                sock_fd, cerver->info->name->str, idx
-            );
-            #endif
+			#ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Removed sock fd <%d> from cerver %s ON HOLD poll, idx: %d",
+				sock_fd, cerver->info->name->str, idx
+			);
+			#endif
 
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_CERVER, LOG_TYPE_CERVER,
-                "Cerver %s current ON HOLD connections: %ld", 
-                cerver->info->name->str, cerver->stats->current_n_hold_connections
-            );
-            #endif
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_CERVER,
+				"Cerver %s current ON HOLD connections: %ld",
+				cerver->info->name->str, cerver->stats->current_n_hold_connections
+			);
+			#endif
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            // #ifdef AUTH_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-                "Sock fd <%d> was NOT found in cerver %s ON HOLD poll!",
-                sock_fd, cerver->info->name->str
-            );
-            // #endif
-        }
+		else {
+			// #ifdef AUTH_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+				"Sock fd <%d> was NOT found in cerver %s ON HOLD poll!",
+				sock_fd, cerver->info->name->str
+			);
+			// #endif
+		}
 
-        // pthread_mutex_unlock (cerver->on_hold_poll_lock);
-    }
+		// pthread_mutex_unlock (cerver->on_hold_poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1069,147 +1069,147 @@ u8 on_hold_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 // returns 0 on success, 1 on error
 static u8 on_hold_poll_unregister_connection (Cerver *cerver, Connection *connection) {
 
-    return (cerver && connection) ? 
-        on_hold_poll_unregister_sock_fd (cerver, connection->socket->sock_fd) : 1;
+	return (cerver && connection) ?
+		on_hold_poll_unregister_sock_fd (cerver, connection->socket->sock_fd) : 1;
 
 }
 
 static inline void on_hold_poll_handle_actual (Cerver *cerver, const u32 idx, CerverReceive *cr) {
 
-    switch (cerver->hold_fds[idx].revents) {
-        // A connection setup has been completed or new data arrived
-        case POLLIN: {
-            // printf ("on_hold_poll_handle () - Receive fd: %d\n", cerver->hold_fds[idx].fd);
-                
-            // if (cerver->thpool) {
-                // pthread_mutex_lock (socket->mutex);
+	switch (cerver->hold_fds[idx].revents) {
+		// A connection setup has been completed or new data arrived
+		case POLLIN: {
+			// printf ("on_hold_poll_handle () - Receive fd: %d\n", cerver->hold_fds[idx].fd);
 
-                // handle received packets using multiple threads
-                // if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
-                //     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!", 
-                //         cerver->info->name->str);
-                //     if (s) {
-                //         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                //         free (s);
-                //     }
-                // }
+			// if (cerver->thpool) {
+				// pthread_mutex_lock (socket->mutex);
 
-                // 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
-                // and the received buffer handler method is the one that is called 
-                // inside the thread pool - using this method we were able to get a correct behaviour
-                // however, we still may have room form improvement as we original though ->
-                // by performing reading also inside the thpool
-                // cerver_receive (cr);
+				// handle received packets using multiple threads
+				// if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
+				//     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!",
+				//         cerver->info->name->str);
+				//     if (s) {
+				//         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
+				//         free (s);
+				//     }
+				// }
 
-                // pthread_mutex_unlock (socket->mutex);
-            // }
+				// 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
+				// and the received buffer handler method is the one that is called
+				// inside the thread pool - using this method we were able to get a correct behaviour
+				// however, we still may have room form improvement as we original though ->
+				// by performing reading also inside the thpool
+				// cerver_receive (cr);
 
-            // else {
-                // handle all received packets in the same thread
-                cerver_receive (cr);
-            // }
-        } break;
+				// pthread_mutex_unlock (socket->mutex);
+			// }
 
-        default: {
-            if (cerver->hold_fds[idx].revents != 0) {
-                // 17/06/2020 -- 15:06 -- handle as failed any other signal
-                // to avoid hanging up at 100% or getting a segfault
-                cerver_switch_receive_handle_failed (cr);
-            }
-        } break;
-    }
+			// else {
+				// handle all received packets in the same thread
+				cerver_receive (cr);
+			// }
+		} break;
+
+		default: {
+			if (cerver->hold_fds[idx].revents != 0) {
+				// 17/06/2020 -- 15:06 -- handle as failed any other signal
+				// to avoid hanging up at 100% or getting a segfault
+				cerver_switch_receive_handle_failed (cr);
+			}
+		} break;
+	}
 
 }
 
 static inline void on_hold_poll_handle (Cerver *cerver) {
 
-    if (cerver) {
-        // pthread_mutex_lock (cerver->on_hold_poll_lock);
+	if (cerver) {
+		// pthread_mutex_lock (cerver->on_hold_poll_lock);
 
-        // one or more fd(s) are readable, need to determine which ones they are
-        for (u32 idx = 0; idx < cerver->max_on_hold_connections; idx++) {
-            if (cerver->hold_fds[idx].fd > -1) {
-                if (cerver->hold_fds[idx].fd != -1) {
-                    CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_ON_HOLD, cerver, cerver->hold_fds[idx].fd);
-                    if (cr) {
-                        on_hold_poll_handle_actual (cerver, idx, cr);
-                    }
-                }
-            }
-        }
+		// one or more fd(s) are readable, need to determine which ones they are
+		for (u32 idx = 0; idx < cerver->max_on_hold_connections; idx++) {
+			if (cerver->hold_fds[idx].fd > -1) {
+				if (cerver->hold_fds[idx].fd != -1) {
+					CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_ON_HOLD, cerver, cerver->hold_fds[idx].fd);
+					if (cr) {
+						on_hold_poll_handle_actual (cerver, idx, cr);
+					}
+				}
+			}
+		}
 
-        // pthread_mutex_unlock (cerver->on_hold_poll_lock);
-    }
+		// pthread_mutex_unlock (cerver->on_hold_poll_lock);
+	}
 
 }
 
 // handles packets from the on hold clients until they authenticate
 void *on_hold_poll (void *cerver_ptr) {
 
-    if (cerver_ptr) {
-        Cerver *cerver = (Cerver *) cerver_ptr;
+	if (cerver_ptr) {
+		Cerver *cerver = (Cerver *) cerver_ptr;
 
-        cerver_log (
-            LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
-            "Cerver %s ON HOLD poll has started!", cerver->info->name->str
-        );
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+			"Cerver %s ON HOLD poll has started!", cerver->info->name->str
+		);
 
-        char *thread_name = c_string_create ("%s-on-hold", cerver->info->name->str);
-        if (thread_name) {
-            thread_set_name (thread_name);
-            free (thread_name);
-        }
+		char *thread_name = c_string_create ("%s-on-hold", cerver->info->name->str);
+		if (thread_name) {
+			thread_set_name (thread_name);
+			free (thread_name);
+		}
 
-        #ifdef AUTH_DEBUG
-        cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections to put on hold...");
-        #endif
+		#ifdef AUTH_DEBUG
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections to put on hold...");
+		#endif
 
-        int poll_retval = 0;
-        while (cerver->isRunning) {
-            poll_retval = poll (cerver->hold_fds, cerver->max_on_hold_connections, cerver->on_hold_poll_timeout);
+		int poll_retval = 0;
+		while (cerver->isRunning) {
+			poll_retval = poll (cerver->hold_fds, cerver->max_on_hold_connections, cerver->on_hold_poll_timeout);
 
-            switch (poll_retval) {
-                case -1: {
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                        "Cerver %s ON HOLD poll has failed!", cerver->info->name->str
-                    );
+			switch (poll_retval) {
+				case -1: {
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+						"Cerver %s ON HOLD poll has failed!", cerver->info->name->str
+					);
 
-                    perror ("Error");
-                    cerver->isRunning = false;
-                } break;
+					perror ("Error");
+					cerver->isRunning = false;
+				} break;
 
-                case 0: {
-                    // #ifdef AUTH_DEBUG
-                    // cerver_log (
-                    //     LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                    //     "Cerver %s ON HOLD poll timeout", cerver->info->name->str
-                    // );
-                    // #endif
-                } break;
+				case 0: {
+					// #ifdef AUTH_DEBUG
+					// cerver_log (
+					//     LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+					//     "Cerver %s ON HOLD poll timeout", cerver->info->name->str
+					// );
+					// #endif
+				} break;
 
-                default: {
-                    on_hold_poll_handle (cerver);
-                } break;
-            }
-        }
+				default: {
+					on_hold_poll_handle (cerver);
+				} break;
+			}
+		}
 
-        #ifdef AUTH_DEBUG
-        cerver_log (
-            LOG_TYPE_CERVER, LOG_TYPE_NONE,
-            "Cerver %s ON HOLD poll has stopped!", cerver->info->name->str
-        );
-        #endif
-    }
+		#ifdef AUTH_DEBUG
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Cerver %s ON HOLD poll has stopped!", cerver->info->name->str
+		);
+		#endif
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-            "Can't handle ON HOLD clients on a NULL cerver!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Can't handle ON HOLD clients on a NULL cerver!"
+		);
+	}
 
-    return NULL;
+	return NULL;
 
 }
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1,7 +1,3 @@
-#ifndef _GNU_SOURCE
-    #define _GNU_SOURCE
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1386,8 +1386,8 @@ static u8 cerver_init_internal (Cerver *cerver) {
 			"Initializing cerver %s...", cerver->info->name->str
 		);
 
-		cerver_log_msg ("Cerver type: %s\n", cerver_type_to_string (cerver->type));
-		cerver_log_msg ("Cerver handler type: %s\n", cerver_handler_type_to_string (cerver->handler_type));
+		cerver_log_msg ("Cerver type: %s", cerver_type_to_string (cerver->type));
+		cerver_log_msg ("Cerver handler type: %s", cerver_handler_type_to_string (cerver->handler_type));
 
 		if (!cerver_network_init (cerver)) {
 			if (!cerver_init_data_structures (cerver)) {
@@ -1764,10 +1764,17 @@ static u8 cerver_custom_handler_start (Cerver *cerver) {
 		}
 
 		else {
-			cerver_log_warning (
-				"Cerver %s does not have an custom_packet_handler",
-				cerver->info->name->str
-			);
+			switch (cerver->type) {
+				case CERVER_TYPE_WEB: break;
+				case CERVER_TYPE_FILES: break;
+
+				default: {
+					cerver_log_warning (
+						"Cerver %s does not have a custom_packet_handler",
+						cerver->info->name->str
+					);
+				} break;
+			}
 		}
 	}
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -43,7 +43,7 @@
 // should be called only once at the start of the program
 void cerver_init (void) {
 
-    cerver_log_init ();
+	cerver_log_init ();
 
 }
 
@@ -51,7 +51,7 @@ void cerver_init (void) {
 // should be called only once at the very end of the program
 void cerver_end (void) {
 
-    cerver_log_end ();
+	cerver_log_end ();
 
 }
 
@@ -61,38 +61,38 @@ void cerver_end (void) {
 
 const char *cerver_type_to_string (CerverType type) {
 
-    switch (type) {
-        #define XX(num, name, string) case CERVER_TYPE_##name: return #string;
-        CERVER_TYPE_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, string) case CERVER_TYPE_##name: return #string;
+		CERVER_TYPE_MAP(XX)
+		#undef XX
+	}
 
-    return cerver_type_to_string (CERVER_TYPE_NONE);
+	return cerver_type_to_string (CERVER_TYPE_NONE);
 
 }
 
 const char *cerver_handler_type_to_string (CerverHandlerType type) {
 
-    switch (type) {
-        #define XX(num, name, string, description) case CERVER_HANDLER_TYPE_##name: return #string;
-        CERVER_HANDLER_TYPE_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, string, description) case CERVER_HANDLER_TYPE_##name: return #string;
+		CERVER_HANDLER_TYPE_MAP(XX)
+		#undef XX
+	}
 
-    return cerver_handler_type_to_string (CERVER_TYPE_NONE);
+	return cerver_handler_type_to_string (CERVER_TYPE_NONE);
 
 }
 
 const char *cerver_handler_type_description (CerverHandlerType type) {
 
-    switch (type) {
-        #define XX(num, name, string, description) case CERVER_HANDLER_TYPE_##name: return #description;
-        CERVER_HANDLER_TYPE_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, string, description) case CERVER_HANDLER_TYPE_##name: return #description;
+		CERVER_HANDLER_TYPE_MAP(XX)
+		#undef XX
+	}
 
-    return cerver_handler_type_description (CERVER_TYPE_NONE);
-    
+	return cerver_handler_type_description (CERVER_TYPE_NONE);
+
 }
 
 #pragma endregion
@@ -101,27 +101,27 @@ const char *cerver_handler_type_description (CerverHandlerType type) {
 
 static CerverInfo *cerver_info_new (void) {
 
-    CerverInfo *cerver_info = (CerverInfo *) malloc (sizeof (CerverInfo));
-    if (cerver_info) {
-        memset (cerver_info, 0, sizeof (CerverInfo));
-        cerver_info->name = NULL;
-        cerver_info->welcome_msg = NULL;
-        cerver_info->cerver_info_packet = NULL;
-    }
+	CerverInfo *cerver_info = (CerverInfo *) malloc (sizeof (CerverInfo));
+	if (cerver_info) {
+		memset (cerver_info, 0, sizeof (CerverInfo));
+		cerver_info->name = NULL;
+		cerver_info->welcome_msg = NULL;
+		cerver_info->cerver_info_packet = NULL;
+	}
 
-    return cerver_info;
+	return cerver_info;
 
 }
 
 static void cerver_info_delete (CerverInfo *cerver_info) {
 
-    if (cerver_info) {
-        str_delete (cerver_info->name);
-        str_delete (cerver_info->welcome_msg);
-        packet_delete (cerver_info->cerver_info_packet);
+	if (cerver_info) {
+		str_delete (cerver_info->name);
+		str_delete (cerver_info->welcome_msg);
+		packet_delete (cerver_info->cerver_info_packet);
 
-        free (cerver_info);
-    }
+		free (cerver_info);
+	}
 
 }
 
@@ -129,17 +129,17 @@ static void cerver_info_delete (CerverInfo *cerver_info) {
 // retuns 0 on success, 1 on error
 u8 cerver_set_welcome_msg (Cerver *cerver, const char *msg) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (cerver->info) {
-            str_delete (cerver->info->welcome_msg);
-            cerver->info->welcome_msg = msg ? str_new (msg) : NULL;
-            retval = 0;
-        }
-    }
+	if (cerver) {
+		if (cerver->info) {
+			str_delete (cerver->info->welcome_msg);
+			cerver->info->welcome_msg = msg ? str_new (msg) : NULL;
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -147,31 +147,31 @@ u8 cerver_set_welcome_msg (Cerver *cerver, const char *msg) {
 // retuns 0 on success, 1 on error
 u8 cerver_info_send_info_packet (Cerver *cerver, Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        packet_set_network_values (
-            cerver->info->cerver_info_packet,
-            cerver,
-            client,
-            connection,
-            NULL
-        );
+	if (cerver && connection) {
+		packet_set_network_values (
+			cerver->info->cerver_info_packet,
+			cerver,
+			client,
+			connection,
+			NULL
+		);
 
-        if (!packet_send (cerver->info->cerver_info_packet, 0, NULL, false)) {
-            retval = 0;
-        }
+		if (!packet_send (cerver->info->cerver_info_packet, 0, NULL, false)) {
+			retval = 0;
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_PACKET,
-                "Failed to send cerver %s info packet!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_PACKET,
+				"Failed to send cerver %s info packet!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -181,98 +181,98 @@ u8 cerver_info_send_info_packet (Cerver *cerver, Client *client, Connection *con
 
 static CerverStats *cerver_stats_new (void) {
 
-    CerverStats *cerver_stats = (CerverStats *) malloc (sizeof (CerverStats));
-    if (cerver_stats) {
-        memset (cerver_stats, 0, sizeof (CerverStats));
-        cerver_stats->received_packets = packets_per_type_new ();
-        cerver_stats->sent_packets = packets_per_type_new ();
-    }
+	CerverStats *cerver_stats = (CerverStats *) malloc (sizeof (CerverStats));
+	if (cerver_stats) {
+		memset (cerver_stats, 0, sizeof (CerverStats));
+		cerver_stats->received_packets = packets_per_type_new ();
+		cerver_stats->sent_packets = packets_per_type_new ();
+	}
 
-    return cerver_stats;
+	return cerver_stats;
 
 }
 
 static void cerver_stats_delete (CerverStats *cerver_stats) {
 
-    if (cerver_stats) {
-        packets_per_type_delete (cerver_stats->received_packets);
-        packets_per_type_delete (cerver_stats->sent_packets);
+	if (cerver_stats) {
+		packets_per_type_delete (cerver_stats->received_packets);
+		packets_per_type_delete (cerver_stats->sent_packets);
 
-        free (cerver_stats);
-    }
+		free (cerver_stats);
+	}
 
 }
 
 // sets the cerver stats threshold time (how often the stats get reset)
 void cerver_stats_set_threshold_time (Cerver *cerver, time_t threshold_time) {
 
-    if (cerver) {
-        if (cerver->stats) cerver->stats->threshold_time = threshold_time;
-    }
+	if (cerver) {
+		if (cerver->stats) cerver->stats->threshold_time = threshold_time;
+	}
 
 }
 
 void cerver_stats_print (Cerver *cerver, bool received, bool sent) {
 
-    if (cerver) {
-        if (cerver->stats) {
-            printf ("\nCerver's %s stats: \n", cerver->info->name->str);
-            printf ("Threshold time:                %ld\n", cerver->stats->threshold_time);
+	if (cerver) {
+		if (cerver->stats) {
+			printf ("\nCerver's %s stats: \n", cerver->info->name->str);
+			printf ("Threshold time:                %ld\n", cerver->stats->threshold_time);
 
-            if (cerver->auth_required) {
-                printf ("Client packets received:       %ld\n", cerver->stats->client_n_packets_received);
-                printf ("Client receives done:          %ld\n", cerver->stats->client_receives_done);
-                printf ("Client bytes received:         %ld\n\n", cerver->stats->client_bytes_received);
+			if (cerver->auth_required) {
+				printf ("Client packets received:       %ld\n", cerver->stats->client_n_packets_received);
+				printf ("Client receives done:          %ld\n", cerver->stats->client_receives_done);
+				printf ("Client bytes received:         %ld\n\n", cerver->stats->client_bytes_received);
 
-                printf ("On hold packets received:       %ld\n", cerver->stats->on_hold_n_packets_received);
-                printf ("On hold receives done:          %ld\n", cerver->stats->on_hold_receives_done);
-                printf ("On hold bytes received:         %ld\n\n", cerver->stats->on_hold_bytes_received);
-            }
+				printf ("On hold packets received:       %ld\n", cerver->stats->on_hold_n_packets_received);
+				printf ("On hold receives done:          %ld\n", cerver->stats->on_hold_receives_done);
+				printf ("On hold bytes received:         %ld\n\n", cerver->stats->on_hold_bytes_received);
+			}
 
-            printf ("\n");
-            printf ("Total packets received:        %ld\n", cerver->stats->total_n_packets_received);
-            printf ("Total receives done:           %ld\n", cerver->stats->total_n_receives_done);
-            printf ("Total bytes received:          %ld\n\n", cerver->stats->total_bytes_received);
+			printf ("\n");
+			printf ("Total packets received:        %ld\n", cerver->stats->total_n_packets_received);
+			printf ("Total receives done:           %ld\n", cerver->stats->total_n_receives_done);
+			printf ("Total bytes received:          %ld\n\n", cerver->stats->total_bytes_received);
 
-            printf ("\n");
-            printf ("N packets sent:                %ld\n", cerver->stats->n_packets_sent);
-            printf ("Total bytes sent:              %ld\n", cerver->stats->total_bytes_sent);
+			printf ("\n");
+			printf ("N packets sent:                %ld\n", cerver->stats->n_packets_sent);
+			printf ("Total bytes sent:              %ld\n", cerver->stats->total_bytes_sent);
 
-            printf ("\n");
-            printf ("Current active client connections:         %ld\n", cerver->stats->current_active_client_connections);
-            printf ("Current connected clients:                 %ld\n", cerver->stats->current_n_connected_clients);
-            printf ("Current on hold connections:               %ld\n", cerver->stats->current_n_hold_connections);
-            printf ("Total on hold connections:                 %ld\n", cerver->stats->total_on_hold_connections);
-            printf ("Total clients:                             %ld\n", cerver->stats->total_n_clients);
-            printf ("Unique clients:                            %ld\n", cerver->stats->unique_clients);
-            printf ("Total client connections:                  %ld\n", cerver->stats->total_client_connections);
+			printf ("\n");
+			printf ("Current active client connections:         %ld\n", cerver->stats->current_active_client_connections);
+			printf ("Current connected clients:                 %ld\n", cerver->stats->current_n_connected_clients);
+			printf ("Current on hold connections:               %ld\n", cerver->stats->current_n_hold_connections);
+			printf ("Total on hold connections:                 %ld\n", cerver->stats->total_on_hold_connections);
+			printf ("Total clients:                             %ld\n", cerver->stats->total_n_clients);
+			printf ("Unique clients:                            %ld\n", cerver->stats->unique_clients);
+			printf ("Total client connections:                  %ld\n", cerver->stats->total_client_connections);
 
-            if (received) {
-                printf ("\nReceived packets:\n");
-                packets_per_type_print (cerver->stats->received_packets);
-            }
+			if (received) {
+				printf ("\nReceived packets:\n");
+				packets_per_type_print (cerver->stats->received_packets);
+			}
 
-            if (sent) {
-                printf ("\nSent packets:\n");
-                packets_per_type_print (cerver->stats->sent_packets);
-            }
-        }
+			if (sent) {
+				printf ("\nSent packets:\n");
+				packets_per_type_print (cerver->stats->sent_packets);
+			}
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Cerver %s does not have a reference to cerver stats!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver %s does not have a reference to cerver stats!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-            "Cant print stats of a NULL cerver!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+			"Cant print stats of a NULL cerver!"
+		);
+	}
 
 }
 
@@ -282,205 +282,205 @@ void cerver_stats_print (Cerver *cerver, bool received, bool sent) {
 
 Cerver *cerver_new (void) {
 
-    Cerver *c = (Cerver *) malloc (sizeof (Cerver));
-    if (c) {
-        memset (c, 0, sizeof (Cerver));
+	Cerver *c = (Cerver *) malloc (sizeof (Cerver));
+	if (c) {
+		memset (c, 0, sizeof (Cerver));
 
-        c->sock = -1;
+		c->sock = -1;
 
-        c->protocol = PROTOCOL_TCP;         // default protocol
-        c->use_ipv6 = false;
-        c->connection_queue = DEFAULT_CONNECTION_QUEUE;
-        c->receive_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
+		c->protocol = PROTOCOL_TCP;         // default protocol
+		c->use_ipv6 = false;
+		c->connection_queue = DEFAULT_CONNECTION_QUEUE;
+		c->receive_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
 
-        c->isRunning = false;
-        c->blocking = true;
+		c->isRunning = false;
+		c->blocking = true;
 
-        c->cerver_data = NULL;
-        c->delete_cerver_data = NULL;
+		c->cerver_data = NULL;
+		c->delete_cerver_data = NULL;
 
-        c->n_thpool_threads = 0;
-        c->thpool = NULL;
+		c->n_thpool_threads = 0;
+		c->thpool = NULL;
 
-        c->sockets_pool_init = DEFAULT_SOCKETS_INIT;
-        c->sockets_pool = NULL;
+		c->sockets_pool_init = DEFAULT_SOCKETS_INIT;
+		c->sockets_pool = NULL;
 
-        c->clients = NULL;
-        c->client_sock_fd_map = NULL;
+		c->clients = NULL;
+		c->client_sock_fd_map = NULL;
 
-        c->inactive_clients = false;
+		c->inactive_clients = false;
 
-        c->handler_type = CERVER_HANDLER_TYPE_NONE;
+		c->handler_type = CERVER_HANDLER_TYPE_NONE;
 
-        c->handle_detachable_threads = false;
+		c->handle_detachable_threads = false;
 
-        c->fds = NULL;
-        c->poll_timeout = DEFAULT_POLL_TIMEOUT;
-        c->poll_lock = NULL;
+		c->fds = NULL;
+		c->poll_timeout = DEFAULT_POLL_TIMEOUT;
+		c->poll_lock = NULL;
 
-        c->auth_required = false;
-        c->auth_packet = NULL;
-        c->max_auth_tries = DEFAULT_AUTH_TRIES;
-        c->authenticate = NULL;
+		c->auth_required = false;
+		c->auth_packet = NULL;
+		c->max_auth_tries = DEFAULT_AUTH_TRIES;
+		c->authenticate = NULL;
 
-        c->on_hold_connections = NULL;
-        c->on_hold_connection_sock_fd_map = NULL;
-        c->hold_fds = NULL;
-        c->on_hold_poll_timeout = DEFAULT_POLL_TIMEOUT;
-        c->on_hold_poll_lock = NULL;
-        c->on_hold_max_bad_packets = DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
-        c->on_hold_check_packets = false;
+		c->on_hold_connections = NULL;
+		c->on_hold_connection_sock_fd_map = NULL;
+		c->hold_fds = NULL;
+		c->on_hold_poll_timeout = DEFAULT_POLL_TIMEOUT;
+		c->on_hold_poll_lock = NULL;
+		c->on_hold_max_bad_packets = DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
+		c->on_hold_check_packets = false;
 
-        c->use_sessions = false;
-        c->session_id_generator = NULL;
+		c->use_sessions = false;
+		c->session_id_generator = NULL;
 
-        c->handle_received_buffer = NULL;
+		c->handle_received_buffer = NULL;
 
-        c->app_packet_handler = NULL;
-        c->app_error_packet_handler = NULL;
-        c->custom_packet_handler = NULL;
+		c->app_packet_handler = NULL;
+		c->app_error_packet_handler = NULL;
+		c->custom_packet_handler = NULL;
 
-        c->app_packet_handler_delete_packet = true;
-        c->app_error_packet_handler_delete_packet = true;
-        c->custom_packet_handler_delete_packet = true;
+		c->app_packet_handler_delete_packet = true;
+		c->app_error_packet_handler_delete_packet = true;
+		c->custom_packet_handler_delete_packet = true;
 
-        c->handlers = NULL;
-        c->handlers_lock = NULL;
+		c->handlers = NULL;
+		c->handlers_lock = NULL;
 
-        c->check_packets = false;
+		c->check_packets = false;
 
-        c->update = NULL;
-        c->update_args = NULL;
-        c->delete_update_args = NULL;
-        c->update_ticks = DEFAULT_UPDATE_TICKS;
+		c->update = NULL;
+		c->update_args = NULL;
+		c->delete_update_args = NULL;
+		c->update_ticks = DEFAULT_UPDATE_TICKS;
 
-        c->update_interval = NULL;
-        c->update_interval_args = NULL;
-        c->delete_update_interval_args = NULL;
-        c->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
+		c->update_interval = NULL;
+		c->update_interval_args = NULL;
+		c->delete_update_interval_args = NULL;
+		c->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
 
-        c->admin = NULL;
+		c->admin = NULL;
 
-        for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
-            c->events[i] = NULL;
+		for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
+			c->events[i] = NULL;
 
-        for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
-            c->errors[i] = NULL;
+		for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
+			c->errors[i] = NULL;
 
-        c->info = NULL;
-        c->stats = NULL;
-    }
+		c->info = NULL;
+		c->stats = NULL;
+	}
 
-    return c;
+	return c;
 
 }
 
 void cerver_delete (void *ptr) {
 
-    if (ptr) {
-        Cerver *cerver = (Cerver *) ptr;
+	if (ptr) {
+		Cerver *cerver = (Cerver *) ptr;
 
-        if (cerver->cerver_data) {
-            if (cerver->delete_cerver_data) cerver->delete_cerver_data (cerver->cerver_data);
-            else free (cerver->cerver_data);
-        }
+		if (cerver->cerver_data) {
+			if (cerver->delete_cerver_data) cerver->delete_cerver_data (cerver->cerver_data);
+			else free (cerver->cerver_data);
+		}
 
-        pool_delete (cerver->sockets_pool);
+		pool_delete (cerver->sockets_pool);
 
-        if (cerver->clients) avl_delete (cerver->clients);
-        if (cerver->client_sock_fd_map) htab_destroy (cerver->client_sock_fd_map);
+		if (cerver->clients) avl_delete (cerver->clients);
+		if (cerver->client_sock_fd_map) htab_destroy (cerver->client_sock_fd_map);
 
-        if (cerver->fds) free (cerver->fds);
+		if (cerver->fds) free (cerver->fds);
 
-        // 28/05/2020
-        if (cerver->poll_lock) {
-            pthread_mutex_destroy (cerver->poll_lock);
-            free (cerver->poll_lock);
-        }
+		// 28/05/2020
+		if (cerver->poll_lock) {
+			pthread_mutex_destroy (cerver->poll_lock);
+			free (cerver->poll_lock);
+		}
 
-        packet_delete (cerver->auth_packet);
+		packet_delete (cerver->auth_packet);
 
-        if (cerver->on_hold_connections) avl_delete (cerver->on_hold_connections);
-        if (cerver->on_hold_connection_sock_fd_map) htab_destroy (cerver->on_hold_connection_sock_fd_map);
-        if (cerver->hold_fds) free (cerver->hold_fds);
+		if (cerver->on_hold_connections) avl_delete (cerver->on_hold_connections);
+		if (cerver->on_hold_connection_sock_fd_map) htab_destroy (cerver->on_hold_connection_sock_fd_map);
+		if (cerver->hold_fds) free (cerver->hold_fds);
 
-        if (cerver->on_hold_poll_lock) {
-            pthread_mutex_destroy (cerver->on_hold_poll_lock);
-            free (cerver->on_hold_poll_lock);
-        }
+		if (cerver->on_hold_poll_lock) {
+			pthread_mutex_destroy (cerver->on_hold_poll_lock);
+			free (cerver->on_hold_poll_lock);
+		}
 
-        // 27/05/2020
-        handler_delete (cerver->app_packet_handler);
-        handler_delete (cerver->app_error_packet_handler);
-        handler_delete (cerver->custom_packet_handler);
+		// 27/05/2020
+		handler_delete (cerver->app_packet_handler);
+		handler_delete (cerver->app_error_packet_handler);
+		handler_delete (cerver->custom_packet_handler);
 
-        // 10/05/2020
-        if (cerver->handlers) {
-            for (unsigned int idx = 0; idx < cerver->n_handlers; idx++) {
-                handler_delete (cerver->handlers[idx]);
-            }
+		// 10/05/2020
+		if (cerver->handlers) {
+			for (unsigned int idx = 0; idx < cerver->n_handlers; idx++) {
+				handler_delete (cerver->handlers[idx]);
+			}
 
-            free (cerver->handlers);
-        }
+			free (cerver->handlers);
+		}
 
-        if (cerver->handlers_lock) {
-            pthread_mutex_destroy (cerver->handlers_lock);
-            free (cerver->handlers_lock);
-        }
+		if (cerver->handlers_lock) {
+			pthread_mutex_destroy (cerver->handlers_lock);
+			free (cerver->handlers_lock);
+		}
 
-        admin_cerver_delete (cerver->admin);
+		admin_cerver_delete (cerver->admin);
 
-        for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
-            if (cerver->events[i]) cerver_event_delete (cerver->events[i]);
+		for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
+			if (cerver->events[i]) cerver_event_delete (cerver->events[i]);
 
-        for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
-            if (cerver->errors[i]) cerver_error_event_delete (cerver->errors[i]);
+		for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
+			if (cerver->errors[i]) cerver_error_event_delete (cerver->errors[i]);
 
-        cerver_info_delete (cerver->info);
-        cerver_stats_delete (cerver->stats);
+		cerver_info_delete (cerver->info);
+		cerver_stats_delete (cerver->stats);
 
-        free (cerver);
-    }
+		free (cerver);
+	}
 
 }
 
 // sets the cerver main network values
 void cerver_set_network_values (
-    Cerver *cerver,
-    const u16 port, const Protocol protocol,
-    bool use_ipv6, const u16 connection_queue
+	Cerver *cerver,
+	const u16 port, const Protocol protocol,
+	bool use_ipv6, const u16 connection_queue
 ) {
 
-    if (cerver) {
-        cerver->port = port;
-        cerver->protocol = protocol;
-        cerver->use_ipv6 = use_ipv6;
-        cerver->connection_queue = connection_queue;
-    }
+	if (cerver) {
+		cerver->port = port;
+		cerver->protocol = protocol;
+		cerver->use_ipv6 = use_ipv6;
+		cerver->connection_queue = connection_queue;
+	}
 
 }
 
 // sets the cerver connection queue (how many connections to queue for accept)
 void cerver_set_connection_queue (Cerver *cerver, const u16 connection_queue) {
 
-    if (cerver) cerver->connection_queue = connection_queue;
+	if (cerver) cerver->connection_queue = connection_queue;
 
 }
 
 // sets the cerver's receive buffer size used in recv method
 void cerver_set_receive_buffer_size (Cerver *cerver, const u32 size) {
 
-    if (cerver) cerver->receive_buffer_size = size;
+	if (cerver) cerver->receive_buffer_size = size;
 
 }
 
 // sets the cerver's data and a way to free it
 void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data) {
 
-    if (cerver) {
-        cerver->cerver_data = data;
-        cerver->delete_cerver_data = delete_data;
-    }
+	if (cerver) {
+		cerver->cerver_data = data;
+		cerver->delete_cerver_data = delete_data;
+	}
 
 }
 
@@ -492,7 +492,7 @@ void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data) {
 // by default, all received packets will be handle only in one thread
 void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads) {
 
-    if (cerver) cerver->n_thpool_threads = n_threads;
+	if (cerver) cerver->n_thpool_threads = n_threads;
 
 }
 
@@ -500,7 +500,7 @@ void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads) {
 // the defauult value is 10
 void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets) {
 
-    if (cerver) cerver->sockets_pool_init = n_sockets;
+	if (cerver) cerver->sockets_pool_init = n_sockets;
 
 }
 
@@ -511,11 +511,11 @@ void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets) {
 // check_inactive_interval - how often to check for inactive clients in secs, 0 for default
 void cerver_set_inactive_clients (Cerver *cerver, u32 max_inactive_time, u32 check_inactive_interval) {
 
-    if (cerver) {
-        cerver->inactive_clients = true;
-        cerver->max_inactive_time = max_inactive_time ? max_inactive_time : DEFAULT_MAX_INACTIVE_TIME;
-        cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : DEFAULT_CHECK_INACTIVE_INTERVAL;
-    }
+	if (cerver) {
+		cerver->inactive_clients = true;
+		cerver->max_inactive_time = max_inactive_time ? max_inactive_time : DEFAULT_MAX_INACTIVE_TIME;
+		cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : DEFAULT_CHECK_INACTIVE_INTERVAL;
+	}
 
 }
 
@@ -524,7 +524,7 @@ void cerver_set_inactive_clients (Cerver *cerver, u32 max_inactive_time, u32 che
 // if threads type is selected, a new thread will be created for each new connection
 void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type) {
 
-    if (cerver) cerver->handler_type = handler_type;
+	if (cerver) cerver->handler_type = handler_type;
 
 }
 
@@ -534,14 +534,14 @@ void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type) {
 // if cerver is of type CERVER_TYPE_WEB, the thpool will be used more often as connections have a shorter life
 void cerver_set_handle_detachable_threads (Cerver *cerver, bool active) {
 
-    if (cerver) cerver->handle_detachable_threads = active;
+	if (cerver) cerver->handle_detachable_threads = active;
 
 }
 
 // sets the cerver poll timeout
 void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout) {
 
-    if (cerver) cerver->poll_timeout = poll_timeout;
+	if (cerver) cerver->poll_timeout = poll_timeout;
 
 }
 
@@ -550,24 +550,24 @@ void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout) {
 // retuns 0 on success, 1 on error
 u8 cerver_set_auth (Cerver *cerver, u8 max_auth_tries, delegate authenticate) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        cerver->auth_required = true;
-        cerver->max_auth_tries = max_auth_tries;
-        cerver->authenticate = authenticate;
+	if (cerver) {
+		cerver->auth_required = true;
+		cerver->max_auth_tries = max_auth_tries;
+		cerver->authenticate = authenticate;
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sets the max auth tries a new connection is allowed to have before it is dropped due to failure
 void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries) {
 
-    if (cerver) cerver->max_auth_tries = max_auth_tries;
+	if (cerver) cerver->max_auth_tries = max_auth_tries;
 
 }
 
@@ -575,14 +575,14 @@ void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries) {
 // must return 0 on success authentication
 void cerver_set_auth_method (Cerver *cerver, delegate authenticate) {
 
-    if (cerver && authenticate) cerver->authenticate = authenticate;
+	if (cerver && authenticate) cerver->authenticate = authenticate;
 
 }
 
 // sets the cerver on poll timeout in ms
 void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout) {
 
-    if (cerver) cerver->on_hold_poll_timeout = on_hold_poll_timeout;
+	if (cerver) cerver->on_hold_poll_timeout = on_hold_poll_timeout;
 
 }
 
@@ -592,7 +592,7 @@ void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout) 
 // or because it failed the packet_check () method
 void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_packets) {
 
-    if (cerver) cerver->on_hold_max_bad_packets = on_hold_max_bad_packets;
+	if (cerver) cerver->on_hold_max_bad_packets = on_hold_max_bad_packets;
 
 }
 
@@ -600,7 +600,7 @@ void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_pack
 // any packet that fails the check will be considered as a bad packet
 void cerver_set_on_hold_check_packets (Cerver *cerver, bool check) {
 
-    if (cerver) cerver->on_hold_check_packets = check;
+	if (cerver) cerver->on_hold_check_packets = check;
 
 }
 
@@ -608,44 +608,44 @@ void cerver_set_on_hold_check_packets (Cerver *cerver, bool check) {
 // retuns 0 on success, 1 on error
 u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const void *)) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (session_id_generator) {
-            cerver->session_id_generator = session_id_generator;
-            cerver->use_sessions = true;
+	if (cerver) {
+		if (session_id_generator) {
+			cerver->session_id_generator = session_id_generator;
+			cerver->use_sessions = true;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sets a custom method to handle the raw received buffer from the socker
 void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer) {
 
-    if (cerver) cerver->handle_received_buffer = handle_received_buffer;
+	if (cerver) cerver->handle_received_buffer = handle_received_buffer;
 
 }
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 void cerver_set_app_handlers (Cerver *cerver, Handler *app_handler, Handler *app_error_handler) {
 
-    if (cerver) {
-        cerver->app_packet_handler = app_handler;
-        if (cerver->app_packet_handler) {
-            cerver->app_packet_handler->type = HANDLER_TYPE_CERVER;
-            cerver->app_packet_handler->cerver = cerver;
-        }
+	if (cerver) {
+		cerver->app_packet_handler = app_handler;
+		if (cerver->app_packet_handler) {
+			cerver->app_packet_handler->type = HANDLER_TYPE_CERVER;
+			cerver->app_packet_handler->cerver = cerver;
+		}
 
-        cerver->app_error_packet_handler = app_error_handler;
-        if (cerver->app_error_packet_handler) {
-            cerver->app_error_packet_handler->type = HANDLER_TYPE_CERVER;
-            cerver->app_error_packet_handler->cerver = cerver;
-        }
-    }
+		cerver->app_error_packet_handler = app_error_handler;
+		if (cerver->app_error_packet_handler) {
+			cerver->app_error_packet_handler->type = HANDLER_TYPE_CERVER;
+			cerver->app_error_packet_handler->cerver = cerver;
+		}
+	}
 
 }
 
@@ -654,7 +654,7 @@ void cerver_set_app_handlers (Cerver *cerver, Handler *app_handler, Handler *app
 // by the default, packets are deleted by cerver
 void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet) {
 
-    if (cerver) cerver->app_packet_handler_delete_packet = delete_packet;
+	if (cerver) cerver->app_packet_handler_delete_packet = delete_packet;
 
 }
 
@@ -663,20 +663,20 @@ void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet) {
 // by the default, packets are deleted by cerver
 void cerver_set_app_error_handler_delete (Cerver *cerver, bool delete_packet) {
 
-    if (cerver) cerver->app_error_packet_handler_delete_packet = delete_packet;
+	if (cerver) cerver->app_error_packet_handler_delete_packet = delete_packet;
 
 }
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
 void cerver_set_custom_handler (Cerver *cerver, Handler *custom_handler) {
 
-    if (cerver) {
-        cerver->custom_packet_handler = custom_handler;
-        if (cerver->custom_packet_handler) {
-            cerver->custom_packet_handler->type = HANDLER_TYPE_CERVER;
-            cerver->custom_packet_handler->cerver = cerver;
-        }
-    }
+	if (cerver) {
+		cerver->custom_packet_handler = custom_handler;
+		if (cerver->custom_packet_handler) {
+			cerver->custom_packet_handler->type = HANDLER_TYPE_CERVER;
+			cerver->custom_packet_handler->cerver = cerver;
+		}
+	}
 
 }
 
@@ -685,7 +685,7 @@ void cerver_set_custom_handler (Cerver *cerver, Handler *custom_handler) {
 // by the default, packets are deleted by cerver
 void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet) {
 
-    if (cerver) cerver->custom_packet_handler_delete_packet = delete_packet;
+	if (cerver) cerver->custom_packet_handler_delete_packet = delete_packet;
 
 }
 
@@ -693,26 +693,26 @@ void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet) {
 // returns 0 on success, 1 on error
 int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (cerver) {
-        cerver->multiple_handlers = true;
-        cerver->n_handlers = n_handlers;
+	if (cerver) {
+		cerver->multiple_handlers = true;
+		cerver->n_handlers = n_handlers;
 
-        cerver->handlers = (Handler **) calloc (cerver->n_handlers, sizeof (Handler *));
-        if (cerver->handlers) {
-            for (unsigned int idx = 0; idx < cerver->n_handlers; idx++)
-                cerver->handlers[idx] = NULL;
+		cerver->handlers = (Handler **) calloc (cerver->n_handlers, sizeof (Handler *));
+		if (cerver->handlers) {
+			for (unsigned int idx = 0; idx < cerver->n_handlers; idx++)
+				cerver->handlers[idx] = NULL;
 
-            // 27/05/2020 -- moved to cerver_handlers_start ()
-            // cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-            // pthread_mutex_init (cerver->handlers_lock, NULL);
+			// 27/05/2020 -- moved to cerver_handlers_start ()
+			// cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+			// pthread_mutex_init (cerver->handlers_lock, NULL);
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -723,9 +723,9 @@ int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers) {
 // by default, this option is turned off
 void cerver_set_check_packets (Cerver *cerver, bool check_packets) {
 
-    if (cerver) {
-        cerver->check_packets = check_packets;
-    }
+	if (cerver) {
+		cerver->check_packets = check_packets;
+	}
 
 }
 
@@ -734,17 +734,17 @@ void cerver_set_check_packets (Cerver *cerver, bool check_packets) {
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void cerver_set_update (
-    Cerver *cerver,
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u8 fps
+	Cerver *cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u8 fps
 ) {
 
-    if (cerver) {
-        cerver->update = update;
-        cerver->update_args = update_args;
-        cerver->delete_update_args = delete_update_args;
-        cerver->update_ticks = fps;
-    }
+	if (cerver) {
+		cerver->update = update;
+		cerver->update_args = update_args;
+		cerver->delete_update_args = delete_update_args;
+		cerver->update_ticks = fps;
+	}
 
 }
 
@@ -753,17 +753,17 @@ void cerver_set_update (
 // the update args will be passed to your method as a CerverUpdate &
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void cerver_set_update_interval (
-    Cerver *cerver,
-    Action update, void *update_args, void (*delete_update_args)(void *),
-    const u32 interval
+	Cerver *cerver,
+	Action update, void *update_args, void (*delete_update_args)(void *),
+	const u32 interval
 ) {
 
-    if (cerver) {
-        cerver->update_interval = update;
-        cerver->update_interval_args = update_args;
-        cerver->delete_update_interval_args = delete_update_args;
-        cerver->update_interval_secs = interval;
-    }
+	if (cerver) {
+		cerver->update_interval = update;
+		cerver->update_interval_args = update_args;
+		cerver->delete_update_interval_args = delete_update_args;
+		cerver->update_interval_secs = interval;
+	}
 
 }
 
@@ -771,17 +771,17 @@ void cerver_set_update_interval (
 // returns 0 on success, 1 on error
 u8 cerver_set_admin_enable (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        cerver->admin = admin_cerver_create ();
-        if (cerver->admin) {
-            cerver->admin->cerver = cerver;
-            retval = 0;
-        }
-    }
+	if (cerver) {
+		cerver->admin = admin_cerver_create ();
+		if (cerver->admin) {
+			cerver->admin->cerver = cerver;
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -791,56 +791,56 @@ u8 cerver_set_admin_enable (Cerver *cerver) {
 
 static int cerver_sockets_pool_init (Cerver *cerver) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (cerver) {
-        cerver->sockets_pool = pool_create (socket_delete);
-        if (cerver->sockets_pool) {
-            retval = pool_init (
-                cerver->sockets_pool,
-                socket_create_empty,
-                cerver->sockets_pool_init
-            );
-        }
-    }
+	if (cerver) {
+		cerver->sockets_pool = pool_create (socket_delete);
+		if (cerver->sockets_pool) {
+			retval = pool_init (
+				cerver->sockets_pool,
+				socket_create_empty,
+				cerver->sockets_pool_init
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 int cerver_sockets_pool_push (Cerver *cerver, Socket *socket) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (cerver && socket) {
-        retval = pool_push (cerver->sockets_pool, socket);
-        // printf ("push!\n");
-    }
+	if (cerver && socket) {
+		retval = pool_push (cerver->sockets_pool, socket);
+		// printf ("push!\n");
+	}
 
-    return retval;
+	return retval;
 
 }
 
 Socket *cerver_sockets_pool_pop (Cerver *cerver) {
 
-    Socket *retval = NULL;
+	Socket *retval = NULL;
 
-    if (cerver) {
-        void *value = pool_pop (cerver->sockets_pool);
-        if (value) retval = (Socket *) value;
-        // printf ("pop!\n");
-    }
+	if (cerver) {
+		void *value = pool_pop (cerver->sockets_pool);
+		if (value) retval = (Socket *) value;
+		// printf ("pop!\n");
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void cerver_sockets_pool_end (Cerver *cerver) {
 
-    if (cerver) {
-        pool_delete (cerver->sockets_pool);
-        cerver->sockets_pool = NULL;
-    }
+	if (cerver) {
+		pool_delete (cerver->sockets_pool);
+		cerver->sockets_pool = NULL;
+	}
 
 }
 
@@ -851,17 +851,17 @@ static void cerver_sockets_pool_end (Cerver *cerver) {
 // prints info about current handlers
 void cerver_handlers_print_info (Cerver *cerver) {
 
-    if (cerver) {
-        cerver_log_debug (
-            "%d - current ACTIVE handlers in cerver %s",
-            cerver->num_handlers_alive, cerver->info->name->str
-        );
+	if (cerver) {
+		cerver_log_debug (
+			"%d - current ACTIVE handlers in cerver %s",
+			cerver->num_handlers_alive, cerver->info->name->str
+		);
 
-        cerver_log_debug (
-            "%d - current WORKING handlers in cerver %s",
-            cerver->num_handlers_working, cerver->info->name->str
-        );
-    }
+		cerver_log_debug (
+			"%d - current WORKING handlers in cerver %s",
+			cerver->num_handlers_working, cerver->info->name->str
+		);
+	}
 
 }
 
@@ -870,185 +870,185 @@ void cerver_handlers_print_info (Cerver *cerver) {
 // returns 0 on success, 1 on error
 u8 cerver_handlers_add (Cerver *cerver, Handler *handler) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && handler) {
-        if (cerver->handlers) {
-            cerver->handlers[handler->id] = handler;
+	if (cerver && handler) {
+		if (cerver->handlers) {
+			cerver->handlers[handler->id] = handler;
 
-            handler->type = HANDLER_TYPE_CERVER;
-            handler->cerver = cerver;
+			handler->type = HANDLER_TYPE_CERVER;
+			handler->cerver = cerver;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // returns the current number of app handlers (multiple handlers option)
 unsigned int cerver_get_n_handlers (Cerver *cerver) {
 
-    unsigned int retval = 0;
+	unsigned int retval = 0;
 
-    if (cerver) {
-        pthread_mutex_lock (cerver->handlers_lock);
-        retval = cerver->n_handlers;
-        pthread_mutex_unlock (cerver->handlers_lock);
-    }
+	if (cerver) {
+		pthread_mutex_lock (cerver->handlers_lock);
+		retval = cerver->n_handlers;
+		pthread_mutex_unlock (cerver->handlers_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // returns the total number of handlers currently alive (ready to handle packets)
 unsigned int cerver_get_n_handlers_alive (Cerver *cerver) {
 
-    unsigned int retval = 0;
+	unsigned int retval = 0;
 
-    if (cerver) {
-        pthread_mutex_lock (cerver->handlers_lock);
-        retval = cerver->num_handlers_alive;
-        pthread_mutex_unlock (cerver->handlers_lock);
-    }
+	if (cerver) {
+		pthread_mutex_lock (cerver->handlers_lock);
+		retval = cerver->num_handlers_alive;
+		pthread_mutex_unlock (cerver->handlers_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // returns the total number of handlers currently working (handling a packet)
 unsigned int cerver_get_n_handlers_working (Cerver *cerver) {
 
-    unsigned int retval = 0;
+	unsigned int retval = 0;
 
-    if (cerver) {
-        pthread_mutex_lock (cerver->handlers_lock);
-        retval = cerver->num_handlers_working;
-        pthread_mutex_unlock (cerver->handlers_lock);
-    }
+	if (cerver) {
+		pthread_mutex_lock (cerver->handlers_lock);
+		retval = cerver->num_handlers_working;
+		pthread_mutex_unlock (cerver->handlers_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // correctly destroys multiple app handlers, if any
 static u8 cerver_multiple_app_handlers_destroy (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (cerver->handlers && (cerver->num_handlers_alive > 0)) {
-            #ifdef CERVER_DEBUG
-            cerver_log_debug (
-                "Stopping multiple app handlers in cerver %s...",
-                cerver->info->name->str
-            );
-            #endif
+	if (cerver) {
+		if (cerver->handlers && (cerver->num_handlers_alive > 0)) {
+			#ifdef CERVER_DEBUG
+			cerver_log_debug (
+				"Stopping multiple app handlers in cerver %s...",
+				cerver->info->name->str
+			);
+			#endif
 
-            #ifdef CERVER_DEBUG
-            cerver_handlers_print_info (cerver);
-            #endif
+			#ifdef CERVER_DEBUG
+			cerver_handlers_print_info (cerver);
+			#endif
 
-            // give x timeout to kill idle handlers
-            double timeout = 1.0;
-            time_t start = 0, end = 0;
-            double time_passed = 0.0;
-            time (&start);
-            while (time_passed < timeout && cerver->num_handlers_alive) {
-                for (unsigned int i = 0; i < cerver->n_handlers; i++) {
-                    bsem_post_all (cerver->handlers[i]->job_queue->has_jobs);
-                    time (&end);
-                    time_passed = difftime (end, start);
-                }
-            }
+			// give x timeout to kill idle handlers
+			double timeout = 1.0;
+			time_t start = 0, end = 0;
+			double time_passed = 0.0;
+			time (&start);
+			while (time_passed < timeout && cerver->num_handlers_alive) {
+				for (unsigned int i = 0; i < cerver->n_handlers; i++) {
+					bsem_post_all (cerver->handlers[i]->job_queue->has_jobs);
+					time (&end);
+					time_passed = difftime (end, start);
+				}
+			}
 
-            // poll remaining handlers
-            while (cerver->num_handlers_alive) {
-                for (unsigned int i = 0; i < cerver->n_handlers; i++) {
-                    bsem_post_all (cerver->handlers[i]->job_queue->has_jobs);
-                    sleep (1);
-                }
-            }
+			// poll remaining handlers
+			while (cerver->num_handlers_alive) {
+				for (unsigned int i = 0; i < cerver->n_handlers; i++) {
+					bsem_post_all (cerver->handlers[i]->job_queue->has_jobs);
+					sleep (1);
+				}
+			}
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_app_handlers_destroy (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (cerver->multiple_handlers) {
-            if (cerver->handlers && (cerver->num_handlers_alive > 0)) {
-                if (!cerver_multiple_app_handlers_destroy (cerver)) {
-                    #ifdef CERVER_DEBUG
-                    cerver_log_success (
-                        "Done destroying multiple app handlers in cerver %s!",
-                        cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (cerver) {
+		if (cerver->multiple_handlers) {
+			if (cerver->handlers && (cerver->num_handlers_alive > 0)) {
+				if (!cerver_multiple_app_handlers_destroy (cerver)) {
+					#ifdef CERVER_DEBUG
+					cerver_log_success (
+						"Done destroying multiple app handlers in cerver %s!",
+						cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to destroy multiple app handlers in cerver %s!",
-                        cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to destroy multiple app handlers in cerver %s!",
+						cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            if (cerver->app_packet_handler) {
-                if (!cerver->app_packet_handler->direct_handle) {
-                    // stop app handler
-                    bsem_post_all (cerver->app_packet_handler->job_queue->has_jobs);
-                }
-            }
-        }
-    }
+		else {
+			if (cerver->app_packet_handler) {
+				if (!cerver->app_packet_handler->direct_handle) {
+					// stop app handler
+					bsem_post_all (cerver->app_packet_handler->job_queue->has_jobs);
+				}
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_app_error_handler_destroy (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (cerver->app_error_packet_handler) {
-            if (!cerver->app_error_packet_handler->direct_handle) {
-                // stop app error handler
-                bsem_post_all (cerver->app_error_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (cerver) {
+		if (cerver->app_error_packet_handler) {
+			if (!cerver->app_error_packet_handler->direct_handle) {
+				// stop app error handler
+				bsem_post_all (cerver->app_error_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_custom_handler_destroy (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (cerver->custom_packet_handler) {
-            if (!cerver->custom_packet_handler->direct_handle) {
-                // stop custom handler
-                bsem_post_all (cerver->custom_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (cerver) {
+		if (cerver->custom_packet_handler) {
+			if (!cerver->custom_packet_handler->direct_handle) {
+				// stop custom handler
+				bsem_post_all (cerver->custom_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
@@ -1056,38 +1056,38 @@ static u8 cerver_custom_handler_destroy (Cerver *cerver) {
 // correctly destroy cerver's custom handlers
 static u8 cerver_handlers_destroy (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        #ifdef CERVER_DEBUG
-        cerver_log_debug (
-            "Stopping handlers in cerver %s...",
-            cerver->info->name->str
-        );
-        #endif
+	if (cerver) {
+		#ifdef CERVER_DEBUG
+		cerver_log_debug (
+			"Stopping handlers in cerver %s...",
+			cerver->info->name->str
+		);
+		#endif
 
-        errors |= cerver_app_handlers_destroy (cerver);
+		errors |= cerver_app_handlers_destroy (cerver);
 
-        errors |= cerver_app_error_handler_destroy (cerver);
+		errors |= cerver_app_error_handler_destroy (cerver);
 
-        errors |= cerver_custom_handler_destroy (cerver);
+		errors |= cerver_custom_handler_destroy (cerver);
 
-        // poll remaining handlers
-        while (cerver->num_handlers_alive) {
-            if (cerver->app_packet_handler)
-                bsem_post_all (cerver->app_packet_handler->job_queue->has_jobs);
+		// poll remaining handlers
+		while (cerver->num_handlers_alive) {
+			if (cerver->app_packet_handler)
+				bsem_post_all (cerver->app_packet_handler->job_queue->has_jobs);
 
-            if (cerver->app_error_packet_handler)
-                bsem_post_all (cerver->app_error_packet_handler->job_queue->has_jobs);
+			if (cerver->app_error_packet_handler)
+				bsem_post_all (cerver->app_error_packet_handler->job_queue->has_jobs);
 
-            if (cerver->custom_packet_handler)
-                bsem_post_all (cerver->custom_packet_handler->job_queue->has_jobs);
+			if (cerver->custom_packet_handler)
+				bsem_post_all (cerver->custom_packet_handler->job_queue->has_jobs);
 
-            sleep (1);
-        }
-    }
+			sleep (1);
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
@@ -1097,63 +1097,63 @@ static u8 cerver_handlers_destroy (Cerver *cerver) {
 
 // returns a new cerver with the specified parameters
 Cerver *cerver_create (
-    const CerverType type, const char *name,
-    const u16 port, const Protocol protocol, bool use_ipv6,
-    u16 connection_queue, u32 poll_timeout
+	const CerverType type, const char *name,
+	const u16 port, const Protocol protocol, bool use_ipv6,
+	u16 connection_queue, u32 poll_timeout
 ) {
 
-    Cerver *cerver = NULL;
+	Cerver *cerver = NULL;
 
-    if (name) {
-        cerver = cerver_new ();
-        if (cerver) {
-            cerver->type = type;
+	if (name) {
+		cerver = cerver_new ();
+		if (cerver) {
+			cerver->type = type;
 
-            cerver_set_network_values (cerver, port, protocol, use_ipv6, connection_queue);
+			cerver_set_network_values (cerver, port, protocol, use_ipv6, connection_queue);
 
-            // init cerver type based values
-            switch (cerver->type) {
-                case CERVER_TYPE_CUSTOM: break;
+			// init cerver type based values
+			switch (cerver->type) {
+				case CERVER_TYPE_CUSTOM: break;
 
-                case CERVER_TYPE_GAME: {
-                    cerver->cerver_data = game_new ();
-                    cerver->delete_cerver_data = game_delete;
-                } break;
+				case CERVER_TYPE_GAME: {
+					cerver->cerver_data = game_new ();
+					cerver->delete_cerver_data = game_delete;
+				} break;
 
-                case CERVER_TYPE_WEB: {
-                    cerver->cerver_data = http_cerver_create (cerver);
-                    cerver->delete_cerver_data = http_cerver_delete;
-                } break;
+				case CERVER_TYPE_WEB: {
+					cerver->cerver_data = http_cerver_create (cerver);
+					cerver->delete_cerver_data = http_cerver_delete;
+				} break;
 
-                case CERVER_TYPE_FILES: {
-                    cerver->cerver_data = file_cerver_create (cerver);
-                    cerver->delete_cerver_data = file_cerver_delete;
-                } break;
+				case CERVER_TYPE_FILES: {
+					cerver->cerver_data = file_cerver_create (cerver);
+					cerver->delete_cerver_data = file_cerver_delete;
+				} break;
 
-                default: break;
-            }
+				default: break;
+			}
 
-            cerver->handler_type = CERVER_HANDLER_TYPE_POLL;
+			cerver->handler_type = CERVER_HANDLER_TYPE_POLL;
 
-            cerver_set_poll_time_out (cerver, poll_timeout);
+			cerver_set_poll_time_out (cerver, poll_timeout);
 
-            cerver_set_handle_recieved_buffer (cerver, cerver_receive_handle_buffer);
+			cerver_set_handle_recieved_buffer (cerver, cerver_receive_handle_buffer);
 
-            cerver->info = cerver_info_new ();
-            cerver->info->name = str_new (name);
+			cerver->info = cerver_info_new ();
+			cerver->info->name = str_new (name);
 
-            cerver->stats = cerver_stats_new ();
-        }
-    }
+			cerver->stats = cerver_stats_new ();
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_NONE,
-            "A name is required to create a new cerver!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_NONE,
+			"A name is required to create a new cerver!"
+		);
+	}
 
-    return cerver;
+	return cerver;
 
 }
 
@@ -1164,377 +1164,377 @@ Cerver *cerver_create (
 // inits the cerver's address & binds the socket to it
 static u8 cerver_network_init_address (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
+	memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
 
-    if (cerver->use_ipv6) {
-        struct sockaddr_in6 *addr = (struct sockaddr_in6 *) &cerver->address;
-        addr->sin6_family = AF_INET6;
-        addr->sin6_addr = in6addr_any;
-        addr->sin6_port = htons (cerver->port);
-    }
+	if (cerver->use_ipv6) {
+		struct sockaddr_in6 *addr = (struct sockaddr_in6 *) &cerver->address;
+		addr->sin6_family = AF_INET6;
+		addr->sin6_addr = in6addr_any;
+		addr->sin6_port = htons (cerver->port);
+	}
 
-    else {
-        struct sockaddr_in *addr = (struct sockaddr_in *) &cerver->address;
-        addr->sin_family = AF_INET;
-        addr->sin_addr.s_addr = INADDR_ANY;
-        addr->sin_port = htons (cerver->port);
-    }
+	else {
+		struct sockaddr_in *addr = (struct sockaddr_in *) &cerver->address;
+		addr->sin_family = AF_INET;
+		addr->sin_addr.s_addr = INADDR_ANY;
+		addr->sin_port = htons (cerver->port);
+	}
 
-    if (!bind (cerver->sock, (const struct sockaddr *) &cerver->address, sizeof (struct sockaddr_storage))) {
-        retval = 0;       // success!!
-    }
+	if (!bind (cerver->sock, (const struct sockaddr *) &cerver->address, sizeof (struct sockaddr_storage))) {
+		retval = 0;       // success!!
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-            "Failed to bind cerver %s socket!", cerver->info->name->str
-        );
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Failed to bind cerver %s socket!", cerver->info->name->str
+		);
 
-        close (cerver->sock);
-    }
+		close (cerver->sock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // set cerver's socket blocking property based on cerver handler type
 static u8 cerver_network_init_block_socket (Cerver *cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    switch (cerver->handler_type) {
-        case CERVER_HANDLER_TYPE_NONE: break;
+	switch (cerver->handler_type) {
+		case CERVER_HANDLER_TYPE_NONE: break;
 
-        case CERVER_HANDLER_TYPE_POLL: {
-            // set the socket to non blocking mode
-            if (sock_set_blocking (cerver->sock, cerver->blocking)) {
-                cerver->blocking = false;
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                    "Cerver %s socket set to non blocking mode.",
-                    cerver->info->name->str
-                );
-                #endif
-            }
+		case CERVER_HANDLER_TYPE_POLL: {
+			// set the socket to non blocking mode
+			if (sock_set_blocking (cerver->sock, cerver->blocking)) {
+				cerver->blocking = false;
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+					"Cerver %s socket set to non blocking mode.",
+					cerver->info->name->str
+				);
+				#endif
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Failed to set cerver %s socket to non blocking mode!",
-                    cerver->info->name->str
-                );
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Failed to set cerver %s socket to non blocking mode!",
+					cerver->info->name->str
+				);
 
-                close (cerver->sock);
+				close (cerver->sock);
 
-                retval = 1;     // error
-            }
-        } break;
+				retval = 1;     // error
+			}
+		} break;
 
-        case CERVER_HANDLER_TYPE_THREADS: break;
+		case CERVER_HANDLER_TYPE_THREADS: break;
 
-        default: break;
-    }
+		default: break;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // inits the cerver networking capabilities
 static u8 cerver_network_init (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        // init the cerver with the selected protocol
-        switch (cerver->protocol) {
-            case IPPROTO_TCP:
-                cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_STREAM, 0);
-                break;
+	if (cerver) {
+		// init the cerver with the selected protocol
+		switch (cerver->protocol) {
+			case IPPROTO_TCP:
+				cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_STREAM, 0);
+				break;
 
-            case IPPROTO_UDP:
-                cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_DGRAM, 0);
-                break;
+			case IPPROTO_UDP:
+				cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_DGRAM, 0);
+				break;
 
-            default: cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Unknown protocol type!"); break;
-        }
+			default: cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Unknown protocol type!"); break;
+		}
 
-        if (cerver->sock >= 0) {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Created cerver %s socket - <%d>!",
-                cerver->info->name->str,
-                cerver->sock
-            );
-            #endif
+		if (cerver->sock >= 0) {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Created cerver %s socket - <%d>!",
+				cerver->info->name->str,
+				cerver->sock
+			);
+			#endif
 
-            if (!cerver_network_init_block_socket (cerver)) {
-                retval = cerver_network_init_address (cerver);
-            }
-        }
+			if (!cerver_network_init_block_socket (cerver)) {
+				retval = cerver_network_init_address (cerver);
+			}
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to create cerver %s socket!", cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to create cerver %s socket!", cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_init_poll_fds (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    cerver->fds = (struct pollfd *) calloc (poll_n_fds, sizeof (struct pollfd));
-    if (cerver->fds) {
-        memset (cerver->fds, 0, sizeof (struct pollfd) * poll_n_fds);
-        // set all fds as available spaces
-        for (u32 i = 0; i < poll_n_fds; i++) cerver->fds[i].fd = -1;
+	cerver->fds = (struct pollfd *) calloc (poll_n_fds, sizeof (struct pollfd));
+	if (cerver->fds) {
+		memset (cerver->fds, 0, sizeof (struct pollfd) * poll_n_fds);
+		// set all fds as available spaces
+		for (u32 i = 0; i < poll_n_fds; i++) cerver->fds[i].fd = -1;
 
-        cerver->max_n_fds = poll_n_fds;
-        cerver->current_n_fds = 0;
+		cerver->max_n_fds = poll_n_fds;
+		cerver->current_n_fds = 0;
 
-        retval = 0;     // success!!
-    }
+		retval = 0;     // success!!
+	}
 
-    else {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-            "Failed to allocate cerver %s main fds!", cerver->info->name->str
-        );
-        #endif
-    }
+	else {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Failed to allocate cerver %s main fds!", cerver->info->name->str
+		);
+		#endif
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_init_data_structures (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        cerver->clients = avl_init (
-            cerver->use_sessions ? client_comparator_session_id : client_comparator_client_id,
-            client_delete
-        );
+	if (cerver) {
+		cerver->clients = avl_init (
+			cerver->use_sessions ? client_comparator_session_id : client_comparator_client_id,
+			client_delete
+		);
 
-        if (cerver->clients) {
-            cerver->client_sock_fd_map = htab_create (poll_n_fds, NULL, NULL);
-            if (cerver->client_sock_fd_map) {
-                u8 errors = 0;
+		if (cerver->clients) {
+			cerver->client_sock_fd_map = htab_create (poll_n_fds, NULL, NULL);
+			if (cerver->client_sock_fd_map) {
+				u8 errors = 0;
 
-                // init cerver handler type based values
-                switch (cerver->handler_type) {
-                    case CERVER_HANDLER_TYPE_NONE: break;
+				// init cerver handler type based values
+				switch (cerver->handler_type) {
+					case CERVER_HANDLER_TYPE_NONE: break;
 
-                    case CERVER_HANDLER_TYPE_POLL: {
-                        // initialize main pollfd structures
-                        errors |= cerver_init_poll_fds (cerver);
-                    } break;
+					case CERVER_HANDLER_TYPE_POLL: {
+						// initialize main pollfd structures
+						errors |= cerver_init_poll_fds (cerver);
+					} break;
 
-                    case CERVER_HANDLER_TYPE_THREADS: break;
+					case CERVER_HANDLER_TYPE_THREADS: break;
 
-                    default: break;
-                }
+					default: break;
+				}
 
-                retval = errors;
-            }
+				retval = errors;
+			}
 
-            else {
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Failed to init clients sock fd map in cerver %s",
-                    cerver->info->name->str
-                );
-                #endif
-            }
-        }
+			else {
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Failed to init clients sock fd map in cerver %s",
+					cerver->info->name->str
+				);
+				#endif
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to init clients avl in cerver %s",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to init clients avl in cerver %s",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // inits a cerver of a given type
 static u8 cerver_init_internal (Cerver *cerver) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (cerver) {
-        cerver_log (
-            LOG_TYPE_CERVER, LOG_TYPE_NONE,
-            "Initializing cerver %s...", cerver->info->name->str
-        );
+	if (cerver) {
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Initializing cerver %s...", cerver->info->name->str
+		);
 
-        cerver_log_msg ("Cerver type: %s\n", cerver_type_to_string (cerver->type));
-        cerver_log_msg ("Cerver handler type: %s\n", cerver_handler_type_to_string (cerver->handler_type));
+		cerver_log_msg ("Cerver type: %s\n", cerver_type_to_string (cerver->type));
+		cerver_log_msg ("Cerver handler type: %s\n", cerver_handler_type_to_string (cerver->handler_type));
 
-        if (!cerver_network_init (cerver)) {
-            if (!cerver_init_data_structures (cerver)) {
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
-                    "Done initializing cerver %s network values & data structures!",
-                    cerver->info->name->str
-                );
-                #endif
+		if (!cerver_network_init (cerver)) {
+			if (!cerver_init_data_structures (cerver)) {
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+					"Done initializing cerver %s network values & data structures!",
+					cerver->info->name->str
+				);
+				#endif
 
-                retval = 0;     // success!!
-            }
+				retval = 0;     // success!!
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Failed to init cerver %s data structures!",
-                    cerver->info->name->str
-                );
-            }
-        }
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Failed to init cerver %s data structures!",
+					cerver->info->name->str
+				);
+			}
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to init cerver %s network!", cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to init cerver %s network!", cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_one_time_init_thpool (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (cerver->n_thpool_threads) {
-            #ifdef CERVER_DEBUG
-            cerver_log_debug (
-                "Cerver %s is configured to use a thpool with %d threads",
-                cerver->info->name->str, cerver->n_thpool_threads
-            );
-            #endif
+	if (cerver) {
+		if (cerver->n_thpool_threads) {
+			#ifdef CERVER_DEBUG
+			cerver_log_debug (
+				"Cerver %s is configured to use a thpool with %d threads",
+				cerver->info->name->str, cerver->n_thpool_threads
+			);
+			#endif
 
-            cerver->thpool = thpool_create (cerver->n_thpool_threads);
-            thpool_set_name (cerver->thpool, cerver->info->name->str);
-            if (thpool_init (cerver->thpool)) {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                    "Failed to init cerver %s thpool!", cerver->info->name->str
-                );
+			cerver->thpool = thpool_create (cerver->n_thpool_threads);
+			thpool_set_name (cerver->thpool, cerver->info->name->str);
+			if (thpool_init (cerver->thpool)) {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					"Failed to init cerver %s thpool!", cerver->info->name->str
+				);
 
-                errors = 1;
-            }
-        }
+				errors = 1;
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log_debug (
-                "Cerver %s is configured to NOT use a thpool for receive methods",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log_debug (
+				"Cerver %s is configured to NOT use a thpool for receive methods",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_one_time_init (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (!cerver_init_internal (cerver)) {
-            cerver_log (
-                LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
-                "Initialized cerver %s!", cerver->info->name->str
-            );
+	if (cerver) {
+		if (!cerver_init_internal (cerver)) {
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+				"Initialized cerver %s!", cerver->info->name->str
+			);
 
-            // 29/05/2020
-            errors |= cerver_sockets_pool_init (cerver);
+			// 29/05/2020
+			errors |= cerver_sockets_pool_init (cerver);
 
-            // 28/05/2020
-            cerver->poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-            pthread_mutex_init (cerver->poll_lock, NULL);
+			// 28/05/2020
+			cerver->poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+			pthread_mutex_init (cerver->poll_lock, NULL);
 
-            // init the cerver thpool
-            errors |= cerver_one_time_init_thpool (cerver);
+			// init the cerver thpool
+			errors |= cerver_one_time_init_thpool (cerver);
 
-            // perform one time init methods by cerver type
-            switch (cerver->type) {
-                case CERVER_TYPE_CUSTOM: break;
+			// perform one time init methods by cerver type
+			switch (cerver->type) {
+				case CERVER_TYPE_CUSTOM: break;
 
-                case CERVER_TYPE_GAME: {
-                    GameCerver *game_data = (GameCerver *) cerver->cerver_data;
-                    game_data->cerver = cerver;
-                    if (game_data && game_data->load_game_data) {
-                        game_data->load_game_data (NULL);
-                    }
+				case CERVER_TYPE_GAME: {
+					GameCerver *game_data = (GameCerver *) cerver->cerver_data;
+					game_data->cerver = cerver;
+					if (game_data && game_data->load_game_data) {
+						game_data->load_game_data (NULL);
+					}
 
-                    else {
-                        cerver_log (
-                            LOG_TYPE_WARNING, LOG_TYPE_GAME,
-                            "Game cerver %s doesn't have a reference to a game data!",
-                            cerver->info->name->str
-                        );
-                    }
-                } break;
+					else {
+						cerver_log (
+							LOG_TYPE_WARNING, LOG_TYPE_GAME,
+							"Game cerver %s doesn't have a reference to a game data!",
+							cerver->info->name->str
+						);
+					}
+				} break;
 
-                case CERVER_TYPE_WEB: {
-                    http_cerver_init ((HttpCerver *) cerver->cerver_data);
-                } break;
+				case CERVER_TYPE_WEB: {
+					http_cerver_init ((HttpCerver *) cerver->cerver_data);
+				} break;
 
-                case CERVER_TYPE_FILES: break;
+				case CERVER_TYPE_FILES: break;
 
-                default: break;
-            }
+				default: break;
+			}
 
-            cerver->info->cerver_info_packet = cerver_packet_generate (cerver);
-            if (!cerver->info->cerver_info_packet) {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Failed to generate cerver %s info packet",
-                    cerver->info->name->str
-                );
+			cerver->info->cerver_info_packet = cerver_packet_generate (cerver);
+			if (!cerver->info->cerver_info_packet) {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Failed to generate cerver %s info packet",
+					cerver->info->name->str
+				);
 
-                errors |= 1;
-            }
-        }
+				errors |= 1;
+			}
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to init cerver %s!", cerver->info->name->str
-            );
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to init cerver %s!", cerver->info->name->str
+			);
 
-            errors |= 1;
-        }
-    }
+			errors |= 1;
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
@@ -1549,508 +1549,508 @@ static void cerver_update_interval (void *args);
 // inits cerver's auth capabilities
 static u8 cerver_auth_start (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        cerver->auth_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_REQUEST_AUTH, NULL, 0);
+	if (cerver) {
+		cerver->auth_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_REQUEST_AUTH, NULL, 0);
 
-        cerver->max_on_hold_connections = poll_n_fds / 2;
-        cerver->on_hold_connections = avl_init (connection_comparator, connection_delete);
-        cerver->on_hold_connection_sock_fd_map = htab_create (cerver->max_on_hold_connections / 4, NULL, NULL);
-        if (cerver->on_hold_connections && cerver->on_hold_connection_sock_fd_map) {
-            cerver->hold_fds = (struct pollfd *) calloc (cerver->max_on_hold_connections, sizeof (struct pollfd));
-            if (cerver->hold_fds) {
-                memset (cerver->hold_fds, 0, sizeof (struct pollfd) * cerver->max_on_hold_connections);
+		cerver->max_on_hold_connections = poll_n_fds / 2;
+		cerver->on_hold_connections = avl_init (connection_comparator, connection_delete);
+		cerver->on_hold_connection_sock_fd_map = htab_create (cerver->max_on_hold_connections / 4, NULL, NULL);
+		if (cerver->on_hold_connections && cerver->on_hold_connection_sock_fd_map) {
+			cerver->hold_fds = (struct pollfd *) calloc (cerver->max_on_hold_connections, sizeof (struct pollfd));
+			if (cerver->hold_fds) {
+				memset (cerver->hold_fds, 0, sizeof (struct pollfd) * cerver->max_on_hold_connections);
 
-                for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
-                    cerver->hold_fds[i].fd = -1;
+				for (u32 i = 0; i < cerver->max_on_hold_connections; i++)
+					cerver->hold_fds[i].fd = -1;
 
-                cerver->current_on_hold_nfds = 0;
+				cerver->current_on_hold_nfds = 0;
 
-                cerver->on_hold_poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-                pthread_mutex_init (cerver->on_hold_poll_lock, NULL);
+				cerver->on_hold_poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+				pthread_mutex_init (cerver->on_hold_poll_lock, NULL);
 
-                if (!thread_create_detachable (&cerver->on_hold_poll_id, on_hold_poll, cerver)) {
-                    retval = 0;
-                }
+				if (!thread_create_detachable (&cerver->on_hold_poll_id, on_hold_poll, cerver)) {
+					retval = 0;
+				}
 
-                else {
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                        "Failed to create cerver's %s on_hold_poll () thread!",
-                        cerver->info->name->str
-                    );
-                }
+				else {
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_NONE,
+						"Failed to create cerver's %s on_hold_poll () thread!",
+						cerver->info->name->str
+					);
+				}
 
-                retval = 0;
-            }
-        }
-    }
+				retval = 0;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // 11/05/2020 -- start cerver's multiple app handlers
 static u8 cerver_multiple_app_handlers_start (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        cerver->num_handlers_alive = 0;
-        cerver->num_handlers_working = 0;
+	if (cerver) {
+		cerver->num_handlers_alive = 0;
+		cerver->num_handlers_working = 0;
 
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-            "Initializing cerver %s multiple app handlers...",
-            cerver->info->name->str
-        );
-        #endif
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Initializing cerver %s multiple app handlers...",
+			cerver->info->name->str
+		);
+		#endif
 
-        for (unsigned int i = 0; i < cerver->n_handlers; i++) {
-            if (cerver->handlers[i]) {
-                if (!cerver->handlers[i]->direct_handle) {
-                    errors |= handler_start (cerver->handlers[i]);
-                }
-            }
-        }
+		for (unsigned int i = 0; i < cerver->n_handlers; i++) {
+			if (cerver->handlers[i]) {
+				if (!cerver->handlers[i]->direct_handle) {
+					errors |= handler_start (cerver->handlers[i]);
+				}
+			}
+		}
 
-        if (!errors) {
-            // wait for all handlers to be initialized
-            while (cerver->num_handlers_alive != cerver->n_handlers) {}
+		if (!errors) {
+			// wait for all handlers to be initialized
+			while (cerver->num_handlers_alive != cerver->n_handlers) {}
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
-                "Cerver %s multiple app handlers are ready!",
-                cerver->info->name->str
-            );
-            #endif
-        }
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+				"Cerver %s multiple app handlers are ready!",
+				cerver->info->name->str
+			);
+			#endif
+		}
 
-        else {
-            cerver_log_error (
-                "Failed to init ALL multiple app handlers in cerver %s",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"Failed to init ALL multiple app handlers in cerver %s",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_app_handlers_start (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        if (cerver->multiple_handlers) {
-            errors |= cerver_multiple_app_handlers_start (cerver);
-        }
+	if (cerver) {
+		if (cerver->multiple_handlers) {
+			errors |= cerver_multiple_app_handlers_start (cerver);
+		}
 
-        else {
-            if (cerver->app_packet_handler) {
-                if (!cerver->app_packet_handler->direct_handle) {
-                    // init single app packet handler
-                    if (!handler_start (cerver->app_packet_handler)) {
-                        #ifdef CERVER_DEBUG
-                        cerver_log_success (
-                            "Cerver %s app_packet_handler has started!",
-                            cerver->info->name->str
-                        );
-                        #endif
-                    }
+		else {
+			if (cerver->app_packet_handler) {
+				if (!cerver->app_packet_handler->direct_handle) {
+					// init single app packet handler
+					if (!handler_start (cerver->app_packet_handler)) {
+						#ifdef CERVER_DEBUG
+						cerver_log_success (
+							"Cerver %s app_packet_handler has started!",
+							cerver->info->name->str
+						);
+						#endif
+					}
 
-                    else {
-                        cerver_log_error (
-                            "Failed to start cerver %s app_packet_handler!",
-                            cerver->info->name->str
-                        );
+					else {
+						cerver_log_error (
+							"Failed to start cerver %s app_packet_handler!",
+							cerver->info->name->str
+						);
 
-                        errors = 1;
-                    }
-                }
-            }
+						errors = 1;
+					}
+				}
+			}
 
-            else {
-                switch (cerver->type) {
-                    case CERVER_TYPE_WEB: break;
-                    case CERVER_TYPE_FILES: break;
+			else {
+				switch (cerver->type) {
+					case CERVER_TYPE_WEB: break;
+					case CERVER_TYPE_FILES: break;
 
-                    default: {
-                        cerver_log_warning (
-                            "Cerver %s does not have an app_packet_handler",
-                            cerver->info->name->str
-                        );
-                    } break;
-                }
-            }
-        }
-    }
+					default: {
+						cerver_log_warning (
+							"Cerver %s does not have an app_packet_handler",
+							cerver->info->name->str
+						);
+					} break;
+				}
+			}
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_app_error_handler_start (Cerver *cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (cerver) {
-        if (cerver->app_error_packet_handler) {
-            if (!cerver->app_error_packet_handler->direct_handle) {
-                if (!handler_start (cerver->app_error_packet_handler)) {
-                    #ifdef CERVER_DEBUG
-                    cerver_log_success (
-                        "Cerver %s app_error_packet_handler has started!",
-                        cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (cerver) {
+		if (cerver->app_error_packet_handler) {
+			if (!cerver->app_error_packet_handler->direct_handle) {
+				if (!handler_start (cerver->app_error_packet_handler)) {
+					#ifdef CERVER_DEBUG
+					cerver_log_success (
+						"Cerver %s app_error_packet_handler has started!",
+						cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start cerver %s app_error_packet_handler!",
-                        cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to start cerver %s app_error_packet_handler!",
+						cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            switch (cerver->type) {
-                case CERVER_TYPE_WEB: break;
-                case CERVER_TYPE_FILES: break;
+		else {
+			switch (cerver->type) {
+				case CERVER_TYPE_WEB: break;
+				case CERVER_TYPE_FILES: break;
 
-                default: {
-                    cerver_log_warning (
-                        "Cerver %s does not have an app_error_packet_handler",
-                        cerver->info->name->str
-                    );
-                } break;
-            }
-        }
-    }
+				default: {
+					cerver_log_warning (
+						"Cerver %s does not have an app_error_packet_handler",
+						cerver->info->name->str
+					);
+				} break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_custom_handler_start (Cerver *cerver) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (cerver) {
-        if (cerver->custom_packet_handler) {
-            if (!cerver->custom_packet_handler->direct_handle) {
-                if (!handler_start (cerver->custom_packet_handler)) {
-                    #ifdef CERVER_DEBUG
-                    cerver_log_success (
-                        "Cerver %s custom_packet_handler has started!",
-                        cerver->info->name->str
-                    );
-                    #endif
-                }
+	if (cerver) {
+		if (cerver->custom_packet_handler) {
+			if (!cerver->custom_packet_handler->direct_handle) {
+				if (!handler_start (cerver->custom_packet_handler)) {
+					#ifdef CERVER_DEBUG
+					cerver_log_success (
+						"Cerver %s custom_packet_handler has started!",
+						cerver->info->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start cerver %s custom_packet_handler!",
-                        cerver->info->name->str
-                    );
-                }
-            }
-        }
+				else {
+					cerver_log_error (
+						"Failed to start cerver %s custom_packet_handler!",
+						cerver->info->name->str
+					);
+				}
+			}
+		}
 
-        else {
-            cerver_log_warning (
-                "Cerver %s does not have an custom_packet_handler",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_warning (
+				"Cerver %s does not have an custom_packet_handler",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // 27/05/2020 -- starts all cerver's handlers
 static u8 cerver_handlers_start (Cerver *cerver) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver) {
-        #ifdef CERVER_DEBUG
-        cerver_log_debug (
-            "Initializing %s handlers...",
-            cerver->info->name->str
-        );
-        #endif
+	if (cerver) {
+		#ifdef CERVER_DEBUG
+		cerver_log_debug (
+			"Initializing %s handlers...",
+			cerver->info->name->str
+		);
+		#endif
 
-        cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (cerver->handlers_lock, NULL);
+		cerver->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (cerver->handlers_lock, NULL);
 
-        errors |= cerver_app_handlers_start (cerver);
+		errors |= cerver_app_handlers_start (cerver);
 
-        errors |= cerver_app_error_handler_start (cerver);
+		errors |= cerver_app_error_handler_start (cerver);
 
-        errors |= cerver_custom_handler_start (cerver);
+		errors |= cerver_custom_handler_start (cerver);
 
-        if (!errors) {
-            #ifdef CERVER_DEBUG
-            cerver_log_debug (
-                "Done initializing %s handlers!",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		if (!errors) {
+			#ifdef CERVER_DEBUG
+			cerver_log_debug (
+				"Done initializing %s handlers!",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 cerver_update_start (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (!thread_create_detachable (
-        &cerver->update_thread_id,
-        (void *(*) (void *)) cerver_update,
-        cerver
-    )) {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-            "Created cerver %s UPDATE thread!",
-            cerver->info->name->str
-        );
-        #endif
+	if (!thread_create_detachable (
+		&cerver->update_thread_id,
+		(void *(*) (void *)) cerver_update,
+		cerver
+	)) {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Created cerver %s UPDATE thread!",
+			cerver->info->name->str
+		);
+		#endif
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        cerver_log_error (
-            "Failed to create cerver %s UPDATE thread!",
-            cerver->info->name->str
-        );
-    }
+	else {
+		cerver_log_error (
+			"Failed to create cerver %s UPDATE thread!",
+			cerver->info->name->str
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_update_interval_start (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (!thread_create_detachable (
-        &cerver->update_interval_thread_id,
-        (void *(*) (void *)) cerver_update_interval,
-        cerver
-    )) {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-            "Created cerver %s UPDATE INTERVAL thread!",
-            cerver->info->name->str
-        );
-        #endif
+	if (!thread_create_detachable (
+		&cerver->update_interval_thread_id,
+		(void *(*) (void *)) cerver_update_interval,
+		cerver
+	)) {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Created cerver %s UPDATE INTERVAL thread!",
+			cerver->info->name->str
+		);
+		#endif
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        cerver_log_error (
-            "Failed to create cerver %s UPDATE INTERVAL thread!",
-            cerver->info->name->str
-        );
-    }
+	else {
+		cerver_log_error (
+			"Failed to create cerver %s UPDATE INTERVAL thread!",
+			cerver->info->name->str
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void cerver_inactive_check (AVLNode *node, Cerver *cerver, time_t current_time) {
 
-    cerver_inactive_check (node->right, cerver, current_time);
+	cerver_inactive_check (node->right, cerver, current_time);
 
-    // check for client inactivity
-    if (node->id) {
-        Client *client = (Client *) node->id;
+	// check for client inactivity
+	if (node->id) {
+		Client *client = (Client *) node->id;
 
-        if ((current_time - client->last_activity) >= cerver->max_inactive_time) {
-            // TODO: the client should be dropped
-            cerver_log_warning (
-                "Client %ld has been inactive more than %d secs and should be dropped",
-                client->id, cerver->max_inactive_time
-            );
-        }
-    }
+		if ((current_time - client->last_activity) >= cerver->max_inactive_time) {
+			// TODO: the client should be dropped
+			cerver_log_warning (
+				"Client %ld has been inactive more than %d secs and should be dropped",
+				client->id, cerver->max_inactive_time
+			);
+		}
+	}
 
-    cerver_inactive_check (node->left, cerver, current_time);
+	cerver_inactive_check (node->left, cerver, current_time);
 
 }
 
 // 17/06/2020 - thread to check for inactive clients
 static void *cerver_inactive_thread (void *args) {
 
-    if (args) {
-        Cerver *cerver = (Cerver *) args;
+	if (args) {
+		Cerver *cerver = (Cerver *) args;
 
-        u32 count = 0;
-        while (cerver->isRunning) {
-            if (count == cerver->check_inactive_interval) {
-                count = 0;
+		u32 count = 0;
+		while (cerver->isRunning) {
+			if (count == cerver->check_inactive_interval) {
+				count = 0;
 
-                cerver_log_debug (
-                    "Checking for inactive clients in cerver %s...",
-                    cerver->info->name->str
-                );
+				cerver_log_debug (
+					"Checking for inactive clients in cerver %s...",
+					cerver->info->name->str
+				);
 
-                time_t current_time = time (NULL);
-                cerver_inactive_check (cerver->clients->root, cerver, current_time);
+				time_t current_time = time (NULL);
+				cerver_inactive_check (cerver->clients->root, cerver, current_time);
 
-                cerver_log_debug (
-                    "Done checking for inactive clients in cerver %s",
-                    cerver->info->name->str
-                );
-            }
+				cerver_log_debug (
+					"Done checking for inactive clients in cerver %s",
+					cerver->info->name->str
+				);
+			}
 
-            sleep (1);
-            count++;
-        }
-    }
+			sleep (1);
+			count++;
+		}
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
 static u8 cerver_start_inactive (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        cerver_log_debug (
-            "Cerver %s is set to check for inactive clients with max time of <%d> secs every <%d> secs",
-            cerver->info->name->str,
-            cerver->max_inactive_time,
-            cerver->check_inactive_interval
-        );
+	if (cerver) {
+		cerver_log_debug (
+			"Cerver %s is set to check for inactive clients with max time of <%d> secs every <%d> secs",
+			cerver->info->name->str,
+			cerver->max_inactive_time,
+			cerver->check_inactive_interval
+		);
 
-        if (!thread_create_detachable (
-            &cerver->inactive_thread_id,
-            (void *(*) (void *)) cerver_inactive_thread,
-            cerver
-        )) {
-            cerver_log_success (
-                "Created cerver %s INACTIVE thread!",
-                cerver->info->name->str
-            );
+		if (!thread_create_detachable (
+			&cerver->inactive_thread_id,
+			(void *(*) (void *)) cerver_inactive_thread,
+			cerver
+		)) {
+			cerver_log_success (
+				"Created cerver %s INACTIVE thread!",
+				cerver->info->name->str
+			);
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            cerver_log_error (
-                "Failed to create cerver %s INACTIVE thread!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"Failed to create cerver %s INACTIVE thread!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_start_tcp (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    switch (cerver->handler_type) {
-        case CERVER_HANDLER_TYPE_NONE: break;
+	switch (cerver->handler_type) {
+		case CERVER_HANDLER_TYPE_NONE: break;
 
-        case CERVER_HANDLER_TYPE_POLL: {
-            if (!cerver->blocking) {
-                if (!listen (cerver->sock, cerver->connection_queue)) {
-                    // register the cerver start time
-                    time (&cerver->info->time_started);
+		case CERVER_HANDLER_TYPE_POLL: {
+			if (!cerver->blocking) {
+				if (!listen (cerver->sock, cerver->connection_queue)) {
+					// register the cerver start time
+					time (&cerver->info->time_started);
 
-                    // set up the initial listening socket
-                    cerver->fds[cerver->current_n_fds].fd = cerver->sock;
-                    cerver->fds[cerver->current_n_fds].events = POLLIN;
-                    cerver->current_n_fds++;
+					// set up the initial listening socket
+					cerver->fds[cerver->current_n_fds].fd = cerver->sock;
+					cerver->fds[cerver->current_n_fds].events = POLLIN;
+					cerver->current_n_fds++;
 
-                    cerver_event_trigger (
-                        CERVER_EVENT_STARTED,
-                        cerver,
-                        NULL, NULL
-                    );
+					cerver_event_trigger (
+						CERVER_EVENT_STARTED,
+						cerver,
+						NULL, NULL
+					);
 
-                    retval = cerver_poll (cerver);
-                }
+					retval = cerver_poll (cerver);
+				}
 
-                else {
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                        "Failed to listen in cerver %s socket!",
-                        cerver->info->name->str
-                    );
+				else {
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+						"Failed to listen in cerver %s socket!",
+						cerver->info->name->str
+					);
 
-                    close (cerver->sock);
-                }
-            }
+					close (cerver->sock);
+				}
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Can't start cerver %s in CERVER_HANDLER_TYPE_POLL - socket is NOT set to non blocking!",
-                    cerver->info->name->str
-                );
-            }
-        } break;
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Can't start cerver %s in CERVER_HANDLER_TYPE_POLL - socket is NOT set to non blocking!",
+					cerver->info->name->str
+				);
+			}
+		} break;
 
-        case CERVER_HANDLER_TYPE_THREADS: {
-            if (cerver->blocking) {
-                if (!listen (cerver->sock, cerver->connection_queue)) {
-                    // register the cerver start time
-                    time (&cerver->info->time_started);
+		case CERVER_HANDLER_TYPE_THREADS: {
+			if (cerver->blocking) {
+				if (!listen (cerver->sock, cerver->connection_queue)) {
+					// register the cerver start time
+					time (&cerver->info->time_started);
 
-                    cerver_event_trigger (
-                        CERVER_EVENT_STARTED,
-                        cerver,
-                        NULL, NULL
-                    );
+					cerver_event_trigger (
+						CERVER_EVENT_STARTED,
+						cerver,
+						NULL, NULL
+					);
 
-                    retval = cerver_threads (cerver);
-                }
+					retval = cerver_threads (cerver);
+				}
 
-                else {
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                        "Failed to listen in cerver %s socket!",
-                        cerver->info->name->str
-                    );
+				else {
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+						"Failed to listen in cerver %s socket!",
+						cerver->info->name->str
+					);
 
-                    close (cerver->sock);
-                }
-            }
+					close (cerver->sock);
+				}
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                    "Can't start cerver %s in CERVER_HANDLER_TYPE_THREADS - socket is NOT blocking!",
-                    cerver->info->name->str
-                );
-            }
-        } break;
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Can't start cerver %s in CERVER_HANDLER_TYPE_THREADS - socket is NOT blocking!",
+					cerver->info->name->str
+				);
+			}
+		} break;
 
-        default: break;
-    }
+		default: break;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2067,100 +2067,100 @@ static void cerver_start_udp (Cerver *cerver) { /*** TODO: ***/ }
 // returns 0 on success, 1 on error
 u8 cerver_start (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (!cerver->isRunning) {
-        cerver->isRunning = true;
+	if (!cerver->isRunning) {
+		cerver->isRunning = true;
 
-        if (!cerver_one_time_init (cerver)) {
-            u8 errors = 0;
+		if (!cerver_one_time_init (cerver)) {
+			u8 errors = 0;
 
-            errors |= cerver_handlers_start (cerver);
+			errors |= cerver_handlers_start (cerver);
 
-            if (cerver->auth_required) {
-                cerver_log_debug (
-                    "Cerver %s requires authentication",
-                    cerver->info->name->str
-                );
+			if (cerver->auth_required) {
+				cerver_log_debug (
+					"Cerver %s requires authentication",
+					cerver->info->name->str
+				);
 
-                errors |= cerver_auth_start (cerver);
-            }
+				errors |= cerver_auth_start (cerver);
+			}
 
-            if (cerver->use_sessions) {
-                cerver_log_debug (
-                    "Cerver %s supports sessions",
-                    cerver->info->name->str
-                );
-            }
+			if (cerver->use_sessions) {
+				cerver_log_debug (
+					"Cerver %s supports sessions",
+					cerver->info->name->str
+				);
+			}
 
-            // start the admin cerver
-            if (cerver->admin) {
-                cerver_log_debug (
-                    "Cerver %s can handle admins",
-                    cerver->info->name->str
-                );
+			// start the admin cerver
+			if (cerver->admin) {
+				cerver_log_debug (
+					"Cerver %s can handle admins",
+					cerver->info->name->str
+				);
 
-                errors |= admin_cerver_start (cerver->admin);
-            }
+				errors |= admin_cerver_start (cerver->admin);
+			}
 
-            if (cerver->update) {
-                errors |= cerver_update_start (cerver);
-            }
+			if (cerver->update) {
+				errors |= cerver_update_start (cerver);
+			}
 
-            if (cerver->update_interval) {
-                errors |= cerver_update_interval_start (cerver);
-            }
+			if (cerver->update_interval) {
+				errors |= cerver_update_interval_start (cerver);
+			}
 
-            // 17/06/2020
-            // check for inactive will be handled in its own thread
-            // to avoid messing with other dedicated update threads timings
-            if (cerver->inactive_clients) {
-                errors |= cerver_start_inactive (cerver);
-            }
+			// 17/06/2020
+			// check for inactive will be handled in its own thread
+			// to avoid messing with other dedicated update threads timings
+			if (cerver->inactive_clients) {
+				errors |= cerver_start_inactive (cerver);
+			}
 
-            if (!errors) {
-                switch (cerver->protocol) {
-                    case PROTOCOL_TCP: {
-                        retval = cerver_start_tcp (cerver);
-                    } break;
+			if (!errors) {
+				switch (cerver->protocol) {
+					case PROTOCOL_TCP: {
+						retval = cerver_start_tcp (cerver);
+					} break;
 
-                    case PROTOCOL_UDP: {
-                        // retval = cerver_start_udp (cerver);
-                        cerver_log_warning (
-                            "Cerver %s - udp server is not yet implemented!",
-                            cerver->info->name->str
-                        );
-                    } break;
+					case PROTOCOL_UDP: {
+						// retval = cerver_start_udp (cerver);
+						cerver_log_warning (
+							"Cerver %s - udp server is not yet implemented!",
+							cerver->info->name->str
+						);
+					} break;
 
-                    default: {
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                            "Cant't start cerver %s! Unknown protocol!",
-                            cerver->info->name->str
-                        );
-                    }
-                    break;
-                }
-            }
-        }
+					default: {
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+							"Cant't start cerver %s! Unknown protocol!",
+							cerver->info->name->str
+						);
+					}
+					break;
+				}
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "Failed cerver_one_time_init () for cerver %s!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"Failed cerver_one_time_init () for cerver %s!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-            "The cerver %s is already running!",
-            cerver->info->name->str
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+			"The cerver %s is already running!",
+			cerver->info->name->str
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2170,19 +2170,19 @@ u8 cerver_start (Cerver *cerver) {
 
 CerverUpdate *cerver_update_new (Cerver *cerver, void *args) {
 
-    CerverUpdate *cu = (CerverUpdate *) malloc (sizeof (CerverUpdate));
-    if (cu) {
-        cu->cerver = cerver;
-        cu->args = args;
-    }
+	CerverUpdate *cu = (CerverUpdate *) malloc (sizeof (CerverUpdate));
+	if (cu) {
+		cu->cerver = cerver;
+		cu->args = args;
+	}
 
-    return cu;
+	return cu;
 
 }
 
 void cerver_update_delete (void *cerver_update_ptr) {
 
-    if (cerver_update_ptr) free (cerver_update_ptr);
+	if (cerver_update_ptr) free (cerver_update_ptr);
 
 }
 
@@ -2190,72 +2190,72 @@ void cerver_update_delete (void *cerver_update_ptr) {
 // executes methods every tick
 static void cerver_update (void *args) {
 
-    if (args) {
-        Cerver *cerver = (Cerver *) args;
+	if (args) {
+		Cerver *cerver = (Cerver *) args;
 
-        #ifdef CERVER_DEBUG
-        cerver_log_success (
-            "Cerver's %s cerver_update () has started!",
-            cerver->info->name->str
-        );
-        #endif
+		#ifdef CERVER_DEBUG
+		cerver_log_success (
+			"Cerver's %s cerver_update () has started!",
+			cerver->info->name->str
+		);
+		#endif
 
-        CerverUpdate *cu = cerver_update_new (cerver, cerver->update_args);
+		CerverUpdate *cu = cerver_update_new (cerver, cerver->update_args);
 
-        u32 time_per_frame = 1000000 / cerver->update_ticks;
-        // printf ("time per frame: %d\n", time_per_frame);
-        u32 temp = 0;
-        i32 sleep_time = 0;
-        u64 delta_time = 0;
+		u32 time_per_frame = 1000000 / cerver->update_ticks;
+		// printf ("time per frame: %d\n", time_per_frame);
+		u32 temp = 0;
+		i32 sleep_time = 0;
+		u64 delta_time = 0;
 
-        u64 delta_ticks = 0;
-        u32 fps = 0;
-        struct timespec start = { 0 }, middle = { 0 }, end = { 0 };
+		u64 delta_ticks = 0;
+		u32 fps = 0;
+		struct timespec start = { 0 }, middle = { 0 }, end = { 0 };
 
-        while (cerver->isRunning) {
-            clock_gettime (CLOCK_MONOTONIC_RAW, &start);
+		while (cerver->isRunning) {
+			clock_gettime (CLOCK_MONOTONIC_RAW, &start);
 
-            // do stuff
-            if (cerver->update) cerver->update (cu);
+			// do stuff
+			if (cerver->update) cerver->update (cu);
 
-            // limit the fps
-            clock_gettime (CLOCK_MONOTONIC_RAW, &middle);
-            temp = (middle.tv_nsec - start.tv_nsec) / 1000;
-            // printf ("temp: %d\n", temp);
-            sleep_time = time_per_frame - temp;
-            // printf ("sleep time: %d\n", sleep_time);
-            if (sleep_time > 0) {
-                usleep (sleep_time);
-            }
+			// limit the fps
+			clock_gettime (CLOCK_MONOTONIC_RAW, &middle);
+			temp = (middle.tv_nsec - start.tv_nsec) / 1000;
+			// printf ("temp: %d\n", temp);
+			sleep_time = time_per_frame - temp;
+			// printf ("sleep time: %d\n", sleep_time);
+			if (sleep_time > 0) {
+				usleep (sleep_time);
+			}
 
-            // count fps
-            clock_gettime (CLOCK_MONOTONIC_RAW, &end);
-            delta_time = (end.tv_nsec - start.tv_nsec) / 1000000;
-            delta_ticks += delta_time;
-            fps++;
-            // printf ("delta ticks: %ld\n", delta_ticks);
-            if (delta_ticks >= 1000) {
-                // printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
-                delta_ticks = 0;
-                fps = 0;
-            }
-        }
+			// count fps
+			clock_gettime (CLOCK_MONOTONIC_RAW, &end);
+			delta_time = (end.tv_nsec - start.tv_nsec) / 1000000;
+			delta_ticks += delta_time;
+			fps++;
+			// printf ("delta ticks: %ld\n", delta_ticks);
+			if (delta_ticks >= 1000) {
+				// printf ("cerver %s update fps: %i\n", cerver->info->name->str, fps);
+				delta_ticks = 0;
+				fps = 0;
+			}
+		}
 
-        cerver_update_delete (cu);
+		cerver_update_delete (cu);
 
-        if (cerver->update_args) {
-            if (cerver->delete_update_args) {
-                cerver->delete_update_args (cerver->update_args);
-            }
-        }
+		if (cerver->update_args) {
+			if (cerver->delete_update_args) {
+				cerver->delete_update_args (cerver->update_args);
+			}
+		}
 
-        #ifdef CERVER_DEBUG
-        cerver_log_success (
-            "Cerver's %s cerver_update () has ended!",
-            cerver->info->name->str
-        );
-        #endif
-    }
+		#ifdef CERVER_DEBUG
+		cerver_log_success (
+			"Cerver's %s cerver_update () has ended!",
+			cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
@@ -2263,39 +2263,39 @@ static void cerver_update (void *args) {
 // executes methods every x seconds
 static void cerver_update_interval (void *args) {
 
-    if (args) {
-        Cerver *cerver = (Cerver *) args;
+	if (args) {
+		Cerver *cerver = (Cerver *) args;
 
-        #ifdef CERVER_DEBUG
-        cerver_log_success (
-            "Cerver's %s cerver_update_interval () has started!",
-            cerver->info->name->str
-        );
-        #endif
+		#ifdef CERVER_DEBUG
+		cerver_log_success (
+			"Cerver's %s cerver_update_interval () has started!",
+			cerver->info->name->str
+		);
+		#endif
 
-        CerverUpdate *cu = cerver_update_new (cerver, cerver->update_interval_args);
+		CerverUpdate *cu = cerver_update_new (cerver, cerver->update_interval_args);
 
-        while (cerver->isRunning) {
-            if (cerver->update_interval) cerver->update_interval (cu);
+		while (cerver->isRunning) {
+			if (cerver->update_interval) cerver->update_interval (cu);
 
-            sleep (cerver->update_interval_secs);
-        }
+			sleep (cerver->update_interval_secs);
+		}
 
-        cerver_update_delete (cu);
+		cerver_update_delete (cu);
 
-        if (cerver->update_interval_args) {
-            if (cerver->delete_update_interval_args) {
-                cerver->delete_update_interval_args (cerver->update_interval_args);
-            }
-        }
+		if (cerver->update_interval_args) {
+			if (cerver->delete_update_interval_args) {
+				cerver->delete_update_interval_args (cerver->update_interval_args);
+			}
+		}
 
-        #ifdef CERVER_DEBUG
-        cerver_log_success (
-            "Cerver's %s cerver_update_interval () has ended!",
-            cerver->info->name->str
-        );
-        #endif
-    }
+		#ifdef CERVER_DEBUG
+		cerver_log_success (
+			"Cerver's %s cerver_update_interval () has ended!",
+			cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
@@ -2307,191 +2307,191 @@ static void cerver_update_interval (void *args) {
 // returns 0 on success, 1 on error
 u8 cerver_shutdown (Cerver *cerver) {
 
-    if (cerver->isRunning) {
-        cerver->isRunning = false;
+	if (cerver->isRunning) {
+		cerver->isRunning = false;
 
-        // close the cerver socket
-        if (!close (cerver->sock)) {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "The cerver %s socket has been closed.",
-                cerver->info->name->str
-            );
-            #endif
+		// close the cerver socket
+		if (!close (cerver->sock)) {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"The cerver %s socket has been closed.",
+				cerver->info->name->str
+			);
+			#endif
 
-            return 0;
-        }
+			return 0;
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to close cerver %s socket!",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to close cerver %s socket!",
+				cerver->info->name->str
+			);
+		}
+	}
 
-    return 1;
+	return 1;
 
 }
 
 // get rid of any on hold connections
 static void cerver_destroy_on_hold_connections (Cerver *cerver) {
 
-    if (cerver) {
-        if (cerver->auth_required) {
-            // ends and deletes any on hold connection
-            avl_delete (cerver->on_hold_connections);
-            cerver->on_hold_connections = NULL;
+	if (cerver) {
+		if (cerver->auth_required) {
+			// ends and deletes any on hold connection
+			avl_delete (cerver->on_hold_connections);
+			cerver->on_hold_connections = NULL;
 
-            if (cerver->hold_fds) {
-                free (cerver->hold_fds);
-                cerver->hold_fds = NULL;
-            }
-        }
-    }
+			if (cerver->hold_fds) {
+				free (cerver->hold_fds);
+				cerver->hold_fds = NULL;
+			}
+		}
+	}
 
 }
 
 // cleans up the client's structures in the current cerver
 static void cerver_destroy_clients (Cerver *cerver) {
 
-    if (cerver) {
-        if (cerver->stats->current_n_connected_clients > 0) {
-            // send a cerver teardown packet to all clients connected to cerver
-            Packet *packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_TEARDOWN, NULL, 0);
-            if (packet) {
-                client_broadcast_to_all_avl (cerver->clients->root, cerver, packet);
-                packet_delete (packet);
-            }
-        }
+	if (cerver) {
+		if (cerver->stats->current_n_connected_clients > 0) {
+			// send a cerver teardown packet to all clients connected to cerver
+			Packet *packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_TEARDOWN, NULL, 0);
+			if (packet) {
+				client_broadcast_to_all_avl (cerver->clients->root, cerver, packet);
+				packet_delete (packet);
+			}
+		}
 
-        // destroy the sock fd client map
-        htab_destroy (cerver->client_sock_fd_map);
-        cerver->client_sock_fd_map = NULL;
+		// destroy the sock fd client map
+		htab_destroy (cerver->client_sock_fd_map);
+		cerver->client_sock_fd_map = NULL;
 
-        // this will end and delete client connections and then delete the client
-        avl_delete (cerver->clients);
-        cerver->clients = NULL;
+		// this will end and delete client connections and then delete the client
+		avl_delete (cerver->clients);
+		cerver->clients = NULL;
 
-        if (cerver->fds) {
-            free (cerver->fds);
-            cerver->fds = NULL;
-        }
-    }
+		if (cerver->fds) {
+			free (cerver->fds);
+			cerver->fds = NULL;
+		}
+	}
 
 }
 
 // clean cerver data structures
 static void cerver_clean (Cerver *cerver) {
 
-    if (cerver) {
-        switch (cerver->type) {
-            case CERVER_TYPE_CUSTOM: break;
+	if (cerver) {
+		switch (cerver->type) {
+			case CERVER_TYPE_CUSTOM: break;
 
-            case CERVER_TYPE_GAME: {
-                if (cerver->cerver_data) {
-                    GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+			case CERVER_TYPE_GAME: {
+				if (cerver->cerver_data) {
+					GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
 
-                    if (game_cerver->final_game_action)
-                        game_cerver->final_game_action (game_cerver->final_action_args);
+					if (game_cerver->final_game_action)
+						game_cerver->final_game_action (game_cerver->final_action_args);
 
-                    Lobby *lobby = NULL;
-                    for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
-                        lobby = (Lobby *) le->data;
-                        lobby->running = false;
-                    }
+					Lobby *lobby = NULL;
+					for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
+						lobby = (Lobby *) le->data;
+						lobby->running = false;
+					}
 
-                    game_delete (game_cerver);      // delete game cerver data
-                    cerver->cerver_data = NULL;
-                }
-            } break;
+					game_delete (game_cerver);      // delete game cerver data
+					cerver->cerver_data = NULL;
+				}
+			} break;
 
-            case CERVER_TYPE_WEB: {
-                if (cerver->cerver_data) {
-                    http_cerver_delete (cerver->cerver_data);
-                    cerver->cerver_data = NULL;
-                }
-            } break;
+			case CERVER_TYPE_WEB: {
+				if (cerver->cerver_data) {
+					http_cerver_delete (cerver->cerver_data);
+					cerver->cerver_data = NULL;
+				}
+			} break;
 
-            case CERVER_TYPE_FILES: {
-                if (cerver->cerver_data) {
-                    file_cerver_delete (cerver->cerver_data);
-                    cerver->cerver_data = NULL;
-                }
-            } break;
+			case CERVER_TYPE_FILES: {
+				if (cerver->cerver_data) {
+					file_cerver_delete (cerver->cerver_data);
+					cerver->cerver_data = NULL;
+				}
+			} break;
 
-            default: break;
-        }
+			default: break;
+		}
 
-        // clean up on hold connections
-        cerver_destroy_on_hold_connections (cerver);
+		// clean up on hold connections
+		cerver_destroy_on_hold_connections (cerver);
 
-        // clean up cerver connected clients
-        cerver_destroy_clients (cerver);
-        #ifdef CERVER_DEBUG
-        cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Done cleaning up clients.");
-        #endif
+		// clean up cerver connected clients
+		cerver_destroy_clients (cerver);
+		#ifdef CERVER_DEBUG
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Done cleaning up clients.");
+		#endif
 
-        // disable socket I/O in both ways and stop any ongoing job
-        if (!cerver_shutdown (cerver)) {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
-                "Cerver %s has been shutted down.", cerver->info->name->str
-            );
-            #endif
-        }
+		// disable socket I/O in both ways and stop any ongoing job
+		if (!cerver_shutdown (cerver)) {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+				"Cerver %s has been shutted down.", cerver->info->name->str
+			);
+			#endif
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to shutdown cerver %s!", cerver->info->name->str
-            );
-            #endif
-        }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to shutdown cerver %s!", cerver->info->name->str
+			);
+			#endif
+		}
 
-        // stop any app / custom handler
-        if (!cerver_handlers_destroy (cerver)) {
-            cerver_log_success (
-                "Done destroying handlers in cerver %s",
-                cerver->info->name->str
-            );
-        }
+		// stop any app / custom handler
+		if (!cerver_handlers_destroy (cerver)) {
+			cerver_log_success (
+				"Done destroying handlers in cerver %s",
+				cerver->info->name->str
+			);
+		}
 
-        if (cerver->thpool) {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Cerver %s active thpool threads: %i",
-                cerver->info->name->str,
-                thpool_get_num_threads_working (cerver->thpool)
-            );
-            #endif
+		if (cerver->thpool) {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Cerver %s active thpool threads: %i",
+				cerver->info->name->str,
+				thpool_get_num_threads_working (cerver->thpool)
+			);
+			#endif
 
-            thpool_destroy (cerver->thpool);
+			thpool_destroy (cerver->thpool);
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Destroyed cerver %s thpool!", cerver->info->name->str
-            );
-            #endif
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Destroyed cerver %s thpool!", cerver->info->name->str
+			);
+			#endif
 
-            cerver->thpool = NULL;
-        }
+			cerver->thpool = NULL;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log_debug (
-                "Cerver %s does NOT have a thpool to destroy",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log_debug (
+				"Cerver %s does NOT have a thpool to destroy",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
 }
 
@@ -2499,48 +2499,48 @@ static void cerver_clean (Cerver *cerver) {
 // returns 0 on success, 1 on error
 u8 cerver_teardown (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_CERVER, LOG_TYPE_NONE,
-            "Starting cerver %s teardown...", cerver->info->name->str
-        );
-        #endif
+	if (cerver) {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Starting cerver %s teardown...", cerver->info->name->str
+		);
+		#endif
 
-        cerver_event_trigger (
-            CERVER_EVENT_TEARDOWN,
-            cerver,
-            NULL, NULL
-        );
+		cerver_event_trigger (
+			CERVER_EVENT_TEARDOWN,
+			cerver,
+			NULL, NULL
+		);
 
-        cerver_clean (cerver);
+		cerver_clean (cerver);
 
-        // correctly end admin connections & stop admin handlers
-        admin_cerver_end (cerver->admin);
+		// correctly end admin connections & stop admin handlers
+		admin_cerver_end (cerver->admin);
 
-        // 29/05/2020
-        cerver_sockets_pool_end (cerver);
+		// 29/05/2020
+		cerver_sockets_pool_end (cerver);
 
-        cerver_log (
-            LOG_TYPE_SUCCESS, LOG_TYPE_NONE,
-            "Cerver %s teardown was successful!",
-            cerver->info->name->str
-        );
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_NONE,
+			"Cerver %s teardown was successful!",
+			cerver->info->name->str
+		);
 
-        cerver_delete (cerver);
+		cerver_delete (cerver);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        #ifdef CERVER_DEBUG
-        cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Can't teardown a NULL cerver!");
-        #endif
-    }
+	else {
+		#ifdef CERVER_DEBUG
+		cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Can't teardown a NULL cerver!");
+		#endif
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2550,175 +2550,175 @@ u8 cerver_teardown (Cerver *cerver) {
 
 static CerverReport *cerver_report_new (void) {
 
-    CerverReport *cerver_report = (CerverReport *) malloc (sizeof (Cerver));
-    if (cerver_report) {
-        memset (cerver_report, 0, sizeof (CerverReport));
+	CerverReport *cerver_report = (CerverReport *) malloc (sizeof (Cerver));
+	if (cerver_report) {
+		memset (cerver_report, 0, sizeof (CerverReport));
 
-        cerver_report->name = NULL;
-    }
+		cerver_report->name = NULL;
+	}
 
-    return cerver_report;
+	return cerver_report;
 
 }
 
 void cerver_report_delete (void *ptr) {
 
-    if (ptr) {
-        CerverReport *cerver_report = (CerverReport *) ptr;
+	if (ptr) {
+		CerverReport *cerver_report = (CerverReport *) ptr;
 
-        str_delete (cerver_report->name);
+		str_delete (cerver_report->name);
 
-        str_delete (cerver_report->welcome);
+		str_delete (cerver_report->welcome);
 
-        free (cerver_report);
-    }
+		free (cerver_report);
+	}
 
 }
 
 static void cerver_report_check_info_handle_auth (
-    CerverReport *cerver_report,
-    Client *client, Connection *connection
+	CerverReport *cerver_report,
+	Client *client, Connection *connection
 ) {
 
-    if (cerver_report && connection) {
-        if (cerver_report->auth_required) {
-            // #ifdef CLIENT_DEBUG
-            cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver requires authentication.");
-            // #endif
-            if (connection->auth_data) {
-                #ifdef CLIENT_DEBUG
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Sending auth data to cerver...");
-                #endif
+	if (cerver_report && connection) {
+		if (cerver_report->auth_required) {
+			// #ifdef CLIENT_DEBUG
+			cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver requires authentication.");
+			// #endif
+			if (connection->auth_data) {
+				#ifdef CLIENT_DEBUG
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Sending auth data to cerver...");
+				#endif
 
-                if (!connection->auth_packet) {
-                    if (!connection_generate_auth_packet (connection)) {
-                        cerver_log_success (
-                            "cerver_check_info () - Generated connection %s auth packet!",
-                            connection->name->str
-                        );
-                    }
+				if (!connection->auth_packet) {
+					if (!connection_generate_auth_packet (connection)) {
+						cerver_log_success (
+							"cerver_check_info () - Generated connection %s auth packet!",
+							connection->name->str
+						);
+					}
 
-                    else {
-                        cerver_log_error (
-                            "cerver_check_info () - Failed to generate connection %s auth packet!",
-                            connection->name->str
-                        );
-                    }
-                }
+					else {
+						cerver_log_error (
+							"cerver_check_info () - Failed to generate connection %s auth packet!",
+							connection->name->str
+						);
+					}
+				}
 
-                if (connection->auth_packet) {
-                    packet_set_network_values (
-                        connection->auth_packet,
-                        NULL,
-                        NULL,
-                        connection,
-                        NULL
-                    );
+				if (connection->auth_packet) {
+					packet_set_network_values (
+						connection->auth_packet,
+						NULL,
+						NULL,
+						connection,
+						NULL
+					);
 
-                    if (!packet_send (connection->auth_packet, 0, NULL, false)) {
-                        cerver_log_success (
-                            "cerver_check_info () - Sent connection %s auth packet!",
-                            connection->name->str
-                        );
+					if (!packet_send (connection->auth_packet, 0, NULL, false)) {
+						cerver_log_success (
+							"cerver_check_info () - Sent connection %s auth packet!",
+							connection->name->str
+						);
 
-                        client_event_trigger (CLIENT_EVENT_AUTH_SENT, client, connection);
-                    }
+						client_event_trigger (CLIENT_EVENT_AUTH_SENT, client, connection);
+					}
 
-                    else {
-                        cerver_log_error (
-                            "cerver_check_info () - Failed to send connection %s auth packet!",
-                            connection->name->str
-                        );
-                    }
-                }
+					else {
+						cerver_log_error (
+							"cerver_check_info () - Failed to send connection %s auth packet!",
+							connection->name->str
+						);
+					}
+				}
 
-                if (cerver_report->uses_sessions) {
-                    cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver supports sessions.");
-                }
-            }
+				if (cerver_report->uses_sessions) {
+					cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver supports sessions.");
+				}
+			}
 
-            else {
-                cerver_log_error (
-                    "Connection %s does NOT have an auth packet!",
-                    connection->name->str
-                );
-            }
-        }
+			else {
+				cerver_log_error (
+					"Connection %s does NOT have an auth packet!",
+					connection->name->str
+				);
+			}
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver does NOT require authentication.");
-            #endif
-        }
-    }
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver does NOT require authentication.");
+			#endif
+		}
+	}
 
 }
 
 u8 cerver_report_check_info (
-    CerverReport *cerver_report,
-    Client *client, Connection *connection
+	CerverReport *cerver_report,
+	Client *client, Connection *connection
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver_report && connection) {
-        connection->cerver_report = cerver_report;
+	if (cerver_report && connection) {
+		connection->cerver_report = cerver_report;
 
-        // #ifdef CLIENT_DEBUG
-        cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Connected to cerver %s.", cerver_report->name->str);
+		// #ifdef CLIENT_DEBUG
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Connected to cerver %s.", cerver_report->name->str);
 
-        if (cerver_report->welcome) {
-            cerver_log_msg ("%s", cerver_report->welcome->str);
-        }
+		if (cerver_report->welcome) {
+			cerver_log_msg ("%s", cerver_report->welcome->str);
+		}
 
-        switch (cerver_report->protocol) {
-            case PROTOCOL_TCP:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using TCP protocol.");
-                break;
-            case PROTOCOL_UDP:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using UDP protocol.");
-                break;
+		switch (cerver_report->protocol) {
+			case PROTOCOL_TCP:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using TCP protocol.");
+				break;
+			case PROTOCOL_UDP:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using UDP protocol.");
+				break;
 
-            default:
-                cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Cerver using unknown protocol.");
-                break;
-        }
-        // #endif
+			default:
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Cerver using unknown protocol.");
+				break;
+		}
+		// #endif
 
-        if (cerver_report->use_ipv6) {
-            // #ifdef CLIENT_DEBUG
-            cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
-            // #endif
-        }
+		if (cerver_report->use_ipv6) {
+			// #ifdef CLIENT_DEBUG
+			cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
+			// #endif
+		}
 
-        // #ifdef CLIENT_DEBUG
-        switch (cerver_report->type) {
-            case CERVER_TYPE_CUSTOM:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
-                break;
+		// #ifdef CLIENT_DEBUG
+		switch (cerver_report->type) {
+			case CERVER_TYPE_CUSTOM:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
+				break;
 
-            case CERVER_TYPE_GAME:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: GAME");
-                break;
-            case CERVER_TYPE_WEB:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: WEB");
-                break;
-             case CERVER_TYPE_FILES:
-                cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: FILES");
-                break;
+			case CERVER_TYPE_GAME:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: GAME");
+				break;
+			case CERVER_TYPE_WEB:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: WEB");
+				break;
+			 case CERVER_TYPE_FILES:
+				cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: FILES");
+				break;
 
-            default:
-                cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Cerver type: UNKNOWN");
-                break;
-        }
-        // #endif
+			default:
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Cerver type: UNKNOWN");
+				break;
+		}
+		// #endif
 
-        cerver_report_check_info_handle_auth (cerver_report, client, connection);
+		cerver_report_check_info_handle_auth (cerver_report, client, connection);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2728,9 +2728,9 @@ u8 cerver_report_check_info (
 
 static inline SCerver *scerver_new (void) {
 
-    SCerver *scerver = (SCerver *) malloc (sizeof (SCerver));
-    if (scerver) memset (scerver, 0, sizeof (SCerver));
-    return scerver;
+	SCerver *scerver = (SCerver *) malloc (sizeof (SCerver));
+	if (scerver) memset (scerver, 0, sizeof (SCerver));
+	return scerver;
 
 }
 
@@ -2739,70 +2739,70 @@ static inline void scerver_delete (void *ptr) { if (ptr) free (ptr); }
 // srealizes the cerver
 static SCerver *cerver_serliaze (Cerver *cerver) {
 
-    SCerver *scerver = NULL;
+	SCerver *scerver = NULL;
 
-    if (cerver) {
-        scerver = scerver_new ();
-        if (scerver) {
-            scerver->type = cerver->type;
+	if (cerver) {
+		scerver = scerver_new ();
+		if (scerver) {
+			scerver->type = cerver->type;
 
-            strncpy (scerver->name, cerver->info->name->str, S_CERVER_NAME_LENGTH);
+			strncpy (scerver->name, cerver->info->name->str, S_CERVER_NAME_LENGTH);
 
-            if (cerver->info->welcome_msg)
-                strncpy (scerver->welcome, cerver->info->welcome_msg->str, S_CERVER_WELCOME_LENGTH);
+			if (cerver->info->welcome_msg)
+				strncpy (scerver->welcome, cerver->info->welcome_msg->str, S_CERVER_WELCOME_LENGTH);
 
-            scerver->use_ipv6 = cerver->use_ipv6;
-            scerver->protocol = cerver->protocol;
-            scerver->port = cerver->port;
+			scerver->use_ipv6 = cerver->use_ipv6;
+			scerver->protocol = cerver->protocol;
+			scerver->port = cerver->port;
 
-            scerver->auth_required = cerver->auth_required;
-            scerver->uses_sessions = cerver->use_sessions;
-        }
-    }
+			scerver->auth_required = cerver->auth_required;
+			scerver->uses_sessions = cerver->use_sessions;
+		}
+	}
 
-    return scerver;
+	return scerver;
 
 }
 
 CerverReport *cerver_deserialize (SCerver *scerver) {
 
-    CerverReport *cerver_report = NULL;
+	CerverReport *cerver_report = NULL;
 
-    if (scerver) {
-        cerver_report = cerver_report_new ();
-        if (cerver_report) {
-            cerver_report->type = scerver->type;
+	if (scerver) {
+		cerver_report = cerver_report_new ();
+		if (cerver_report) {
+			cerver_report->type = scerver->type;
 
-            cerver_report->name = str_new (scerver->name);
-            if (strlen (scerver->welcome)) cerver_report->welcome = str_new (scerver->welcome);
+			cerver_report->name = str_new (scerver->name);
+			if (strlen (scerver->welcome)) cerver_report->welcome = str_new (scerver->welcome);
 
-            cerver_report->use_ipv6 = scerver->use_ipv6;
-            cerver_report->protocol = scerver->protocol;
-            cerver_report->port = scerver->port;
+			cerver_report->use_ipv6 = scerver->use_ipv6;
+			cerver_report->protocol = scerver->protocol;
+			cerver_report->port = scerver->port;
 
-            cerver_report->auth_required = scerver->auth_required;
-            cerver_report->uses_sessions = scerver->uses_sessions;
-        }
-    }
+			cerver_report->auth_required = scerver->auth_required;
+			cerver_report->uses_sessions = scerver->uses_sessions;
+		}
+	}
 
-    return cerver_report;
+	return cerver_report;
 
 }
 
 // creates a cerver info packet ready to be sent
 Packet *cerver_packet_generate (Cerver *cerver) {
 
-    Packet *packet = NULL;
+	Packet *packet = NULL;
 
-    if (cerver) {
-        SCerver *scerver = cerver_serliaze (cerver);
-        if (scerver) {
-            packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_INFO, scerver, sizeof (SCerver));
-            scerver_delete (scerver);
-        }
-    }
+	if (cerver) {
+		SCerver *scerver = cerver_serliaze (cerver);
+		if (scerver) {
+			packet = packet_generate_request (PACKET_TYPE_CERVER, CERVER_PACKET_TYPE_INFO, scerver, sizeof (SCerver));
+			scerver_delete (scerver);
+		}
+	}
 
-    return packet;
+	return packet;
 
 }
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -33,10 +33,10 @@ static void client_event_delete (void *ptr);
 static void client_error_delete (void *client_error_ptr);
 
 static u8 client_file_receive (
-    Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 );
 
 unsigned int client_receive (Client *client, Connection *connection);
@@ -47,14 +47,14 @@ static u64 next_client_id = 0;
 
 static ClientConnection *client_connection_aux_new (Client *client, Connection *connection) {
 
-    ClientConnection *cc = (ClientConnection *) malloc (sizeof (ClientConnection));
-    if (cc) {
-        cc->connection_thread_id = 0;
-        cc->client = client;
-        cc->connection = connection;
-    }
+	ClientConnection *cc = (ClientConnection *) malloc (sizeof (ClientConnection));
+	if (cc) {
+		cc->connection_thread_id = 0;
+		cc->client = client;
+		cc->connection = connection;
+	}
 
-    return cc;
+	return cc;
 
 }
 
@@ -66,102 +66,102 @@ void client_connection_aux_delete (ClientConnection *cc) { if (cc) free (cc); }
 
 static ClientStats *client_stats_new (void) {
 
-    ClientStats *client_stats = (ClientStats *) malloc (sizeof (ClientStats));
-    if (client_stats) {
-        memset (client_stats, 0, sizeof (ClientStats));
-        client_stats->received_packets = packets_per_type_new ();
-        client_stats->sent_packets = packets_per_type_new ();
-    }
+	ClientStats *client_stats = (ClientStats *) malloc (sizeof (ClientStats));
+	if (client_stats) {
+		memset (client_stats, 0, sizeof (ClientStats));
+		client_stats->received_packets = packets_per_type_new ();
+		client_stats->sent_packets = packets_per_type_new ();
+	}
 
-    return client_stats;
+	return client_stats;
 
 }
 
 static inline void client_stats_delete (ClientStats *client_stats) {
 
-    if (client_stats) {
-        packets_per_type_delete (client_stats->received_packets);
-        packets_per_type_delete (client_stats->sent_packets);
+	if (client_stats) {
+		packets_per_type_delete (client_stats->received_packets);
+		packets_per_type_delete (client_stats->sent_packets);
 
-        free (client_stats);
-    }
+		free (client_stats);
+	}
 
 }
 
 void client_stats_print (Client *client) {
 
-    if (client) {
-        if (client->stats) {
-            printf ("\nClient's stats:\n");
-            printf ("Threshold time:            %ld\n", client->stats->threshold_time);
+	if (client) {
+		if (client->stats) {
+			printf ("\nClient's stats:\n");
+			printf ("Threshold time:            %ld\n", client->stats->threshold_time);
 
-            printf ("N receives done:           %ld\n", client->stats->n_receives_done);
+			printf ("N receives done:           %ld\n", client->stats->n_receives_done);
 
-            printf ("Total bytes received:      %ld\n", client->stats->total_bytes_received);
-            printf ("Total bytes sent:          %ld\n", client->stats->total_bytes_sent);
+			printf ("Total bytes received:      %ld\n", client->stats->total_bytes_received);
+			printf ("Total bytes sent:          %ld\n", client->stats->total_bytes_sent);
 
-            printf ("N packets received:        %ld\n", client->stats->n_packets_received);
-            printf ("N packets sent:            %ld\n", client->stats->n_packets_sent);
+			printf ("N packets received:        %ld\n", client->stats->n_packets_received);
+			printf ("N packets sent:            %ld\n", client->stats->n_packets_sent);
 
-            printf ("\nReceived packets:\n");
-            packets_per_type_print (client->stats->received_packets);
+			printf ("\nReceived packets:\n");
+			packets_per_type_print (client->stats->received_packets);
 
-            printf ("\nSent packets:\n");
-            packets_per_type_print (client->stats->sent_packets);
-        }
+			printf ("\nSent packets:\n");
+			packets_per_type_print (client->stats->sent_packets);
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Client does not have a reference to a client stats!"
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Client does not have a reference to a client stats!"
+			);
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-            "Can't get stats of a NULL client!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+			"Can't get stats of a NULL client!"
+		);
+	}
 
 }
 
 static ClientFileStats *client_file_stats_new (void) {
 
-    ClientFileStats *file_stats = (ClientFileStats *) malloc (sizeof (ClientFileStats));
-    if (file_stats) {
-        memset (file_stats, 0, sizeof (ClientFileStats));
-    }
+	ClientFileStats *file_stats = (ClientFileStats *) malloc (sizeof (ClientFileStats));
+	if (file_stats) {
+		memset (file_stats, 0, sizeof (ClientFileStats));
+	}
 
-    return file_stats;
+	return file_stats;
 
 }
 
 static void client_file_stats_delete (ClientFileStats *file_stats) {
 
-    if (file_stats) free (file_stats);
+	if (file_stats) free (file_stats);
 
 }
 
 void client_file_stats_print (Client *client) {
 
-    if (client) {
-        if (client->file_stats) {
-            printf ("Files requests:                %ld\n", client->file_stats->n_files_requests);
-            printf ("Success requests:              %ld\n", client->file_stats->n_success_files_requests);
-            printf ("Bad requests:                  %ld\n\n", client->file_stats->n_bad_files_requests);
-            printf ("Files sent:                    %ld\n\n", client->file_stats->n_files_sent);
-            printf ("Failed files sent:             %ld\n\n", client->file_stats->n_bad_files_sent);
-            printf ("Files bytes sent:              %ld\n\n", client->file_stats->n_bytes_sent);
+	if (client) {
+		if (client->file_stats) {
+			printf ("Files requests:                %ld\n", client->file_stats->n_files_requests);
+			printf ("Success requests:              %ld\n", client->file_stats->n_success_files_requests);
+			printf ("Bad requests:                  %ld\n\n", client->file_stats->n_bad_files_requests);
+			printf ("Files sent:                    %ld\n\n", client->file_stats->n_files_sent);
+			printf ("Failed files sent:             %ld\n\n", client->file_stats->n_bad_files_sent);
+			printf ("Files bytes sent:              %ld\n\n", client->file_stats->n_bytes_sent);
 
-            printf ("Files upload requests:         %ld\n", client->file_stats->n_files_upload_requests);
-            printf ("Success uploads:               %ld\n", client->file_stats->n_success_files_uploaded);
-            printf ("Bad uploads:                   %ld\n", client->file_stats->n_bad_files_upload_requests);
-            printf ("Bad files received:            %ld\n", client->file_stats->n_bad_files_received);
-            printf ("Files bytes received:          %ld\n\n", client->file_stats->n_bytes_received);
-        }
-    }
+			printf ("Files upload requests:         %ld\n", client->file_stats->n_files_upload_requests);
+			printf ("Success uploads:               %ld\n", client->file_stats->n_success_files_uploaded);
+			printf ("Bad uploads:                   %ld\n", client->file_stats->n_bad_files_upload_requests);
+			printf ("Bad files received:            %ld\n", client->file_stats->n_bad_files_received);
+			printf ("Files bytes received:          %ld\n\n", client->file_stats->n_bytes_received);
+		}
+	}
 
 }
 
@@ -171,108 +171,108 @@ void client_file_stats_print (Client *client) {
 
 Client *client_new (void) {
 
-    Client *client = (Client *) malloc (sizeof (Client));
-    if (client) {
-        client->id = 0;
-        client->session_id = NULL;
+	Client *client = (Client *) malloc (sizeof (Client));
+	if (client) {
+		client->id = 0;
+		client->session_id = NULL;
 
-        client->name = NULL;
+		client->name = NULL;
 
-        client->connections = NULL;
+		client->connections = NULL;
 
-        client->drop_client = false;
+		client->drop_client = false;
 
-        client->data = NULL;
-        client->delete_data = NULL;
+		client->data = NULL;
+		client->delete_data = NULL;
 
-        client->running = false;
-        client->time_started = 0;
-        client->uptime = 0;
+		client->running = false;
+		client->time_started = 0;
+		client->uptime = 0;
 
-        client->num_handlers_alive = 0;
-        client->num_handlers_working = 0;
-        client->handlers_lock = NULL;
-        client->app_packet_handler = NULL;
-        client->app_error_packet_handler = NULL;
-        client->custom_packet_handler = NULL;
+		client->num_handlers_alive = 0;
+		client->num_handlers_working = 0;
+		client->handlers_lock = NULL;
+		client->app_packet_handler = NULL;
+		client->app_error_packet_handler = NULL;
+		client->custom_packet_handler = NULL;
 
-        client->check_packets = false;
+		client->check_packets = false;
 
-        client->lock = NULL;
+		client->lock = NULL;
 
-        for (unsigned int i = 0; i < CLIENT_MAX_EVENTS; i++)
-            client->events[i] = NULL;
+		for (unsigned int i = 0; i < CLIENT_MAX_EVENTS; i++)
+			client->events[i] = NULL;
 
-        for (unsigned int i = 0; i < CLIENT_MAX_ERRORS; i++)
-            client->errors[i] = NULL;
+		for (unsigned int i = 0; i < CLIENT_MAX_ERRORS; i++)
+			client->errors[i] = NULL;
 
-        client->n_paths = 0;
-        for (unsigned int i = 0; i < CLIENT_FILES_MAX_PATHS; i++)
-            client->paths[i] = NULL;
+		client->n_paths = 0;
+		for (unsigned int i = 0; i < CLIENT_FILES_MAX_PATHS; i++)
+			client->paths[i] = NULL;
 
-        client->uploads_path = NULL;
+		client->uploads_path = NULL;
 
-        client->file_upload_handler = client_file_receive;
+		client->file_upload_handler = client_file_receive;
 
-        client->file_upload_cb = NULL;
+		client->file_upload_cb = NULL;
 
-        client->file_stats = NULL;
+		client->file_stats = NULL;
 
-        client->stats = NULL;
-    }
+		client->stats = NULL;
+	}
 
-    return client;
+	return client;
 
 }
 
 void client_delete (void *ptr) {
 
-    if (ptr) {
-        Client *client = (Client *) ptr;
+	if (ptr) {
+		Client *client = (Client *) ptr;
 
-        str_delete (client->session_id);
+		str_delete (client->session_id);
 
-        str_delete (client->name);
+		str_delete (client->name);
 
-        dlist_delete (client->connections);
+		dlist_delete (client->connections);
 
-        if (client->data) {
-            if (client->delete_data) client->delete_data (client->data);
-            else free (client->data);
-        }
+		if (client->data) {
+			if (client->delete_data) client->delete_data (client->data);
+			else free (client->data);
+		}
 
-        // 16/06/2020
-        if (client->handlers_lock) {
-            pthread_mutex_destroy (client->handlers_lock);
-            free (client->handlers_lock);
-        }
+		// 16/06/2020
+		if (client->handlers_lock) {
+			pthread_mutex_destroy (client->handlers_lock);
+			free (client->handlers_lock);
+		}
 
-        handler_delete (client->app_packet_handler);
-        handler_delete (client->app_error_packet_handler);
-        handler_delete (client->custom_packet_handler);
+		handler_delete (client->app_packet_handler);
+		handler_delete (client->app_error_packet_handler);
+		handler_delete (client->custom_packet_handler);
 
-        if (client->lock) {
-            pthread_mutex_destroy (client->lock);
-            free (client->lock);
-        }
+		if (client->lock) {
+			pthread_mutex_destroy (client->lock);
+			free (client->lock);
+		}
 
-        for (unsigned int i = 0; i < CLIENT_MAX_EVENTS; i++)
-            if (client->events[i]) client_event_delete (client->events[i]);
+		for (unsigned int i = 0; i < CLIENT_MAX_EVENTS; i++)
+			if (client->events[i]) client_event_delete (client->events[i]);
 
-        for (unsigned int i = 0; i < CLIENT_MAX_ERRORS; i++)
-            if (client->errors[i]) client_error_delete (client->errors[i]);
+		for (unsigned int i = 0; i < CLIENT_MAX_ERRORS; i++)
+			if (client->errors[i]) client_error_delete (client->errors[i]);
 
-        for (unsigned int i = 0; i < CLIENT_FILES_MAX_PATHS; i++)
-            str_delete (client->paths[i]);
+		for (unsigned int i = 0; i < CLIENT_FILES_MAX_PATHS; i++)
+			str_delete (client->paths[i]);
 
-        str_delete (client->uploads_path);
+		str_delete (client->uploads_path);
 
-        client_file_stats_delete (client->file_stats);
+		client_file_stats_delete (client->file_stats);
 
-        client_stats_delete (client->stats);
+		client_stats_delete (client->stats);
 
-        free (client);
-    }
+		free (client);
+	}
 
 }
 
@@ -281,55 +281,55 @@ void client_delete_dummy (void *ptr) {}
 // creates a new client and inits its values
 Client *client_create (void) {
 
-    Client *client = client_new ();
-    if (client) {
-        client->id = next_client_id;
-        next_client_id += 1;
+	Client *client = client_new ();
+	if (client) {
+		client->id = next_client_id;
+		next_client_id += 1;
 
-        client->name = str_new ("no-name");
+		client->name = str_new ("no-name");
 
-        time (&client->connected_timestamp);
+		time (&client->connected_timestamp);
 
-        client->connections = dlist_init (connection_delete, connection_comparator);
+		client->connections = dlist_init (connection_delete, connection_comparator);
 
-        client->lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (client->lock, NULL);
+		client->lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (client->lock, NULL);
 
-        client->file_stats = client_file_stats_new ();
+		client->file_stats = client_file_stats_new ();
 
-        client->stats = client_stats_new ();
-    }
+		client->stats = client_stats_new ();
+	}
 
-    return client;
+	return client;
 
 }
 
 // creates a new client and registers a new connection
 Client *client_create_with_connection (Cerver *cerver,
-    const i32 sock_fd, const struct sockaddr_storage address) {
+	const i32 sock_fd, const struct sockaddr_storage address) {
 
-    Client *client = client_create ();
-    if (client) {
-        Connection *connection = connection_create (sock_fd, address, cerver->protocol);
-        if (connection) connection_register_to_client (client, connection);
-        else {
-            // failed to create a new connection
-            client_delete (client);
-            client = NULL;
-        }
-    }
+	Client *client = client_create ();
+	if (client) {
+		Connection *connection = connection_create (sock_fd, address, cerver->protocol);
+		if (connection) connection_register_to_client (client, connection);
+		else {
+			// failed to create a new connection
+			client_delete (client);
+			client = NULL;
+		}
+	}
 
-    return client;
+	return client;
 
 }
 
 // sets the client's name
 void client_set_name (Client *client, const char *name) {
 
-    if (client) {
-        if (client->name) str_delete (client->name);
-        client->name = name ? str_new (name) : NULL;
-    }
+	if (client) {
+		if (client->name) str_delete (client->name);
+		client->name = name ? str_new (name) : NULL;
+	}
 
 }
 
@@ -338,21 +338,21 @@ void client_set_name (Client *client, const char *name) {
 // returns a newly allocated string with the clients id that should be deleted after use
 char *client_get_identifier (Client *client, bool *is_name) {
 
-    char *retval = NULL;
+	char *retval = NULL;
 
-    if (client) {
-        if (client->name) {
-            retval = client->name->str;
-            *is_name = true;
-        }
+	if (client) {
+		if (client->name) {
+			retval = client->name->str;
+			*is_name = true;
+		}
 
-        else {
-           retval = c_string_create ("%ld", client->id);
-           *is_name = false;
-        }
-    }
+		else {
+		   retval = c_string_create ("%ld", client->id);
+		   *is_name = false;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -360,16 +360,16 @@ char *client_get_identifier (Client *client, bool *is_name) {
 // returns 0 on succes, 1 on error
 u8 client_set_session_id (Client *client, const char *session_id) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        str_delete (client->session_id);
-        client->session_id = session_id ? str_new (session_id) : NULL;
+	if (client) {
+		str_delete (client->session_id);
+		client->session_id = session_id ? str_new (session_id) : NULL;
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -380,48 +380,48 @@ void *client_get_data (Client *client) { return (client ? client->data : NULL); 
 // deletes the previous data of the client
 void client_set_data (Client *client, void *data, Action delete_data) {
 
-    if (client) {
-        if (client->data) {
-            if (client->delete_data) client->delete_data (client->data);
-            else free (client->data);
-        }
+	if (client) {
+		if (client->data) {
+			if (client->delete_data) client->delete_data (client->data);
+			else free (client->data);
+		}
 
-        client->data = data;
-        client->delete_data = delete_data;
-    }
+		client->data = data;
+		client->delete_data = delete_data;
+	}
 
 }
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 void client_set_app_handlers (Client *client,
-    Handler *app_handler, Handler *app_error_handler) {
+	Handler *app_handler, Handler *app_error_handler) {
 
-    if (client) {
-        client->app_packet_handler = app_handler;
-        if (client->app_packet_handler) {
-            client->app_packet_handler->type = HANDLER_TYPE_CLIENT;
-            client->app_packet_handler->client = client;
-        }
+	if (client) {
+		client->app_packet_handler = app_handler;
+		if (client->app_packet_handler) {
+			client->app_packet_handler->type = HANDLER_TYPE_CLIENT;
+			client->app_packet_handler->client = client;
+		}
 
-        client->app_error_packet_handler = app_error_handler;
-        if (client->app_error_packet_handler) {
-            client->app_error_packet_handler->type = HANDLER_TYPE_CLIENT;
-            client->app_error_packet_handler->client = client;
-        }
-    }
+		client->app_error_packet_handler = app_error_handler;
+		if (client->app_error_packet_handler) {
+			client->app_error_packet_handler->type = HANDLER_TYPE_CLIENT;
+			client->app_error_packet_handler->client = client;
+		}
+	}
 
 }
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
 void client_set_custom_handler (Client *client, Handler *custom_handler) {
 
-    if (client) {
-        client->custom_packet_handler = custom_handler;
-        if (client->custom_packet_handler) {
-            client->custom_packet_handler->type = HANDLER_TYPE_CLIENT;
-            client->custom_packet_handler->client = client;
-        }
-    }
+	if (client) {
+		client->custom_packet_handler = custom_handler;
+		if (client->custom_packet_handler) {
+			client->custom_packet_handler->type = HANDLER_TYPE_CLIENT;
+			client->custom_packet_handler->client = client;
+		}
+	}
 
 }
 
@@ -432,73 +432,73 @@ void client_set_custom_handler (Client *client, Handler *custom_handler) {
 // by default, this option is turned off
 void client_set_check_packets (Client *client, bool check_packets) {
 
-    if (client) {
-        client->check_packets = check_packets;
-    }
+	if (client) {
+		client->check_packets = check_packets;
+	}
 
 }
 
 // compare clients based on their client ids
 int client_comparator_client_id (const void *a, const void *b) {
 
-    if (a && b) {
-        Client *client_a = (Client *) a;
-        Client *client_b = (Client *) b;
+	if (a && b) {
+		Client *client_a = (Client *) a;
+		Client *client_b = (Client *) b;
 
-        if (client_a->id < client_b->id) return -1;
-        else if (client_a->id == client_b->id) return 0;
-        else return 1;
-    }
+		if (client_a->id < client_b->id) return -1;
+		else if (client_a->id == client_b->id) return 0;
+		else return 1;
+	}
 
-    return 0;
+	return 0;
 
 }
 
 // compare clients based on their session ids
 int client_comparator_session_id (const void *a, const void *b) {
 
-    if (a && b) return str_compare (((Client *) a)->session_id, ((Client *) b)->session_id);
-    if (a && !b) return -1;
-    if (!a && b) return 1;
+	if (a && b) return str_compare (((Client *) a)->session_id, ((Client *) b)->session_id);
+	if (a && !b) return -1;
+	if (!a && b) return 1;
 
-    return 0;
+	return 0;
 
 }
 
 // closes all client connections
 u8 client_disconnect (Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            connection_end (connection);
-        }
+	if (client) {
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			connection_end (connection);
+		}
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // the client got disconnected from the cerver, so correctly clear our data
 void client_got_disconnected (Client *client) {
 
-    if (client) {
-        // close any ongoing connection
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection_end ((Connection *) le->data);
-        }
+	if (client) {
+		// close any ongoing connection
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection_end ((Connection *) le->data);
+		}
 
-        // dlist_reset (client->connections);
+		// dlist_reset (client->connections);
 
-        // reset client
-        client->running = false;
-        client->time_started = 0;
-    }
+		// reset client
+		client->running = false;
+		client->time_started = 0;
+	}
 
 }
 
@@ -506,10 +506,10 @@ void client_got_disconnected (Client *client) {
 // unregisters the client from the cerver and the deletes him
 void client_drop (Cerver *cerver, Client *client) {
 
-    if (cerver && client) {
-        client_unregister_from_cerver (cerver, client);
-        client_delete (client);
-    }
+	if (cerver && client) {
+		client_unregister_from_cerver (cerver, client);
+		client_delete (client);
+	}
 
 }
 
@@ -518,8 +518,8 @@ void client_drop (Cerver *cerver, Client *client) {
 // returns 0 on success, 1 on error
 u8 client_connection_add (Client *client, Connection *connection) {
 
-    return (client && connection) ?
-        (u8) dlist_insert_after (client->connections, dlist_end (client->connections), connection) : 1;
+	return (client && connection) ?
+		(u8) dlist_insert_after (client->connections, dlist_end (client->connections), connection) : 1;
 
 }
 
@@ -527,11 +527,11 @@ u8 client_connection_add (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 client_connection_remove (Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client && connection) retval = dlist_remove (client->connections, connection, NULL) ? 0 : 1;
+	if (client && connection) retval = dlist_remove (client->connections, connection, NULL) ? 0 : 1;
 
-    return retval;
+	return retval;
 
 }
 
@@ -540,17 +540,17 @@ u8 client_connection_remove (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 client_connection_drop (Cerver *cerver, Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client && connection) {
-        if (dlist_remove (client->connections, connection, NULL)) {
-            connection_drop (cerver, connection);
+	if (cerver && client && connection) {
+		if (dlist_remove (client->connections, connection, NULL)) {
+			connection_drop (cerver, connection);
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -560,110 +560,110 @@ u8 client_connection_drop (Cerver *cerver, Client *client, Connection *connectio
 // returns 0 on success, 1 on error
 u8 client_remove_connection_by_sock_fd (Cerver *cerver, Client *client, i32 sock_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        Connection *connection = NULL;
-        switch (client->connections->size) {
-            case 0: {
-                #ifdef CLIENT_DEBUG
-                cerver_log (
-                    LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                    "client_remove_connection_by_sock_fd () - Client <%ld> does not have ANY connection - removing him from cerver...",
-                    client->id
-                );
-                #endif
+	if (cerver && client) {
+		Connection *connection = NULL;
+		switch (client->connections->size) {
+			case 0: {
+				#ifdef CLIENT_DEBUG
+				cerver_log (
+					LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+					"client_remove_connection_by_sock_fd () - Client <%ld> does not have ANY connection - removing him from cerver...",
+					client->id
+				);
+				#endif
 
-                client_remove_from_cerver (cerver, client);
-                client_delete (client);
-            } break;
+				client_remove_from_cerver (cerver, client);
+				client_delete (client);
+			} break;
 
-            case 1: {
-                #ifdef CLIENT_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                    "client_remove_connection_by_sock_fd () - Client <%d> has only 1 connection left!",
-                    client->id
-                );
-                #endif
+			case 1: {
+				#ifdef CLIENT_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+					"client_remove_connection_by_sock_fd () - Client <%d> has only 1 connection left!",
+					client->id
+				);
+				#endif
 
-                connection = (Connection *) client->connections->start->data;
+				connection = (Connection *) client->connections->start->data;
 
-                // remove the connection from cerver structures & poll array
-                connection_remove_from_cerver (cerver, connection);
+				// remove the connection from cerver structures & poll array
+				connection_remove_from_cerver (cerver, connection);
 
-                // remove, close & delete the connection
-                if (!client_connection_drop (
-                    cerver,
-                    client,
-                    connection
-                )) {
-                    cerver_event_trigger (
-                        CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
-                        cerver,
-                        NULL, NULL
-                    );
+				// remove, close & delete the connection
+				if (!client_connection_drop (
+					cerver,
+					client,
+					connection
+				)) {
+					cerver_event_trigger (
+						CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
+						cerver,
+						NULL, NULL
+					);
 
-                    // no connections left in client, just remove and delete
-                    client_remove_from_cerver (cerver, client);
-                    client_delete (client);
+					// no connections left in client, just remove and delete
+					client_remove_from_cerver (cerver, client);
+					client_delete (client);
 
-                    cerver_event_trigger (
-                        CERVER_EVENT_CLIENT_DROPPED,
-                        cerver,
-                        NULL, NULL
-                    );
+					cerver_event_trigger (
+						CERVER_EVENT_CLIENT_DROPPED,
+						cerver,
+						NULL, NULL
+					);
 
-                    retval = 0;
-                }
-            } break;
+					retval = 0;
+				}
+			} break;
 
-            default: {
-                #ifdef CLIENT_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                    "client_remove_connection_by_sock_fd () - Client <%d> has %ld connections left!",
-                    client->id, dlist_size (client->connections)
-                );
-                #endif
+			default: {
+				#ifdef CLIENT_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+					"client_remove_connection_by_sock_fd () - Client <%d> has %ld connections left!",
+					client->id, dlist_size (client->connections)
+				);
+				#endif
 
-                // search the connection in the client
-                connection = connection_get_by_sock_fd_from_client (client, sock_fd);
-                if (connection) {
-                    // remove the connection from cerver structures & poll array
-                    connection_remove_from_cerver (cerver, connection);
+				// search the connection in the client
+				connection = connection_get_by_sock_fd_from_client (client, sock_fd);
+				if (connection) {
+					// remove the connection from cerver structures & poll array
+					connection_remove_from_cerver (cerver, connection);
 
-                    if (!client_connection_drop (
-                        cerver,
-                        client,
-                        connection
-                    )) {
-                        cerver_event_trigger (
-                            CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
-                            cerver,
-                            NULL, NULL
-                        );
+					if (!client_connection_drop (
+						cerver,
+						client,
+						connection
+					)) {
+						cerver_event_trigger (
+							CERVER_EVENT_CLIENT_CLOSE_CONNECTION,
+							cerver,
+							NULL, NULL
+						);
 
-                        retval = 0;
-                    }
-                }
+						retval = 0;
+					}
+				}
 
-                else {
-                    // the connection may not belong to this client
-                    #ifdef CLIENT_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                        "client_remove_connection_by_sock_fd () - Client with id "
-                        "%ld does not have a connection related to sock fd %d",
-                        client->id, sock_fd
-                    );
-                    #endif
-                }
-            } break;
-        }
-    }
+				else {
+					// the connection may not belong to this client
+					#ifdef CLIENT_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+						"client_remove_connection_by_sock_fd () - Client with id "
+						"%ld does not have a connection related to sock fd %d",
+						client->id, sock_fd
+					);
+					#endif
+				}
+			} break;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -671,35 +671,35 @@ u8 client_remove_connection_by_sock_fd (Cerver *cerver, Client *client, i32 sock
 // returns 0 on success registering at least one, 1 if all connections failed
 u8 client_register_connections_to_cerver (Cerver *cerver, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        u8 n_failed = 0;          // n connections that failed to be registered
+	if (cerver && client) {
+		u8 n_failed = 0;          // n connections that failed to be registered
 
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            if (connection_register_to_cerver (cerver, client, connection))
-                n_failed++;
-        }
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			if (connection_register_to_cerver (cerver, client, connection))
+				n_failed++;
+		}
 
-         // check how many connections have failed
-        if (n_failed == client->connections->size) {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Failed to register all the connections for client %ld (id) to cerver %s",
-                client->id, cerver->info->name->str
-            );
-            #endif
+		 // check how many connections have failed
+		if (n_failed == client->connections->size) {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Failed to register all the connections for client %ld (id) to cerver %s",
+				client->id, cerver->info->name->str
+			);
+			#endif
 
-            client_drop (cerver, client);       // drop the client ---> no active connections
-        }
+			client_drop (cerver, client);       // drop the client ---> no active connections
+		}
 
-        else retval = 0;        // at least one connection is active
-    }
+		else retval = 0;        // at least one connection is active
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -707,35 +707,35 @@ u8 client_register_connections_to_cerver (Cerver *cerver, Client *client) {
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
 u8 client_unregister_connections_from_cerver (Cerver *cerver, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        u8 n_failed = 0;        // n connections that failed to unregister
+	if (cerver && client) {
+		u8 n_failed = 0;        // n connections that failed to unregister
 
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            if (connection_unregister_from_cerver (cerver, connection))
-                n_failed++;
-        }
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			if (connection_unregister_from_cerver (cerver, connection))
+				n_failed++;
+		}
 
-        // check how many connections have failed
-        if ((n_failed > 0) && (n_failed == client->connections->size)) {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Failed to unregister all the connections for client %ld (id) from cerver %s",
-                client->id, cerver->info->name->str
-            );
-            #endif
+		// check how many connections have failed
+		if ((n_failed > 0) && (n_failed == client->connections->size)) {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Failed to unregister all the connections for client %ld (id) from cerver %s",
+				client->id, cerver->info->name->str
+			);
+			#endif
 
-            // client_drop (cerver, client);       // drop the client ---> no active connections
-        }
+			// client_drop (cerver, client);       // drop the client ---> no active connections
+		}
 
-        else retval = 0;        // at least one connection is active
-    }
+		else retval = 0;        // at least one connection is active
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -743,36 +743,36 @@ u8 client_unregister_connections_from_cerver (Cerver *cerver, Client *client) {
 // returns 0 on success registering at least one, 1 if all connections failed
 u8 client_register_connections_to_cerver_poll (Cerver *cerver, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        u8 n_failed = 0;          // n connections that failed to be registered
+	if (cerver && client) {
+		u8 n_failed = 0;          // n connections that failed to be registered
 
-        // register all the client connections to the cerver poll
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            if (connection_register_to_cerver_poll (cerver, connection))
-                n_failed++;
-        }
+		// register all the client connections to the cerver poll
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			if (connection_register_to_cerver_poll (cerver, connection))
+				n_failed++;
+		}
 
-        // check how many connections have failed
-        if (n_failed == client->connections->size) {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Failed to register all the connections for client %ld (id) to cerver %s poll",
-                client->id, cerver->info->name->str
-            );
-            #endif
+		// check how many connections have failed
+		if (n_failed == client->connections->size) {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Failed to register all the connections for client %ld (id) to cerver %s poll",
+				client->id, cerver->info->name->str
+			);
+			#endif
 
-            client_drop (cerver, client);       // drop the client ---> no active connections
-        }
+			client_drop (cerver, client);       // drop the client ---> no active connections
+		}
 
-        else retval = 0;        // at least one connection is active
-    }
+		else retval = 0;        // at least one connection is active
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -780,36 +780,36 @@ u8 client_register_connections_to_cerver_poll (Cerver *cerver, Client *client) {
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
 u8 client_unregister_connections_from_cerver_poll (Cerver *cerver, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        u8 n_failed = 0;        // n connections that failed to unregister
+	if (cerver && client) {
+		u8 n_failed = 0;        // n connections that failed to unregister
 
-        // unregister all the client connections from the cerver poll
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            if (connection_unregister_from_cerver_poll (cerver, connection))
-                n_failed++;
-        }
+		// unregister all the client connections from the cerver poll
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			if (connection_unregister_from_cerver_poll (cerver, connection))
+				n_failed++;
+		}
 
-        // check how many connections have failed
-        if (n_failed == client->connections->size) {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Failed to unregister all the connections for client %ld (id) from cerver %s poll",
-                client->id, cerver->info->name->str
-            );
-            #endif
+		// check how many connections have failed
+		if (n_failed == client->connections->size) {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Failed to unregister all the connections for client %ld (id) from cerver %s poll",
+				client->id, cerver->info->name->str
+			);
+			#endif
 
-            client_drop (cerver, client);       // drop the client ---> no active connections
-        }
+			client_drop (cerver, client);       // drop the client ---> no active connections
+		}
 
-        else retval = 0;        // at least one connection is active
-    }
+		else retval = 0;        // at least one connection is active
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -817,66 +817,66 @@ u8 client_unregister_connections_from_cerver_poll (Cerver *cerver, Client *clien
 // removes the client from cerver data structures, not taking into account its connections
 Client *client_remove_from_cerver (Cerver *cerver, Client *client) {
 
-    Client *retval = NULL;
+	Client *retval = NULL;
 
-    if (cerver && client) {
-        void *client_data = avl_remove_node (cerver->clients, client);
-        if (client_data) {
-            retval = (Client *) client_data;
+	if (cerver && client) {
+		void *client_data = avl_remove_node (cerver->clients, client);
+		if (client_data) {
+			retval = (Client *) client_data;
 
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-                "Unregistered a client from cerver %s.", cerver->info->name->str
-            );
-            #endif
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+				"Unregistered a client from cerver %s.", cerver->info->name->str
+			);
+			#endif
 
-            cerver->stats->current_n_connected_clients--;
-            #ifdef CERVER_STATS
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-                "Connected clients to cerver %s: %i.",
-                cerver->info->name->str, cerver->stats->current_n_connected_clients
-            );
-            #endif
-        }
+			cerver->stats->current_n_connected_clients--;
+			#ifdef CERVER_STATS
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Connected clients to cerver %s: %i.",
+				cerver->info->name->str, cerver->stats->current_n_connected_clients
+			);
+			#endif
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Received NULL ptr when attempting to remove a client from cerver's %s client tree.",
-                cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Received NULL ptr when attempting to remove a client from cerver's %s client tree.",
+				cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void client_register_to_cerver_internal (Cerver *cerver, Client *client) {
 
-    (void) avl_insert_node (cerver->clients, client);
+	(void) avl_insert_node (cerver->clients, client);
 
-    #ifdef CLIENT_DEBUG
-    cerver_log (
-        LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-        "Registered a new client to cerver %s.", cerver->info->name->str
-    );
-    #endif
+	#ifdef CLIENT_DEBUG
+	cerver_log (
+		LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+		"Registered a new client to cerver %s.", cerver->info->name->str
+	);
+	#endif
 
-    cerver->stats->total_n_clients++;
-    cerver->stats->current_n_connected_clients++;
+	cerver->stats->total_n_clients++;
+	cerver->stats->current_n_connected_clients++;
 
-    #ifdef CERVER_STATS
-    cerver_log (
-        LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-        "Connected clients to cerver %s: %i.",
-        cerver->info->name->str, cerver->stats->current_n_connected_clients
-    );
-    #endif
+	#ifdef CERVER_STATS
+	cerver_log (
+		LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+		"Connected clients to cerver %s: %i.",
+		cerver->info->name->str, cerver->stats->current_n_connected_clients
+	);
+	#endif
 
 }
 
@@ -885,79 +885,79 @@ static void client_register_to_cerver_internal (Cerver *cerver, Client *client) 
 // returns 0 on success, 1 on error
 u8 client_register_to_cerver (Cerver *cerver, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client) {
-        if (!client_register_connections_to_cerver (cerver, client)) {
-            switch (cerver->handler_type) {
-                case CERVER_HANDLER_TYPE_NONE: break;
+	if (cerver && client) {
+		if (!client_register_connections_to_cerver (cerver, client)) {
+			switch (cerver->handler_type) {
+				case CERVER_HANDLER_TYPE_NONE: break;
 
-                case CERVER_HANDLER_TYPE_POLL: {
-                    if (!client_register_connections_to_cerver_poll (cerver, client)) {
-                        client_register_to_cerver_internal (cerver, client);
+				case CERVER_HANDLER_TYPE_POLL: {
+					if (!client_register_connections_to_cerver_poll (cerver, client)) {
+						client_register_to_cerver_internal (cerver, client);
 
-                        retval = 0;
-                    }
-                } break;
+						retval = 0;
+					}
+				} break;
 
-                case CERVER_HANDLER_TYPE_THREADS: {
-                    client_register_to_cerver_internal (cerver, client);
+				case CERVER_HANDLER_TYPE_THREADS: {
+					client_register_to_cerver_internal (cerver, client);
 
-                    retval = 0;
-                } break;
+					retval = 0;
+				} break;
 
-                default: break;
-            }
-        }
-    }
+				default: break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // unregisters a client from a cerver -- removes it from cerver's structures
 Client *client_unregister_from_cerver (Cerver *cerver, Client *client) {
 
-    Client *retval = NULL;
+	Client *retval = NULL;
 
-    if (cerver && client) {
-        if (client->connections->size > 0) {
-            // unregister the connections from the cerver
-            client_unregister_connections_from_cerver (cerver, client);
+	if (cerver && client) {
+		if (client->connections->size > 0) {
+			// unregister the connections from the cerver
+			client_unregister_connections_from_cerver (cerver, client);
 
-            // unregister all the client connections from the cerver
-            // client_unregister_connections_from_cerver (cerver, client);
-            Connection *connection = NULL;
-            for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-                connection = (Connection *) le->data;
-                connection_unregister_from_cerver_poll (cerver, connection);
-            }
-        }
+			// unregister all the client connections from the cerver
+			// client_unregister_connections_from_cerver (cerver, client);
+			Connection *connection = NULL;
+			for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+				connection = (Connection *) le->data;
+				connection_unregister_from_cerver_poll (cerver, connection);
+			}
+		}
 
-        // remove the client from the cerver's clients
-        retval = client_remove_from_cerver (cerver, client);
-    }
+		// remove the client from the cerver's clients
+		retval = client_remove_from_cerver (cerver, client);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets the client associated with a sock fd using the client-sock fd map
 Client *client_get_by_sock_fd (Cerver *cerver, i32 sock_fd) {
 
-    Client *client = NULL;
+	Client *client = NULL;
 
-    if (cerver) {
-        const i32 *key = &sock_fd;
-        void *client_data = htab_get (
-            cerver->client_sock_fd_map,
-            key, sizeof (i32)
-        );
+	if (cerver) {
+		const i32 *key = &sock_fd;
+		void *client_data = htab_get (
+			cerver->client_sock_fd_map,
+			key, sizeof (i32)
+		);
 
-        if (client_data) client = (Client *) client_data;
-    }
+		if (client_data) client = (Client *) client_data;
+	}
 
-    return client;
+	return client;
 
 }
 
@@ -965,50 +965,50 @@ Client *client_get_by_sock_fd (Cerver *cerver, i32 sock_fd) {
 // the cerver must support sessions
 Client *client_get_by_session_id (Cerver *cerver, const char *session_id) {
 
-    Client *client = NULL;
+	Client *client = NULL;
 
-    if (session_id) {
-        // create our search query
-        Client *client_query = client_new ();
-        if (client_query) {
-            client_set_session_id (client_query, session_id);
+	if (session_id) {
+		// create our search query
+		Client *client_query = client_new ();
+		if (client_query) {
+			client_set_session_id (client_query, session_id);
 
-            void *data = avl_get_node_data_safe (cerver->clients, client_query, NULL);
-            if (data) client = (Client *) data;     // found
+			void *data = avl_get_node_data_safe (cerver->clients, client_query, NULL);
+			if (data) client = (Client *) data;     // found
 
-            client_delete (client_query);
-        }
-    }
+			client_delete (client_query);
+		}
+	}
 
-    return client;
+	return client;
 
 }
 
 // broadcast a packet to all clients inside an avl structure
 void client_broadcast_to_all_avl (
-    AVLNode *node,
-    Cerver *cerver,
-    Packet *packet
+	AVLNode *node,
+	Cerver *cerver,
+	Packet *packet
 ) {
 
-    if (node && cerver && packet) {
-        client_broadcast_to_all_avl (node->right, cerver, packet);
+	if (node && cerver && packet) {
+		client_broadcast_to_all_avl (node->right, cerver, packet);
 
-        // send the packet to current client
-        if (node->id) {
-            Client *client = (Client *) node->id;
+		// send the packet to current client
+		if (node->id) {
+			Client *client = (Client *) node->id;
 
-            // send the packet to all of its active connections
-            Connection *connection = NULL;
-            for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-                connection = (Connection *) le->data;
-                packet_set_network_values (packet, cerver, client, connection, NULL);
-                packet_send (packet, 0, NULL, false);
-            }
-        }
+			// send the packet to all of its active connections
+			Connection *connection = NULL;
+			for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+				connection = (Connection *) le->data;
+				packet_set_network_values (packet, cerver, client, connection, NULL);
+				packet_send (packet, 0, NULL, false);
+			}
+		}
 
-        client_broadcast_to_all_avl (node->left, cerver, packet);
-    }
+		client_broadcast_to_all_avl (node->left, cerver, packet);
+	}
 
 }
 
@@ -1021,100 +1021,100 @@ u8 client_event_unregister (Client *client, ClientEventType event_type);
 // get the description for the current event type
 const char *client_event_type_description (ClientEventType type) {
 
-    switch (type) {
-        #define XX(num, name, description) case CLIENT_EVENT_##name: return #description;
-        CLIENT_EVENT_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, description) case CLIENT_EVENT_##name: return #description;
+		CLIENT_EVENT_MAP(XX)
+		#undef XX
+	}
 
-    return client_event_type_description (CLIENT_EVENT_UNKNOWN);
+	return client_event_type_description (CLIENT_EVENT_UNKNOWN);
 
 }
 
 static ClientEventData *client_event_data_new (void) {
 
-    ClientEventData *event_data = (ClientEventData *) malloc (sizeof (ClientEventData));
-    if (event_data) {
-        event_data->client = NULL;
-        event_data->connection = NULL;
+	ClientEventData *event_data = (ClientEventData *) malloc (sizeof (ClientEventData));
+	if (event_data) {
+		event_data->client = NULL;
+		event_data->connection = NULL;
 
-        event_data->response_data = NULL;
-        event_data->delete_response_data = NULL;
+		event_data->response_data = NULL;
+		event_data->delete_response_data = NULL;
 
-        event_data->action_args = NULL;
-        event_data->delete_action_args = NULL;
-    }
+		event_data->action_args = NULL;
+		event_data->delete_action_args = NULL;
+	}
 
-    return event_data;
+	return event_data;
 
 }
 
 void client_event_data_delete (ClientEventData *event_data) {
 
-    if (event_data) free (event_data);
+	if (event_data) free (event_data);
 
 }
 
 static ClientEventData *client_event_data_create (
-    const Client *client, const Connection *connection,
-    ClientEvent *event
+	const Client *client, const Connection *connection,
+	ClientEvent *event
 ) {
 
-    ClientEventData *event_data = client_event_data_new ();
-    if (event_data) {
-        event_data->client = client;
-        event_data->connection = connection;
+	ClientEventData *event_data = client_event_data_new ();
+	if (event_data) {
+		event_data->client = client;
+		event_data->connection = connection;
 
-        event_data->response_data = event->response_data;
-        event_data->delete_response_data = event->delete_response_data;
+		event_data->response_data = event->response_data;
+		event_data->delete_response_data = event->delete_response_data;
 
-        event_data->action_args = event->action_args;
-        event_data->delete_action_args = event->delete_action_args;
-    }
+		event_data->action_args = event->action_args;
+		event_data->delete_action_args = event->delete_action_args;
+	}
 
-    return event_data;
+	return event_data;
 
 }
 
 static ClientEvent *client_event_new (void) {
 
-    ClientEvent *event = (ClientEvent *) malloc (sizeof (ClientEvent));
-    if (event) {
-        event->type = CLIENT_EVENT_NONE;
+	ClientEvent *event = (ClientEvent *) malloc (sizeof (ClientEvent));
+	if (event) {
+		event->type = CLIENT_EVENT_NONE;
 
-        event->create_thread = false;
-        event->drop_after_trigger = false;
+		event->create_thread = false;
+		event->drop_after_trigger = false;
 
-        event->request_type = 0;
-        event->response_data = NULL;
-        event->delete_response_data = NULL;
+		event->request_type = 0;
+		event->response_data = NULL;
+		event->delete_response_data = NULL;
 
-        event->action = NULL;
-        event->action_args = NULL;
-        event->delete_action_args = NULL;
-    }
+		event->action = NULL;
+		event->action_args = NULL;
+		event->delete_action_args = NULL;
+	}
 
-    return event;
+	return event;
 
 }
 
 static void client_event_delete (void *ptr) {
 
-    if (ptr) {
-        ClientEvent *event = (ClientEvent *) ptr;
+	if (ptr) {
+		ClientEvent *event = (ClientEvent *) ptr;
 
-        if (event->response_data) {
-            if (event->delete_response_data)
-                event->delete_response_data (event->response_data);
-        }
+		if (event->response_data) {
+			if (event->delete_response_data)
+				event->delete_response_data (event->response_data);
+		}
 
-        if (event->action_args) {
-            if (event->delete_action_args)
-                event->delete_action_args (event->action_args);
-        }
+		if (event->action_args) {
+			if (event->delete_action_args)
+				event->delete_action_args (event->action_args);
+		}
 
-        free (event);
-    }
+		free (event);
+	}
 
 }
 
@@ -1124,36 +1124,36 @@ static void client_event_delete (void *ptr) {
 // that should be free using the client_event_data_delete () method
 // returns 0 on success, 1 on error
 u8 client_event_register (
-    Client *client,
-    const ClientEventType event_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	Client *client,
+	const ClientEventType event_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        ClientEvent *event = client_event_new ();
-        if (event) {
-            event->type = event_type;
+	if (client) {
+		ClientEvent *event = client_event_new ();
+		if (event) {
+			event->type = event_type;
 
-            event->create_thread = create_thread;
-            event->drop_after_trigger = drop_after_trigger;
+			event->create_thread = create_thread;
+			event->drop_after_trigger = drop_after_trigger;
 
-            event->action = action;
-            event->action_args = action_args;
-            event->delete_action_args = delete_action_args;
+			event->action = action;
+			event->action_args = action_args;
+			event->delete_action_args = delete_action_args;
 
-            // search if there is an action already registred for that event and remove it
-            (void) client_event_unregister (client, event_type);
+			// search if there is an action already registred for that event and remove it
+			(void) client_event_unregister (client, event_type);
 
-            client->events[event_type] = event;
+			client->events[event_type] = event;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1162,73 +1162,73 @@ u8 client_event_register (
 // returns 0 on success, 1 on error or if event is NOT registered
 u8 client_event_unregister (Client *client, const ClientEventType event_type) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        if (client->events[event_type]) {
-            client_event_delete (client->events[event_type]);
-            client->events[event_type] = NULL;
+	if (client) {
+		if (client->events[event_type]) {
+			client_event_delete (client->events[event_type]);
+			client->events[event_type] = NULL;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 void client_event_set_response (
-    Client *client,
-    const ClientEventType event_type,
-    void *response_data, Action delete_response_data
+	Client *client,
+	const ClientEventType event_type,
+	void *response_data, Action delete_response_data
 ) {
 
-    if (client) {
-        ClientEvent *event = client->events[event_type];
-        if (event) {
-            event->response_data = response_data;
-            event->delete_response_data = delete_response_data;
-        }
-    }
+	if (client) {
+		ClientEvent *event = client->events[event_type];
+		if (event) {
+			event->response_data = response_data;
+			event->delete_response_data = delete_response_data;
+		}
+	}
 
 }
 
 // triggers all the actions that are registred to an event
 void client_event_trigger (
-    const ClientEventType event_type,
-    const Client *client, const Connection *connection
+	const ClientEventType event_type,
+	const Client *client, const Connection *connection
 ) {
 
-    if (client) {
-        ClientEvent *event = client->events[event_type];
-        if (event) {
-            // trigger the action
-            if (event->action) {
-                if (event->create_thread) {
-                    pthread_t thread_id = 0;
-                    thread_create_detachable (
-                        &thread_id,
-                        (void *(*)(void *)) event->action,
-                        client_event_data_create (
-                            client, connection,
-                            event
-                        )
-                    );
-                }
+	if (client) {
+		ClientEvent *event = client->events[event_type];
+		if (event) {
+			// trigger the action
+			if (event->action) {
+				if (event->create_thread) {
+					pthread_t thread_id = 0;
+					thread_create_detachable (
+						&thread_id,
+						(void *(*)(void *)) event->action,
+						client_event_data_create (
+							client, connection,
+							event
+						)
+					);
+				}
 
-                else {
-                    event->action (client_event_data_create (
-                        client, connection,
-                        event
-                    ));
-                }
+				else {
+					event->action (client_event_data_create (
+						client, connection,
+						event
+					));
+				}
 
-                if (event->drop_after_trigger) {
-                    (void) client_event_unregister ((Client *) client, event_type);
-                }
-            }
-        }
-    }
+				if (event->drop_after_trigger) {
+					(void) client_event_unregister ((Client *) client, event_type);
+				}
+			}
+		}
+	}
 
 }
 
@@ -1241,92 +1241,92 @@ u8 client_error_unregister (Client *client, const ClientErrorType error_type);
 // get the description for the current error type
 const char *client_error_type_description (ClientErrorType type) {
 
-    switch (type) {
-        #define XX(num, name, description) case CLIENT_ERROR_##name: return #description;
-        CLIENT_ERROR_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, description) case CLIENT_ERROR_##name: return #description;
+		CLIENT_ERROR_MAP(XX)
+		#undef XX
+	}
 
-    return client_error_type_description (CLIENT_ERROR_UNKNOWN);
+	return client_error_type_description (CLIENT_ERROR_UNKNOWN);
 
 }
 
 static ClientErrorData *client_error_data_new (void) {
 
-    ClientErrorData *error_data = (ClientErrorData *) malloc (sizeof (ClientErrorData));
-    if (error_data) {
-        error_data->client = NULL;
-        error_data->connection = NULL;
+	ClientErrorData *error_data = (ClientErrorData *) malloc (sizeof (ClientErrorData));
+	if (error_data) {
+		error_data->client = NULL;
+		error_data->connection = NULL;
 
-        error_data->action_args = NULL;
+		error_data->action_args = NULL;
 
-        error_data->error_message = NULL;
-    }
+		error_data->error_message = NULL;
+	}
 
-    return error_data;
+	return error_data;
 
 }
 
 void client_error_data_delete (ClientErrorData *error_data) {
 
-    if (error_data) {
-        str_delete (error_data->error_message);
+	if (error_data) {
+		str_delete (error_data->error_message);
 
-        free (error_data);
-    }
+		free (error_data);
+	}
 
 }
 
 static ClientErrorData *client_error_data_create (
-    const Client *client, const Connection *connection,
-    void *args,
-    const char *error_message
+	const Client *client, const Connection *connection,
+	void *args,
+	const char *error_message
 ) {
 
-    ClientErrorData *error_data = client_error_data_new ();
-    if (error_data) {
-        error_data->client = client;
-        error_data->connection = connection;
+	ClientErrorData *error_data = client_error_data_new ();
+	if (error_data) {
+		error_data->client = client;
+		error_data->connection = connection;
 
-        error_data->action_args = args;
+		error_data->action_args = args;
 
-        error_data->error_message = error_message ? str_new (error_message) : NULL;
-    }
+		error_data->error_message = error_message ? str_new (error_message) : NULL;
+	}
 
-    return error_data;
+	return error_data;
 
 }
 
 static ClientError *client_error_new (void) {
 
-    ClientError *client_error = (ClientError *) malloc (sizeof (ClientError));
-    if (client_error) {
-        client_error->type = CLIENT_ERROR_NONE;
+	ClientError *client_error = (ClientError *) malloc (sizeof (ClientError));
+	if (client_error) {
+		client_error->type = CLIENT_ERROR_NONE;
 
-        client_error->create_thread = false;
-        client_error->drop_after_trigger = false;
+		client_error->create_thread = false;
+		client_error->drop_after_trigger = false;
 
-        client_error->action = NULL;
-        client_error->action_args = NULL;
-        client_error->delete_action_args = NULL;
-    }
+		client_error->action = NULL;
+		client_error->action_args = NULL;
+		client_error->delete_action_args = NULL;
+	}
 
-    return client_error;
+	return client_error;
 
 }
 
 static void client_error_delete (void *client_error_ptr) {
 
-    if (client_error_ptr) {
-        ClientError *client_error = (ClientError *) client_error_ptr;
+	if (client_error_ptr) {
+		ClientError *client_error = (ClientError *) client_error_ptr;
 
-        if (client_error->action_args) {
-            if (client_error->delete_action_args)
-                client_error->delete_action_args (client_error->action_args);
-        }
+		if (client_error->action_args) {
+			if (client_error->delete_action_args)
+				client_error->delete_action_args (client_error->action_args);
+		}
 
-        free (client_error_ptr);
-    }
+		free (client_error_ptr);
+	}
 
 }
 
@@ -1336,36 +1336,36 @@ static void client_error_delete (void *client_error_ptr) {
 // that should be free using the client_error_data_delete () method
 // returns 0 on success, 1 on error
 u8 client_error_register (
-    Client *client,
-    const ClientErrorType error_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	Client *client,
+	const ClientErrorType error_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        ClientError *error = client_error_new ();
-        if (error) {
-            error->type = error_type;
+	if (client) {
+		ClientError *error = client_error_new ();
+		if (error) {
+			error->type = error_type;
 
-            error->create_thread = create_thread;
-            error->drop_after_trigger = drop_after_trigger;
+			error->create_thread = create_thread;
+			error->drop_after_trigger = drop_after_trigger;
 
-            error->action = action;
-            error->action_args = action_args;
-            error->delete_action_args = delete_action_args;
+			error->action = action;
+			error->action_args = action_args;
+			error->delete_action_args = delete_action_args;
 
-            // search if there is an action already registred for that error and remove it
-            (void) client_error_unregister (client, error_type);
+			// search if there is an action already registred for that error and remove it
+			(void) client_error_unregister (client, error_type);
 
-            client->errors[error_type] = error;
+			client->errors[error_type] = error;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1374,181 +1374,181 @@ u8 client_error_register (
 // returns 0 on success, 1 on error or if error is NOT registered
 u8 client_error_unregister (Client *client, const ClientErrorType error_type) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        if (client->errors[error_type]) {
-            client_error_delete (client->errors[error_type]);
-            client->errors[error_type] = NULL;
+	if (client) {
+		if (client->errors[error_type]) {
+			client_error_delete (client->errors[error_type]);
+			client->errors[error_type] = NULL;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // triggers all the actions that are registred to an error
 // returns 0 on success, 1 on error
 u8 client_error_trigger (
-    const ClientErrorType error_type,
-    const Client *client, const Connection *connection,
-    const char *error_message
+	const ClientErrorType error_type,
+	const Client *client, const Connection *connection,
+	const char *error_message
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        ClientError *error = client->errors[error_type];
-        if (error) {
-            // trigger the action
-            if (error->action) {
-                if (error->create_thread) {
-                    pthread_t thread_id = 0;
-                    retval = thread_create_detachable (
-                        &thread_id,
-                        (void *(*)(void *)) error->action,
-                        client_error_data_create (
-                            client, connection,
-                            error,
-                            error_message
-                        )
-                    );
-                }
+	if (client) {
+		ClientError *error = client->errors[error_type];
+		if (error) {
+			// trigger the action
+			if (error->action) {
+				if (error->create_thread) {
+					pthread_t thread_id = 0;
+					retval = thread_create_detachable (
+						&thread_id,
+						(void *(*)(void *)) error->action,
+						client_error_data_create (
+							client, connection,
+							error,
+							error_message
+						)
+					);
+				}
 
-                else {
-                    error->action (client_error_data_create (
-                        client, connection,
-                        error,
-                        error_message
-                    ));
+				else {
+					error->action (client_error_data_create (
+						client, connection,
+						error,
+						error_message
+					));
 
-                    retval = 0;
-                }
+					retval = 0;
+				}
 
-                if (error->drop_after_trigger) {
-                    (void) client_error_unregister ((Client *) client, error_type);
-                }
-            }
-        }
-    }
+				if (error->drop_after_trigger) {
+					(void) client_error_unregister ((Client *) client, error_type);
+				}
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // handles error packets
 static void client_error_packet_handler (Packet *packet) {
 
-    if (packet->data_size >= sizeof (SError)) {
-        char *end = (char *) packet->data;
-        SError *s_error = (SError *) end;
+	if (packet->data_size >= sizeof (SError)) {
+		char *end = (char *) packet->data;
+		SError *s_error = (SError *) end;
 
-        switch (s_error->error_type) {
-            case CLIENT_ERROR_NONE: break;
+		switch (s_error->error_type) {
+			case CLIENT_ERROR_NONE: break;
 
-            case CLIENT_ERROR_CERVER_ERROR:
-                client_error_trigger (
-                    CLIENT_ERROR_CERVER_ERROR,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_PACKET_ERROR:
-                client_error_trigger (
-                    CLIENT_ERROR_PACKET_ERROR,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CLIENT_ERROR_CERVER_ERROR:
+				client_error_trigger (
+					CLIENT_ERROR_CERVER_ERROR,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_PACKET_ERROR:
+				client_error_trigger (
+					CLIENT_ERROR_PACKET_ERROR,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            case CLIENT_ERROR_FAILED_AUTH: {
-                if (client_error_trigger (
-                    CLIENT_ERROR_FAILED_AUTH,
-                    packet->client, packet->connection,
-                    s_error->msg
-                )) {
-                    // not error action is registered to handle the error
-                    cerver_log_error ("Failed to authenticate - %s", s_error->msg);
-                }
-            } break;
+			case CLIENT_ERROR_FAILED_AUTH: {
+				if (client_error_trigger (
+					CLIENT_ERROR_FAILED_AUTH,
+					packet->client, packet->connection,
+					s_error->msg
+				)) {
+					// not error action is registered to handle the error
+					cerver_log_error ("Failed to authenticate - %s", s_error->msg);
+				}
+			} break;
 
-            case CLIENT_ERROR_GET_FILE:
-                client_error_trigger (
-                    CLIENT_ERROR_GET_FILE,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_SEND_FILE:
-                client_error_trigger (
-                    CLIENT_ERROR_SEND_FILE,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_FILE_NOT_FOUND:
-                client_error_trigger (
-                    CLIENT_ERROR_FILE_NOT_FOUND,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CLIENT_ERROR_GET_FILE:
+				client_error_trigger (
+					CLIENT_ERROR_GET_FILE,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_SEND_FILE:
+				client_error_trigger (
+					CLIENT_ERROR_SEND_FILE,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_FILE_NOT_FOUND:
+				client_error_trigger (
+					CLIENT_ERROR_FILE_NOT_FOUND,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            case CLIENT_ERROR_CREATE_LOBBY:
-                client_error_trigger (
-                    CLIENT_ERROR_CREATE_LOBBY,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_JOIN_LOBBY:
-                client_error_trigger (
-                    CLIENT_ERROR_JOIN_LOBBY,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_LEAVE_LOBBY:
-                client_error_trigger (
-                    CLIENT_ERROR_LEAVE_LOBBY,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_FIND_LOBBY:
-                client_error_trigger (
-                    CLIENT_ERROR_FIND_LOBBY,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CLIENT_ERROR_CREATE_LOBBY:
+				client_error_trigger (
+					CLIENT_ERROR_CREATE_LOBBY,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_JOIN_LOBBY:
+				client_error_trigger (
+					CLIENT_ERROR_JOIN_LOBBY,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_LEAVE_LOBBY:
+				client_error_trigger (
+					CLIENT_ERROR_LEAVE_LOBBY,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_FIND_LOBBY:
+				client_error_trigger (
+					CLIENT_ERROR_FIND_LOBBY,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            case CLIENT_ERROR_GAME_INIT:
-                client_error_trigger (
-                    CLIENT_ERROR_GAME_INIT,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CLIENT_ERROR_GAME_START:
-                client_error_trigger (
-                    CLIENT_ERROR_GAME_START,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CLIENT_ERROR_GAME_INIT:
+				client_error_trigger (
+					CLIENT_ERROR_GAME_INIT,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CLIENT_ERROR_GAME_START:
+				client_error_trigger (
+					CLIENT_ERROR_GAME_START,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            default: {
-                client_error_trigger (
-                    CLIENT_ERROR_UNKNOWN,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-            } break;
-        }
-    }
+			default: {
+				client_error_trigger (
+					CLIENT_ERROR_UNKNOWN,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+			} break;
+		}
+	}
 
 }
 
@@ -1560,206 +1560,206 @@ unsigned int client_receive (Client *client, Connection *connection);
 
 static u8 client_app_handler_start (Client *client) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (client) {
-        if (client->app_packet_handler) {
-            if (!client->app_packet_handler->direct_handle) {
-                if (!handler_start (client->app_packet_handler)) {
-                    #ifdef CLIENT_DEBUG
-                    cerver_log_success (
-                        "Client %s app_packet_handler has started!",
-                        client->name->str
-                    );
-                    #endif
-                }
+	if (client) {
+		if (client->app_packet_handler) {
+			if (!client->app_packet_handler->direct_handle) {
+				if (!handler_start (client->app_packet_handler)) {
+					#ifdef CLIENT_DEBUG
+					cerver_log_success (
+						"Client %s app_packet_handler has started!",
+						client->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start client %s app_packet_handler!",
-                        client->name->str
-                    );
+				else {
+					cerver_log_error (
+						"Failed to start client %s app_packet_handler!",
+						client->name->str
+					);
 
-                    retval = 1;
-                }
-            }
-        }
+					retval = 1;
+				}
+			}
+		}
 
-        else {
-            cerver_log_warning (
-                "Client %s does not have an app_packet_handler",
-                client->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_warning (
+				"Client %s does not have an app_packet_handler",
+				client->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 client_app_error_handler_start (Client *client) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (client) {
-        if (client->app_error_packet_handler) {
-            if (!client->app_error_packet_handler->direct_handle) {
-                if (!handler_start (client->app_error_packet_handler)) {
-                    #ifdef CLIENT_DEBUG
-                    cerver_log_success (
-                        "Client %s app_error_packet_handler has started!",
-                        client->name->str
-                    );
-                    #endif
-                }
+	if (client) {
+		if (client->app_error_packet_handler) {
+			if (!client->app_error_packet_handler->direct_handle) {
+				if (!handler_start (client->app_error_packet_handler)) {
+					#ifdef CLIENT_DEBUG
+					cerver_log_success (
+						"Client %s app_error_packet_handler has started!",
+						client->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start client %s app_error_packet_handler!",
-                        client->name->str
-                    );
+				else {
+					cerver_log_error (
+						"Failed to start client %s app_error_packet_handler!",
+						client->name->str
+					);
 
-                    retval = 1;
-                }
-            }
-        }
+					retval = 1;
+				}
+			}
+		}
 
-        else {
-            cerver_log_warning (
-                "Client %s does not have an app_error_packet_handler",
-                client->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_warning (
+				"Client %s does not have an app_error_packet_handler",
+				client->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 client_custom_handler_start (Client *client) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (client) {
-        if (client->custom_packet_handler) {
-            if (!client->custom_packet_handler->direct_handle) {
-                if (!handler_start (client->custom_packet_handler)) {
-                    #ifdef CLIENT_DEBUG
-                    cerver_log_success (
-                        "Client %s custom_packet_handler has started!",
-                        client->name->str
-                    );
-                    #endif
-                }
+	if (client) {
+		if (client->custom_packet_handler) {
+			if (!client->custom_packet_handler->direct_handle) {
+				if (!handler_start (client->custom_packet_handler)) {
+					#ifdef CLIENT_DEBUG
+					cerver_log_success (
+						"Client %s custom_packet_handler has started!",
+						client->name->str
+					);
+					#endif
+				}
 
-                else {
-                    cerver_log_error (
-                        "Failed to start client %s custom_packet_handler!",
-                        client->name->str
-                    );
+				else {
+					cerver_log_error (
+						"Failed to start client %s custom_packet_handler!",
+						client->name->str
+					);
 
-                    retval = 1;
-                }
-            }
-        }
+					retval = 1;
+				}
+			}
+		}
 
-        else {
-            cerver_log_warning (
-                "Client %s does not have a custom_packet_handler",
-                client->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_warning (
+				"Client %s does not have a custom_packet_handler",
+				client->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // 16/06/2020 -- starts all client's handlers
 static u8 client_handlers_start (Client *client) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (client) {
-        #ifdef CLIENT_DEBUG
-        cerver_log_debug (
-            "Initializing %s handlers...", client->name->str
-        );
-        #endif
+	if (client) {
+		#ifdef CLIENT_DEBUG
+		cerver_log_debug (
+			"Initializing %s handlers...", client->name->str
+		);
+		#endif
 
-        client->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (client->handlers_lock, NULL);
+		client->handlers_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (client->handlers_lock, NULL);
 
-        errors |= client_app_handler_start (client);
+		errors |= client_app_handler_start (client);
 
-        errors |= client_app_error_handler_start (client);
+		errors |= client_app_error_handler_start (client);
 
-        errors |= client_custom_handler_start (client);
+		errors |= client_custom_handler_start (client);
 
-        if (!errors) {
-            #ifdef CLIENT_DEBUG
-            cerver_log_success (
-                "Done initializing client %s handlers!", client->name->str
-            );
-            #endif
-        }
-    }
+		if (!errors) {
+			#ifdef CLIENT_DEBUG
+			cerver_log_success (
+				"Done initializing client %s handlers!", client->name->str
+			);
+			#endif
+		}
+	}
 
-    return errors;
+	return errors;
 
 }
 
 static u8 client_start (Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        // check if we walready have the client poll running
-        if (!client->running) {
-            time (&client->time_started);
-            client->running = true;
+	if (client) {
+		// check if we walready have the client poll running
+		if (!client->running) {
+			time (&client->time_started);
+			client->running = true;
 
-            if (!client_handlers_start (client)) {
-                retval = 0;
-            }
+			if (!client_handlers_start (client)) {
+				retval = 0;
+			}
 
-            else {
-                client->running = false;
-            }
-        }
+			else {
+				client->running = false;
+			}
+		}
 
-        else {
-            // client is already running because of an active connection
-            retval = 0;
-        }
-    }
+		else {
+			// client is already running because of an active connection
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // creates a new connection that is ready to connect and registers it to the client
 Connection *client_connection_create (
-    Client *client,
-    const char *ip_address, u16 port,
-    Protocol protocol, bool use_ipv6
+	Client *client,
+	const char *ip_address, u16 port,
+	Protocol protocol, bool use_ipv6
 ) {
 
-    Connection *connection = NULL;
+	Connection *connection = NULL;
 
-    if (client) {
-        connection = connection_create_empty ();
-        if (connection) {
-            connection_set_values (connection, ip_address, port, protocol, use_ipv6);
-            connection_init (connection);
-            connection_register_to_client (client, connection);
+	if (client) {
+		connection = connection_create_empty ();
+		if (connection) {
+			connection_set_values (connection, ip_address, port, protocol, use_ipv6);
+			connection_init (connection);
+			connection_register_to_client (client, connection);
 
-            connection->cond = pthread_cond_new ();
-            connection->mutex = pthread_mutex_new ();
-        }
-    }
+			connection->cond = pthread_cond_new ();
+			connection->mutex = pthread_mutex_new ();
+		}
+	}
 
-    return connection;
+	return connection;
 
 }
 
@@ -1767,17 +1767,17 @@ Connection *client_connection_create (
 // retuns 0 on success, 1 on error
 int client_connection_register (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        retval =  dlist_insert_after (
-            client->connections,
-            dlist_end (client->connections),
-            connection
-        );
-    }
+	if (client && connection) {
+		retval =  dlist_insert_after (
+			client->connections,
+			dlist_end (client->connections),
+			connection
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1785,27 +1785,27 @@ int client_connection_register (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error or if the connection does not belong to the client
 int client_connection_unregister (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        if (dlist_remove (client->connections, connection, NULL)) {
-            retval = 0;
-        }
-    }
+	if (client && connection) {
+		if (dlist_remove (client->connections, connection, NULL)) {
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // performs a receive in the connection's socket to get a complete packet & handle it
 void client_connection_get_next_packet (Client *client, Connection *connection) {
 
-    if (client && connection) {
-        connection->full_packet = false;
-        while (!connection->full_packet) {
-            (void) client_receive (client, connection);
-        }
-    }
+	if (client && connection) {
+		connection->full_packet = false;
+		while (!connection->full_packet) {
+			(void) client_receive (client, connection);
+		}
+	}
 
 }
 
@@ -1820,24 +1820,24 @@ void client_connection_get_next_packet (Client *client, Connection *connection) 
 // returns 0 when the connection has been established, 1 on error or failed to connect
 unsigned int client_connect (Client *client, Connection *connection) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (client && connection) {
-        if (!connection_connect (connection)) {
-            client_event_trigger (CLIENT_EVENT_CONNECTED, client, connection);
-            // connection->connected = true;
-            connection->active = true;
-            time (&connection->connected_timestamp);
+	if (client && connection) {
+		if (!connection_connect (connection)) {
+			client_event_trigger (CLIENT_EVENT_CONNECTED, client, connection);
+			// connection->connected = true;
+			connection->active = true;
+			time (&connection->connected_timestamp);
 
-            retval = 0;     // success - connected to cerver
-        }
+			retval = 0;     // success - connected to cerver
+		}
 
-        else {
-            client_event_trigger (CLIENT_EVENT_CONNECTION_FAILED, client, connection);
-        }
-    }
+		else {
+			client_event_trigger (CLIENT_EVENT_CONNECTION_FAILED, client, connection);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1847,36 +1847,36 @@ unsigned int client_connect (Client *client, Connection *connection) {
 // returns 0 when the connection has been established, 1 on error or failed to connect
 unsigned int client_connect_to_cerver (Client *client, Connection *connection) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (!client_connect (client, connection)) {
-        client_receive (client, connection);
+	if (!client_connect (client, connection)) {
+		client_receive (client, connection);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void *client_connect_thread (void *client_connection_ptr) {
 
-    if (client_connection_ptr) {
-        ClientConnection *cc = (ClientConnection *) client_connection_ptr;
+	if (client_connection_ptr) {
+		ClientConnection *cc = (ClientConnection *) client_connection_ptr;
 
-        if (!connection_connect (cc->connection)) {
-            // client_event_trigger (cc->client, EVENT_CONNECTED);
-            // cc->connection->connected = true;
-            cc->connection->active = true;
-            time (&cc->connection->connected_timestamp);
+		if (!connection_connect (cc->connection)) {
+			// client_event_trigger (cc->client, EVENT_CONNECTED);
+			// cc->connection->connected = true;
+			cc->connection->active = true;
+			time (&cc->connection->connected_timestamp);
 
-            client_start (cc->client);
-        }
+			client_start (cc->client);
+		}
 
-        client_connection_aux_delete (cc);
-    }
+		client_connection_aux_delete (cc);
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
@@ -1888,24 +1888,24 @@ static void *client_connect_thread (void *client_connection_ptr) {
 // returns 0 on success connection thread creation, 1 on error
 unsigned int client_connect_async (Client *client, Connection *connection) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (client && connection) {
-        ClientConnection *cc = client_connection_aux_new (client, connection);
-        if (cc) {
-            if (!thread_create_detachable (&cc->connection_thread_id, client_connect_thread, cc)) {
-                retval = 0;         // success
-            }
+	if (client && connection) {
+		ClientConnection *cc = client_connection_aux_new (client, connection);
+		if (cc) {
+			if (!thread_create_detachable (&cc->connection_thread_id, client_connect_thread, cc)) {
+				retval = 0;         // success
+			}
 
-            else {
-                #ifdef CLIENT_DEBUG
-                cerver_log_error ("Failed to create client_connect_thread () detachable thread!");
-                #endif
-            }
-        }
-    }
+			else {
+				#ifdef CLIENT_DEBUG
+				cerver_log_error ("Failed to create client_connect_thread () detachable thread!");
+				#endif
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1919,37 +1919,37 @@ unsigned int client_connect_async (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 int client_connection_start (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        if (connection->active) {
-            if (!client_start (client)) {
-                if (!thread_create_detachable (
-                    &connection->update_thread_id,
-                    (void *(*)(void *)) connection_update,
-                    client_connection_aux_new (client, connection)
-                )) {
-                    retval = 0;         // success
-                }
+	if (client && connection) {
+		if (connection->active) {
+			if (!client_start (client)) {
+				if (!thread_create_detachable (
+					&connection->update_thread_id,
+					(void *(*)(void *)) connection_update,
+					client_connection_aux_new (client, connection)
+				)) {
+					retval = 0;         // success
+				}
 
-                else {
-                    cerver_log_error (
-                        "client_connection_start () - Failed to create update thread for client %s",
-                        client->name->str
-                    );
-                }
-            }
+				else {
+					cerver_log_error (
+						"client_connection_start () - Failed to create update thread for client %s",
+						client->name->str
+					);
+				}
+			}
 
-            else {
-                cerver_log_error (
-                    "client_connection_start () - Failed to start client %s",
-                    client->name->str
-                );
-            }
-        }
-    }
+			else {
+				cerver_log_error (
+					"client_connection_start () - Failed to start client %s",
+					client->name->str
+				);
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -1959,34 +1959,34 @@ int client_connection_start (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 int client_connect_and_start (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        if (!client_connect (client, connection)) {
-            if (!client_connection_start (client, connection)) {
-                retval = 0;
-            }
-        }
+	if (client && connection) {
+		if (!client_connect (client, connection)) {
+			if (!client_connection_start (client, connection)) {
+				retval = 0;
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "client_connect_and_start () - Client %s failed to connect",
-                client->name->str
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"client_connect_and_start () - Client %s failed to connect",
+				client->name->str
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void client_connection_start_wrapper (void *data_ptr) {
 
-    if (data_ptr) {
-        ClientConnection *cc = (ClientConnection *) data_ptr;
-        client_connect_and_start (cc->client, cc->connection);
-        client_connection_aux_delete (cc);
-    }
+	if (data_ptr) {
+		ClientConnection *cc = (ClientConnection *) data_ptr;
+		client_connect_and_start (cc->client, cc->connection);
+		client_connection_aux_delete (cc);
+	}
 
 }
 
@@ -1995,13 +1995,13 @@ static void client_connection_start_wrapper (void *data_ptr) {
 // returns 0 on success creating connection thread, 1 on error
 u8 client_connect_and_start_async (Client *client, Connection *connection) {
 
-    pthread_t thread_id = 0;
+	pthread_t thread_id = 0;
 
-    return (client && connection) ? thread_create_detachable (
-        &thread_id,
-        (void *(*)(void *)) client_connection_start_wrapper,
-        client_connection_aux_new (client, connection)
-    ) : 1;
+	return (client && connection) ? thread_create_detachable (
+		&thread_id,
+		(void *(*)(void *)) client_connection_start_wrapper,
+		client_connection_aux_new (client, connection)
+	) : 1;
 
 }
 
@@ -2018,47 +2018,47 @@ u8 client_connect_and_start_async (Client *client, Connection *connection) {
 // retruns 0 when the response has been handled, 1 on error
 unsigned int client_request_to_cerver (Client *client, Connection *connection, Packet *request) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (client && connection && request) {
-        // send the request to the cerver
-        packet_set_network_values (request, NULL, client, connection, NULL);
+	if (client && connection && request) {
+		// send the request to the cerver
+		packet_set_network_values (request, NULL, client, connection, NULL);
 
-        size_t sent = 0;
-        if (!packet_send (request, 0, &sent, false)) {
-            // printf ("Request to cerver: %ld\n", sent);
+		size_t sent = 0;
+		if (!packet_send (request, 0, &sent, false)) {
+			// printf ("Request to cerver: %ld\n", sent);
 
-            // receive the data directly
-            client_connection_get_next_packet (client, connection);
+			// receive the data directly
+			client_connection_get_next_packet (client, connection);
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log_error ("client_request_to_cerver () - failed to send request packet!");
-            #endif
-        }
-    }
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log_error ("client_request_to_cerver () - failed to send request packet!");
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void *client_request_to_cerver_thread (void *cc_ptr) {
 
-    if (cc_ptr) {
-        ClientConnection *cc = (ClientConnection *) cc_ptr;
+	if (cc_ptr) {
+		ClientConnection *cc = (ClientConnection *) cc_ptr;
 
-        cc->connection->full_packet = false;
-        while (!cc->connection->full_packet) {
-            client_receive (cc->client, cc->connection);
-        }
+		cc->connection->full_packet = false;
+		while (!cc->connection->full_packet) {
+			client_receive (cc->client, cc->connection);
+		}
 
-        client_connection_aux_delete (cc);
-    }
+		client_connection_aux_delete (cc);
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
@@ -2070,35 +2070,35 @@ static void *client_request_to_cerver_thread (void *cc_ptr) {
 // returns 0 on success request, 1 on error
 unsigned int client_request_to_cerver_async (Client *client, Connection *connection, Packet *request) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (client && connection && request) {
-        // send the request to the cerver
-        packet_set_network_values (request, NULL, client, connection, NULL);
-        if (!packet_send (request, 0, NULL, false)) {
-            ClientConnection *cc = client_connection_aux_new (client, connection);
-            if (cc) {
-                // create a new thread to receive & handle the response
-                if (!thread_create_detachable (&cc->connection_thread_id, client_request_to_cerver_thread, cc)) {
-                    retval = 0;         // success
-                }
+	if (client && connection && request) {
+		// send the request to the cerver
+		packet_set_network_values (request, NULL, client, connection, NULL);
+		if (!packet_send (request, 0, NULL, false)) {
+			ClientConnection *cc = client_connection_aux_new (client, connection);
+			if (cc) {
+				// create a new thread to receive & handle the response
+				if (!thread_create_detachable (&cc->connection_thread_id, client_request_to_cerver_thread, cc)) {
+					retval = 0;         // success
+				}
 
-                else {
-                    #ifdef CLIENT_DEBUG
-                    cerver_log_error ("Failed to create client_request_to_cerver_thread () detachable thread!");
-                    #endif
-                }
-            }
-        }
+				else {
+					#ifdef CLIENT_DEBUG
+					cerver_log_error ("Failed to create client_request_to_cerver_thread () detachable thread!");
+					#endif
+				}
+			}
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log_error ("client_request_to_cerver_async () - failed to send request packet!");
-            #endif
-        }
-    }
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log_error ("client_request_to_cerver_async () - failed to send request packet!");
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2107,31 +2107,31 @@ unsigned int client_request_to_cerver_async (Client *client, Connection *connect
 #pragma region files
 
 static u8 client_file_receive (
-    Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    // generate a custom filename taking into account the uploads path
-    *saved_filename = c_string_create (
-        "%s/%ld-%s",
-        client->uploads_path->str,
-        time (NULL), file_header->filename
-    );
+	// generate a custom filename taking into account the uploads path
+	*saved_filename = c_string_create (
+		"%s/%ld-%s",
+		client->uploads_path->str,
+		time (NULL), file_header->filename
+	);
 
-    if (*saved_filename) {
-        retval = file_receive_actual (
-            client, connection,
-            file_header,
-            file_data, file_data_len,
-            saved_filename
-        );
-    }
+	if (*saved_filename) {
+		retval = file_receive_actual (
+			client, connection,
+			file_header,
+			file_data, file_data_len,
+			saved_filename
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2139,26 +2139,26 @@ static u8 client_file_receive (
 // returns 0 on success, 1 on error
 u8 client_files_add_path (Client *client, const char *path) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client && path) {
-        if (client->n_paths < CLIENT_FILES_MAX_PATHS) {
-            client->paths[client->n_paths] = str_new (path);
-            client->n_paths += 1;
-        }
-    }
+	if (client && path) {
+		if (client->n_paths < CLIENT_FILES_MAX_PATHS) {
+			client->paths[client->n_paths] = str_new (path);
+			client->n_paths += 1;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sets the default uploads path to be used when receiving a file
 void client_files_set_uploads_path (Client *client, const char *uploads_path) {
 
-    if (client && uploads_path) {
-        str_delete (client->uploads_path);
-        client->uploads_path = str_new (uploads_path);
-    }
+	if (client && uploads_path) {
+		str_delete (client->uploads_path);
+		client->uploads_path = str_new (uploads_path);
+	}
 
 }
 
@@ -2166,33 +2166,33 @@ void client_files_set_uploads_path (Client *client, const char *uploads_path) {
 // in this method, file contents must be consumed from the sock fd
 // and return 0 on success and 1 on error
 void client_files_set_file_upload_handler (
-    Client *client,
-    u8 (*file_upload_handler) (
-        struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    )
+	Client *client,
+	u8 (*file_upload_handler) (
+		struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	)
 ) {
 
-    if (client) {
-        client->file_upload_handler = file_upload_handler;
-    }
+	if (client) {
+		client->file_upload_handler = file_upload_handler;
+	}
 
 }
 
 // sets a callback to be executed after a file has been successfully received
 void client_files_set_file_upload_cb (
-    Client *client,
-    void (*file_upload_cb) (
-        struct _Client *, struct _Connection *,
-        const char *saved_filename
-    )
+	Client *client,
+	void (*file_upload_cb) (
+		struct _Client *, struct _Connection *,
+		const char *saved_filename
+	)
 ) {
 
-    if (client) {
-        client->file_upload_cb = file_upload_cb;
-    }
+	if (client) {
+		client->file_upload_cb = file_upload_cb;
+	}
 
 }
 
@@ -2200,25 +2200,25 @@ void client_files_set_file_upload_cb (
 // returns the actual filename (path + directory) where it was found, NULL on error
 String *client_files_search_file (Client *client, const char *filename) {
 
-    String *retval = NULL;
+	String *retval = NULL;
 
-    if (client && filename) {
-        char filename_query[DEFAULT_FILENAME_LEN * 2] = { 0 };
-        for (unsigned int i = 0; i < client->n_paths; i++) {
-            (void) snprintf (
-                filename_query, DEFAULT_FILENAME_LEN * 2,
-                "%s/%s",
-                client->paths[i]->str, filename
-            );
+	if (client && filename) {
+		char filename_query[DEFAULT_FILENAME_LEN * 2] = { 0 };
+		for (unsigned int i = 0; i < client->n_paths; i++) {
+			(void) snprintf (
+				filename_query, DEFAULT_FILENAME_LEN * 2,
+				"%s/%s",
+				client->paths[i]->str, filename
+			);
 
-            if (file_exists (filename_query)) {
-                retval = str_new (filename_query);
-                break;
-            }
-        }
-    }
+			if (file_exists (filename_query)) {
+				retval = str_new (filename_query);
+				break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2227,38 +2227,38 @@ String *client_files_search_file (Client *client, const char *filename) {
 // returns 0 on success sending request, 1 on failed to send request
 u8 client_file_get (Client *client, Connection *connection, const char *filename) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client && connection && filename) {
-        if (client->uploads_path) {
-            Packet *packet = packet_new ();
-            if (packet) {
-                size_t packet_len = sizeof (PacketHeader) + sizeof (FileHeader);
+	if (client && connection && filename) {
+		if (client->uploads_path) {
+			Packet *packet = packet_new ();
+			if (packet) {
+				size_t packet_len = sizeof (PacketHeader) + sizeof (FileHeader);
 
-                packet->packet = malloc (packet_len);
-                packet->packet_size = packet_len;
+				packet->packet = malloc (packet_len);
+				packet->packet_size = packet_len;
 
-                char *end = (char *) packet->packet;
-                PacketHeader *header = (PacketHeader *) end;
-                header->packet_type = PACKET_TYPE_REQUEST;
-                header->packet_size = packet_len;
+				char *end = (char *) packet->packet;
+				PacketHeader *header = (PacketHeader *) end;
+				header->packet_type = PACKET_TYPE_REQUEST;
+				header->packet_size = packet_len;
 
-                header->request_type = REQUEST_PACKET_TYPE_GET_FILE;
+				header->request_type = REQUEST_PACKET_TYPE_GET_FILE;
 
-                end += sizeof (PacketHeader);
+				end += sizeof (PacketHeader);
 
-                FileHeader *file_header = (FileHeader *) end;
-                strncpy (file_header->filename, filename, DEFAULT_FILENAME_LEN);
-                file_header->len = 0;
+				FileHeader *file_header = (FileHeader *) end;
+				strncpy (file_header->filename, filename, DEFAULT_FILENAME_LEN);
+				file_header->len = 0;
 
-                packet_set_network_values (packet, NULL, client, connection, NULL);
+				packet_set_network_values (packet, NULL, client, connection, NULL);
 
-                retval = packet_send (packet, 0, NULL, false);
-            }
-        }
-    }
+				retval = packet_send (packet, 0, NULL, false);
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2266,43 +2266,43 @@ u8 client_file_get (Client *client, Connection *connection, const char *filename
 // returns 0 on success sending request, 1 on failed to send request
 u8 client_file_send (Client *client, Connection *connection, const char *filename) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client && connection && filename) {
-        char *last = strrchr (filename, '/');
-        const char *actual_filename = last ? last + 1 : NULL;
-        if (actual_filename) {
-            // try to open the file
-            struct stat filestatus = { 0 };
-            int file_fd = file_open_as_fd (filename, &filestatus, O_RDONLY);
-            if (file_fd >= 0) {
-                size_t sent = file_send_by_fd (
-                    NULL, client, connection,
-                    file_fd, actual_filename, filestatus.st_size
-                );
+	if (client && connection && filename) {
+		char *last = strrchr (filename, '/');
+		const char *actual_filename = last ? last + 1 : NULL;
+		if (actual_filename) {
+			// try to open the file
+			struct stat filestatus = { 0 };
+			int file_fd = file_open_as_fd (filename, &filestatus, O_RDONLY);
+			if (file_fd >= 0) {
+				size_t sent = file_send_by_fd (
+					NULL, client, connection,
+					file_fd, actual_filename, filestatus.st_size
+				);
 
-                client->file_stats->n_files_sent += 1;
-                client->file_stats->n_bytes_sent += sent;
+				client->file_stats->n_files_sent += 1;
+				client->file_stats->n_bytes_sent += sent;
 
-                if (sent == filestatus.st_size) retval = 0;
+				if (sent == filestatus.st_size) retval = 0;
 
-                close (file_fd);
-            }
+				close (file_fd);
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_FILE,
-                    "client_file_send () - Failed to open file %s", filename
-                );
-            }
-        }
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_FILE,
+					"client_file_send () - Failed to open file %s", filename
+				);
+			}
+		}
 
-        else {
-            cerver_log_error ("client_file_send () - failed to get actual filename");
-        }
-    }
+		else {
+			cerver_log_error ("client_file_send () - failed to get actual filename");
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2312,251 +2312,251 @@ u8 client_file_send (Client *client, Connection *connection, const char *filenam
 
 static void client_cerver_packet_handle_info (Packet *packet) {
 
-    if (packet->data && (packet->data_size > 0)) {
-        char *end = (char *) packet->data;
+	if (packet->data && (packet->data_size > 0)) {
+		char *end = (char *) packet->data;
 
-        #ifdef CLIENT_DEBUG
-        cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Received a cerver info packet.");
-        #endif
+		#ifdef CLIENT_DEBUG
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Received a cerver info packet.");
+		#endif
 
-        CerverReport *cerver_report = cerver_deserialize ((SCerver *) end);
-        if (cerver_report_check_info (cerver_report, packet->client, packet->connection))
-            cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to correctly check cerver info!");
-    }
+		CerverReport *cerver_report = cerver_deserialize ((SCerver *) end);
+		if (cerver_report_check_info (cerver_report, packet->client, packet->connection))
+			cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to correctly check cerver info!");
+	}
 
 }
 
 // handles cerver type packets
 void client_cerver_packet_handler (Packet *packet) {
 
-    switch (packet->header->request_type) {
-        case CERVER_PACKET_TYPE_INFO:
-            client_cerver_packet_handle_info (packet);
-            break;
+	switch (packet->header->request_type) {
+		case CERVER_PACKET_TYPE_INFO:
+			client_cerver_packet_handle_info (packet);
+			break;
 
-        // the cerves is going to be teardown, we have to disconnect
-        case CERVER_PACKET_TYPE_TEARDOWN:
-            #ifdef CLIENT_DEBUG
-            cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "---> Server teardown! <---");
-            #endif
-            client_got_disconnected (packet->client);
-            client_event_trigger (CLIENT_EVENT_DISCONNECTED, packet->client, NULL);
-            break;
+		// the cerves is going to be teardown, we have to disconnect
+		case CERVER_PACKET_TYPE_TEARDOWN:
+			#ifdef CLIENT_DEBUG
+			cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "---> Server teardown! <---");
+			#endif
+			client_got_disconnected (packet->client);
+			client_event_trigger (CLIENT_EVENT_DISCONNECTED, packet->client, NULL);
+			break;
 
-        default:
-            cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown cerver type packet.");
-            break;
-    }
+		default:
+			cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown cerver type packet.");
+			break;
+	}
 
 }
 
 // handles a client type packet
 static void client_client_packet_handler (Packet *packet) {
 
-    switch (packet->header->request_type) {
-        // the cerver close our connection
-        case CLIENT_PACKET_TYPE_CLOSE_CONNECTION:
-            client_connection_end (packet->client, packet->connection);
-            break;
+	switch (packet->header->request_type) {
+		// the cerver close our connection
+		case CLIENT_PACKET_TYPE_CLOSE_CONNECTION:
+			client_connection_end (packet->client, packet->connection);
+			break;
 
-        // the cerver has disconneted us
-        case CLIENT_PACKET_TYPE_DISCONNECT:
-            client_got_disconnected (packet->client);
-            client_event_trigger (CLIENT_EVENT_DISCONNECTED, packet->client, NULL);
-            break;
+		// the cerver has disconneted us
+		case CLIENT_PACKET_TYPE_DISCONNECT:
+			client_got_disconnected (packet->client);
+			client_event_trigger (CLIENT_EVENT_DISCONNECTED, packet->client, NULL);
+			break;
 
-        default:
-            cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown client packet type.");
-            break;
-    }
+		default:
+			cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown client packet type.");
+			break;
+	}
 
 }
 
 // handles a request from a cerver to get a file
 static void client_request_get_file (Packet *packet) {
 
-    Client *client = packet->client;
+	Client *client = packet->client;
 
-    client->file_stats->n_files_requests += 1;
+	client->file_stats->n_files_requests += 1;
 
-    // get the necessary information to fulfil the request
-    if (packet->data_size >= sizeof (FileHeader)) {
-        char *end = packet->data;
-        FileHeader *file_header = (FileHeader *) end;
+	// get the necessary information to fulfil the request
+	if (packet->data_size >= sizeof (FileHeader)) {
+		char *end = packet->data;
+		FileHeader *file_header = (FileHeader *) end;
 
-        // search for the requested file in the configured paths
-        String *actual_filename = client_files_search_file (client, file_header->filename);
-        if (actual_filename) {
-            #ifdef CLIENT_DEBUG
-            cerver_log_debug (
-                "client_request_get_file () - Sending %s...\n",
-                actual_filename->str
-            );
-            #endif
+		// search for the requested file in the configured paths
+		String *actual_filename = client_files_search_file (client, file_header->filename);
+		if (actual_filename) {
+			#ifdef CLIENT_DEBUG
+			cerver_log_debug (
+				"client_request_get_file () - Sending %s...\n",
+				actual_filename->str
+			);
+			#endif
 
-            // if found, pipe the file contents to the client's socket fd
-            // the socket should be blocked during the entire operation
-            ssize_t sent = file_send (
-                NULL, client, packet->connection,
-                actual_filename->str
-            );
+			// if found, pipe the file contents to the client's socket fd
+			// the socket should be blocked during the entire operation
+			ssize_t sent = file_send (
+				NULL, client, packet->connection,
+				actual_filename->str
+			);
 
-            if (sent > 0) {
-                client->file_stats->n_success_files_requests += 1;
-                client->file_stats->n_files_sent += 1;
-                client->file_stats->n_bytes_sent += sent;
+			if (sent > 0) {
+				client->file_stats->n_success_files_requests += 1;
+				client->file_stats->n_files_sent += 1;
+				client->file_stats->n_bytes_sent += sent;
 
-                cerver_log_success ("Sent file %s", actual_filename->str);
-            }
+				cerver_log_success ("Sent file %s", actual_filename->str);
+			}
 
-            else {
-                cerver_log_error ("Failed to send file %s", actual_filename->str);
+			else {
+				cerver_log_error ("Failed to send file %s", actual_filename->str);
 
-                client->file_stats->n_bad_files_sent += 1;
-            }
+				client->file_stats->n_bad_files_sent += 1;
+			}
 
-            str_delete (actual_filename);
-        }
+			str_delete (actual_filename);
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log_warning ("client_request_get_file () - file not found");
-            #endif
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log_warning ("client_request_get_file () - file not found");
+			#endif
 
-            // if not found, return an error to the client
-            (void) error_packet_generate_and_send (
-                CLIENT_ERROR_FILE_NOT_FOUND, "File not found",
-                NULL, packet->client, packet->connection
-            );
+			// if not found, return an error to the client
+			(void) error_packet_generate_and_send (
+				CLIENT_ERROR_FILE_NOT_FOUND, "File not found",
+				NULL, packet->client, packet->connection
+			);
 
-            client->file_stats->n_bad_files_requests += 1;
-        }
+			client->file_stats->n_bad_files_requests += 1;
+		}
 
-    }
+	}
 
-    else {
-        #ifdef CLIENT_DEBUG
-        cerver_log_warning ("client_request_get_file () - missing file header");
-        #endif
+	else {
+		#ifdef CLIENT_DEBUG
+		cerver_log_warning ("client_request_get_file () - missing file header");
+		#endif
 
-        // return a bad request error packet
-        (void) error_packet_generate_and_send (
-            CLIENT_ERROR_GET_FILE, "Missing file header",
-            NULL, packet->client, packet->connection
-        );
+		// return a bad request error packet
+		(void) error_packet_generate_and_send (
+			CLIENT_ERROR_GET_FILE, "Missing file header",
+			NULL, packet->client, packet->connection
+		);
 
-        client->file_stats->n_bad_files_requests += 1;
-    }
+		client->file_stats->n_bad_files_requests += 1;
+	}
 
 }
 
 static void client_request_send_file_actual (Packet *packet) {
 
-    Client *client = packet->client;
+	Client *client = packet->client;
 
-    client->file_stats->n_files_upload_requests += 1;
+	client->file_stats->n_files_upload_requests += 1;
 
-    // get the necessary information to fulfil the request
-    if (packet->data_size >= sizeof (FileHeader)) {
-        char *end = packet->data;
-        FileHeader *file_header = (FileHeader *) end;
+	// get the necessary information to fulfil the request
+	if (packet->data_size >= sizeof (FileHeader)) {
+		char *end = packet->data;
+		FileHeader *file_header = (FileHeader *) end;
 
-        const char *file_data = NULL;
-        size_t file_data_len = 0;
-        // printf (
-        // 	"\n\npacket->data_size %ld > sizeof (FileHeader) %ld\n\n",
-        // 	packet->data_size, sizeof (FileHeader)
-        // );
-        if (packet->data_size > sizeof (FileHeader)) {
-            file_data = end += sizeof (FileHeader);
-            file_data_len = packet->data_size - sizeof (FileHeader);
-        }
+		const char *file_data = NULL;
+		size_t file_data_len = 0;
+		// printf (
+		// 	"\n\npacket->data_size %ld > sizeof (FileHeader) %ld\n\n",
+		// 	packet->data_size, sizeof (FileHeader)
+		// );
+		if (packet->data_size > sizeof (FileHeader)) {
+			file_data = end += sizeof (FileHeader);
+			file_data_len = packet->data_size - sizeof (FileHeader);
+		}
 
-        char *saved_filename = NULL;
-        if (!client->file_upload_handler (
-            client, packet->connection,
-            file_header,
-            file_data, file_data_len,
-            &saved_filename
-        )) {
-            client->file_stats->n_success_files_uploaded += 1;
+		char *saved_filename = NULL;
+		if (!client->file_upload_handler (
+			client, packet->connection,
+			file_header,
+			file_data, file_data_len,
+			&saved_filename
+		)) {
+			client->file_stats->n_success_files_uploaded += 1;
 
-            client->file_stats->n_bytes_received += file_header->len;
+			client->file_stats->n_bytes_received += file_header->len;
 
-            if (client->file_upload_cb) {
-                client->file_upload_cb (
-                    packet->client, packet->connection,
-                    saved_filename
-                );
-            }
+			if (client->file_upload_cb) {
+				client->file_upload_cb (
+					packet->client, packet->connection,
+					saved_filename
+				);
+			}
 
-            if (saved_filename) free (saved_filename);
-        }
+			if (saved_filename) free (saved_filename);
+		}
 
-        else {
-            cerver_log_error ("client_request_send_file () - Failed to receive file");
+		else {
+			cerver_log_error ("client_request_send_file () - Failed to receive file");
 
-            client->file_stats->n_bad_files_received += 1;
-        }
-    }
+			client->file_stats->n_bad_files_received += 1;
+		}
+	}
 
-    else {
-        #ifdef CLIENT_DEBUG
-        cerver_log_warning ("client_request_send_file () - missing file header");
-        #endif
+	else {
+		#ifdef CLIENT_DEBUG
+		cerver_log_warning ("client_request_send_file () - missing file header");
+		#endif
 
-        // return a bad request error packet
-        (void) error_packet_generate_and_send (
-            CLIENT_ERROR_SEND_FILE, "Missing file header",
-            NULL, client, packet->connection
-        );
+		// return a bad request error packet
+		(void) error_packet_generate_and_send (
+			CLIENT_ERROR_SEND_FILE, "Missing file header",
+			NULL, client, packet->connection
+		);
 
-        client->file_stats->n_bad_files_upload_requests += 1;
-    }
+		client->file_stats->n_bad_files_upload_requests += 1;
+	}
 
 }
 
 // request from a cerver to receive a file
 static void client_request_send_file (Packet *packet) {
 
-    // check if the client is able to process the request
-    if (packet->client->file_upload_handler && packet->client->uploads_path) {
-        client_request_send_file_actual (packet);
-    }
+	// check if the client is able to process the request
+	if (packet->client->file_upload_handler && packet->client->uploads_path) {
+		client_request_send_file_actual (packet);
+	}
 
-    else {
-        // return a bad request error packet
-        (void) error_packet_generate_and_send (
-            CLIENT_ERROR_SEND_FILE, "Unable to process request",
-            NULL, packet->client, packet->connection
-        );
+	else {
+		// return a bad request error packet
+		(void) error_packet_generate_and_send (
+			CLIENT_ERROR_SEND_FILE, "Unable to process request",
+			NULL, packet->client, packet->connection
+		);
 
-        #ifdef CLIENT_DEBUG
-        cerver_log_warning (
-            "Client %s is unable to handle REQUEST_PACKET_TYPE_SEND_FILE packets!",
-            packet->client->name->str
-        );
-        #endif
-    }
+		#ifdef CLIENT_DEBUG
+		cerver_log_warning (
+			"Client %s is unable to handle REQUEST_PACKET_TYPE_SEND_FILE packets!",
+			packet->client->name->str
+		);
+		#endif
+	}
 
 }
 
 // handles a request made from the cerver
 static void client_request_packet_handler (Packet *packet) {
 
-    if (packet->header) {
-        switch (packet->header->request_type) {
-            // request from a cerver to get a file
-            case REQUEST_PACKET_TYPE_GET_FILE: client_request_get_file (packet); break;
+	if (packet->header) {
+		switch (packet->header->request_type) {
+			// request from a cerver to get a file
+			case REQUEST_PACKET_TYPE_GET_FILE: client_request_get_file (packet); break;
 
-            // request from a cerver to receive a file
-            case REQUEST_PACKET_TYPE_SEND_FILE: client_request_send_file (packet); break;
+			// request from a cerver to receive a file
+			case REQUEST_PACKET_TYPE_SEND_FILE: client_request_send_file (packet); break;
 
-            default:
-                cerver_log (LOG_TYPE_WARNING, LOG_TYPE_HANDLER, "Unknown request from cerver");
-                break;
-        }
-    }
+			default:
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_HANDLER, "Unknown request from cerver");
+				break;
+		}
+	}
 
 }
 
@@ -2564,64 +2564,64 @@ static void client_request_packet_handler (Packet *packet) {
 // returns 0 on succes, 1 on error
 static u8 auth_strip_token (Packet *packet, Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    // check we have a big enough packet
-    if (packet->data_size > 0) {
-        char *end = (char *) packet->data;
+	// check we have a big enough packet
+	if (packet->data_size > 0) {
+		char *end = (char *) packet->data;
 
-        // check if we have a token
-        if (packet->data_size == (sizeof (SToken))) {
-            SToken *s_token = (SToken *) (end);
-            retval = client_set_session_id (client, s_token->token);
-        }
-    }
+		// check if we have a token
+		if (packet->data_size == (sizeof (SToken))) {
+			SToken *s_token = (SToken *) (end);
+			retval = client_set_session_id (client, s_token->token);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void client_auth_success_handler (Packet *packet) {
 
-    packet->connection->authenticated = true;
+	packet->connection->authenticated = true;
 
-    if (packet->connection->cerver_report) {
-        if (packet->connection->cerver_report->uses_sessions) {
-            if (!auth_strip_token (packet, packet->client)) {
-                #ifdef AUTH_DEBUG
-                cerver_log_debug (
-                    "Got client's <%s> session id <%s>",
-                    packet->client->name->str, packet->client->session_id->str
-                );
-                #endif
-            }
-        }
-    }
+	if (packet->connection->cerver_report) {
+		if (packet->connection->cerver_report->uses_sessions) {
+			if (!auth_strip_token (packet, packet->client)) {
+				#ifdef AUTH_DEBUG
+				cerver_log_debug (
+					"Got client's <%s> session id <%s>",
+					packet->client->name->str, packet->client->session_id->str
+				);
+				#endif
+			}
+		}
+	}
 
-    client_event_trigger (CLIENT_EVENT_SUCCESS_AUTH, packet->client, packet->connection);
+	client_event_trigger (CLIENT_EVENT_SUCCESS_AUTH, packet->client, packet->connection);
 
 }
 
 static void client_auth_packet_handler (Packet *packet) {
 
-    switch (packet->header->request_type) {
-        // 24/01/2020 -- cerver requested authentication, if not, we will be disconnected
-        case AUTH_PACKET_TYPE_REQUEST_AUTH:
-            break;
+	switch (packet->header->request_type) {
+		// 24/01/2020 -- cerver requested authentication, if not, we will be disconnected
+		case AUTH_PACKET_TYPE_REQUEST_AUTH:
+			break;
 
-        // we recieve a token from the cerver to use in sessions
-        case AUTH_PACKET_TYPE_CLIENT_AUTH:
-            break;
+		// we recieve a token from the cerver to use in sessions
+		case AUTH_PACKET_TYPE_CLIENT_AUTH:
+			break;
 
-        // we have successfully authenticated with the server
-        case AUTH_PACKET_TYPE_SUCCESS:
-            client_auth_success_handler (packet);
-            break;
+		// we have successfully authenticated with the server
+		case AUTH_PACKET_TYPE_SUCCESS:
+			client_auth_success_handler (packet);
+			break;
 
-        default:
-            cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown auth packet type.");
-            break;
-    }
+		default:
+			cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown auth packet type.");
+			break;
+	}
 
 }
 
@@ -2629,34 +2629,34 @@ static void client_auth_packet_handler (Packet *packet) {
 // handles a PACKET_TYPE_APP packet type
 static void client_app_packet_handler (Packet *packet) {
 
-    if (packet->client->app_packet_handler) {
-        if (packet->client->app_packet_handler->direct_handle) {
-            // printf ("app_packet_handler - direct handle!\n");
-            packet->client->app_packet_handler->handler (packet);
-            packet_delete (packet);
-        }
+	if (packet->client->app_packet_handler) {
+		if (packet->client->app_packet_handler->direct_handle) {
+			// printf ("app_packet_handler - direct handle!\n");
+			packet->client->app_packet_handler->handler (packet);
+			packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->client->app_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to client's %s app_packet_handler!",
-                    packet->client->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->client->app_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to client's %s app_packet_handler!",
+					packet->client->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        cerver_log_warning (
-            "Client %s does not have a app_packet_handler!",
-            packet->client->name->str
-        );
-    }
+	else {
+		cerver_log_warning (
+			"Client %s does not have a app_packet_handler!",
+			packet->client->name->str
+		);
+	}
 
 }
 
@@ -2664,34 +2664,34 @@ static void client_app_packet_handler (Packet *packet) {
 // handles a PACKET_TYPE_APP_ERROR packet type
 static void client_app_error_packet_handler (Packet *packet) {
 
-    if (packet->client->app_error_packet_handler) {
-        if (packet->client->app_error_packet_handler->direct_handle) {
-            // printf ("app_error_packet_handler - direct handle!\n");
-            packet->client->app_error_packet_handler->handler (packet);
-            packet_delete (packet);
-        }
+	if (packet->client->app_error_packet_handler) {
+		if (packet->client->app_error_packet_handler->direct_handle) {
+			// printf ("app_error_packet_handler - direct handle!\n");
+			packet->client->app_error_packet_handler->handler (packet);
+			packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->client->app_error_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to client's %s app_error_packet_handler!",
-                    packet->client->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->client->app_error_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to client's %s app_error_packet_handler!",
+					packet->client->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        cerver_log_warning (
-            "Client %s does not have a app_error_packet_handler!",
-            packet->client->name->str
-        );
-    }
+	else {
+		cerver_log_warning (
+			"Client %s does not have a app_error_packet_handler!",
+			packet->client->name->str
+		);
+	}
 
 }
 
@@ -2699,360 +2699,360 @@ static void client_app_error_packet_handler (Packet *packet) {
 // handles a PACKET_TYPE_CUSTOM packet type
 static void client_custom_packet_handler (Packet *packet) {
 
-    if (packet->client->custom_packet_handler) {
-        if (packet->client->custom_packet_handler->direct_handle) {
-            // printf ("custom_packet_handler - direct handle!\n");
-            packet->client->custom_packet_handler->handler (packet);
-            packet_delete (packet);
-        }
+	if (packet->client->custom_packet_handler) {
+		if (packet->client->custom_packet_handler->direct_handle) {
+			// printf ("custom_packet_handler - direct handle!\n");
+			packet->client->custom_packet_handler->handler (packet);
+			packet_delete (packet);
+		}
 
-        else {
-            // add the packet to the handler's job queueu to be handled
-            // as soon as the handler is available
-            if (job_queue_push (
-                packet->client->custom_packet_handler->job_queue,
-                job_create (NULL, packet)
-            )) {
-                cerver_log_error (
-                    "Failed to push a new job to client's %s custom_packet_handler!",
-                    packet->client->name->str
-                );
-            }
-        }
-    }
+		else {
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->client->custom_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to client's %s custom_packet_handler!",
+					packet->client->name->str
+				);
+			}
+		}
+	}
 
-    else {
-        cerver_log_warning (
-            "Client %s does not have a custom_packet_handler!",
-            packet->client->name->str
-        );
-    }
+	else {
+		cerver_log_warning (
+			"Client %s does not have a custom_packet_handler!",
+			packet->client->name->str
+		);
+	}
 
 }
 
 // the client handles a packet based on its type
 static void client_packet_handler (void *packet_ptr) {
 
-    if (packet_ptr) {
-        Packet *packet = (Packet *) packet_ptr;
-        packet->client->stats->n_packets_received += 1;
+	if (packet_ptr) {
+		Packet *packet = (Packet *) packet_ptr;
+		packet->client->stats->n_packets_received += 1;
 
-        bool good = true;
-        if (packet->client->check_packets) {
-            // we expect the packet version in the packet's data
-            if (packet->data) {
-                packet->version = (PacketVersion *) packet->data_ptr;
-                packet->data_ptr += sizeof (PacketVersion);
-                good = packet_check (packet);
-            }
+		bool good = true;
+		if (packet->client->check_packets) {
+			// we expect the packet version in the packet's data
+			if (packet->data) {
+				packet->version = (PacketVersion *) packet->data_ptr;
+				packet->data_ptr += sizeof (PacketVersion);
+				good = packet_check (packet);
+			}
 
-            else {
-                cerver_log_error ("client_packet_handler () - No packet version to check!");
-                good = false;
-            }
-        }
+			else {
+				cerver_log_error ("client_packet_handler () - No packet version to check!");
+				good = false;
+			}
+		}
 
-        if (good) {
-            switch (packet->header->packet_type) {
-                case PACKET_TYPE_NONE: break;
+		if (good) {
+			switch (packet->header->packet_type) {
+				case PACKET_TYPE_NONE: break;
 
-                // handles cerver type packets
-                case PACKET_TYPE_CERVER:
-                    packet->client->stats->received_packets->n_cerver_packets += 1;
-                    packet->connection->stats->received_packets->n_cerver_packets += 1;
-                    client_cerver_packet_handler (packet);
-                    packet_delete (packet);
-                    break;
+				// handles cerver type packets
+				case PACKET_TYPE_CERVER:
+					packet->client->stats->received_packets->n_cerver_packets += 1;
+					packet->connection->stats->received_packets->n_cerver_packets += 1;
+					client_cerver_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles a client type packet
-                case PACKET_TYPE_CLIENT:
-                    client_client_packet_handler (packet);
-                    break;
+				// handles a client type packet
+				case PACKET_TYPE_CLIENT:
+					client_client_packet_handler (packet);
+					break;
 
-                // handles an error from the server
-                case PACKET_TYPE_ERROR:
-                    packet->client->stats->received_packets->n_error_packets += 1;
-                    packet->connection->stats->received_packets->n_error_packets += 1;
-                    client_error_packet_handler (packet);
-                    packet_delete (packet);
-                    break;
+				// handles an error from the server
+				case PACKET_TYPE_ERROR:
+					packet->client->stats->received_packets->n_error_packets += 1;
+					packet->connection->stats->received_packets->n_error_packets += 1;
+					client_error_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles a request made from the server
-                case PACKET_TYPE_REQUEST:
-                    packet->client->stats->received_packets->n_request_packets += 1;
-                    packet->connection->stats->received_packets->n_request_packets += 1;
-                    client_request_packet_handler (packet);
-                    packet_delete (packet);
-                    break;
+				// handles a request made from the server
+				case PACKET_TYPE_REQUEST:
+					packet->client->stats->received_packets->n_request_packets += 1;
+					packet->connection->stats->received_packets->n_request_packets += 1;
+					client_request_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles authentication packets
-                case PACKET_TYPE_AUTH:
-                    packet->client->stats->received_packets->n_auth_packets += 1;
-                    packet->connection->stats->received_packets->n_auth_packets += 1;
-                    client_auth_packet_handler (packet);
-                    packet_delete (packet);
-                    break;
+				// handles authentication packets
+				case PACKET_TYPE_AUTH:
+					packet->client->stats->received_packets->n_auth_packets += 1;
+					packet->connection->stats->received_packets->n_auth_packets += 1;
+					client_auth_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles a game packet sent from the server
-                case PACKET_TYPE_GAME:
-                    packet->client->stats->received_packets->n_game_packets += 1;
-                    packet->connection->stats->received_packets->n_game_packets += 1;
-                    packet_delete (packet);
-                    break;
+				// handles a game packet sent from the server
+				case PACKET_TYPE_GAME:
+					packet->client->stats->received_packets->n_game_packets += 1;
+					packet->connection->stats->received_packets->n_game_packets += 1;
+					packet_delete (packet);
+					break;
 
-                // user set handler to handler app specific packets
-                case PACKET_TYPE_APP:
-                    packet->client->stats->received_packets->n_app_packets += 1;
-                    packet->connection->stats->received_packets->n_app_packets += 1;
-                    client_app_packet_handler (packet);
-                    break;
+				// user set handler to handler app specific packets
+				case PACKET_TYPE_APP:
+					packet->client->stats->received_packets->n_app_packets += 1;
+					packet->connection->stats->received_packets->n_app_packets += 1;
+					client_app_packet_handler (packet);
+					break;
 
-                // user set handler to handle app specific errors
-                case PACKET_TYPE_APP_ERROR:
-                    packet->client->stats->received_packets->n_app_error_packets += 1;
-                    packet->connection->stats->received_packets->n_app_error_packets += 1;
-                    client_app_error_packet_handler (packet);
-                    break;
+				// user set handler to handle app specific errors
+				case PACKET_TYPE_APP_ERROR:
+					packet->client->stats->received_packets->n_app_error_packets += 1;
+					packet->connection->stats->received_packets->n_app_error_packets += 1;
+					client_app_error_packet_handler (packet);
+					break;
 
-                // custom packet hanlder
-                case PACKET_TYPE_CUSTOM:
-                    packet->client->stats->received_packets->n_custom_packets += 1;
-                    packet->connection->stats->received_packets->n_custom_packets += 1;
-                    client_custom_packet_handler (packet);
-                    break;
+				// custom packet hanlder
+				case PACKET_TYPE_CUSTOM:
+					packet->client->stats->received_packets->n_custom_packets += 1;
+					packet->connection->stats->received_packets->n_custom_packets += 1;
+					client_custom_packet_handler (packet);
+					break;
 
-                // handles a test packet form the cerver
-                case PACKET_TYPE_TEST:
-                    packet->client->stats->received_packets->n_test_packets += 1;
-                    packet->connection->stats->received_packets->n_test_packets += 1;
-                    cerver_log (LOG_TYPE_TEST, LOG_TYPE_NONE, "Got a test packet from cerver");
-                    packet_delete (packet);
-                    break;
+				// handles a test packet form the cerver
+				case PACKET_TYPE_TEST:
+					packet->client->stats->received_packets->n_test_packets += 1;
+					packet->connection->stats->received_packets->n_test_packets += 1;
+					cerver_log (LOG_TYPE_TEST, LOG_TYPE_NONE, "Got a test packet from cerver");
+					packet_delete (packet);
+					break;
 
-                default:
-                    packet->client->stats->received_packets->n_bad_packets += 1;
-                    packet->connection->stats->received_packets->n_bad_packets += 1;
-                    #ifdef CLIENT_DEBUG
-                    cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got a packet of unknown type");
-                    #endif
-                    packet_delete (packet);
-                    break;
-            }
-        }
-    }
+				default:
+					packet->client->stats->received_packets->n_bad_packets += 1;
+					packet->connection->stats->received_packets->n_bad_packets += 1;
+					#ifdef CLIENT_DEBUG
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got a packet of unknown type");
+					#endif
+					packet_delete (packet);
+					break;
+			}
+		}
+	}
 
 }
 
 static void client_receive_handle_spare_packet (
-    Client *client, Connection *connection,
-    size_t buffer_size, char **end, size_t *buffer_pos
+	Client *client, Connection *connection,
+	size_t buffer_size, char **end, size_t *buffer_pos
 ) {
 
-    if (connection->sock_receive->header) {
-        // copy the remaining header size
-        memcpy (connection->sock_receive->header_end, (void *) *end, connection->sock_receive->remaining_header);
+	if (connection->sock_receive->header) {
+		// copy the remaining header size
+		memcpy (connection->sock_receive->header_end, (void *) *end, connection->sock_receive->remaining_header);
 
-        connection->sock_receive->complete_header = true;
-    }
+		connection->sock_receive->complete_header = true;
+	}
 
-    else if (connection->sock_receive->spare_packet) {
-        size_t copy_to_spare = 0;
-        if (connection->sock_receive->missing_packet < buffer_size)
-            copy_to_spare = connection->sock_receive->missing_packet;
+	else if (connection->sock_receive->spare_packet) {
+		size_t copy_to_spare = 0;
+		if (connection->sock_receive->missing_packet < buffer_size)
+			copy_to_spare = connection->sock_receive->missing_packet;
 
-        else copy_to_spare = buffer_size;
+		else copy_to_spare = buffer_size;
 
-        // append new data from buffer to the spare packet
-        if (copy_to_spare > 0) {
-            packet_append_data (connection->sock_receive->spare_packet, *end, copy_to_spare);
+		// append new data from buffer to the spare packet
+		if (copy_to_spare > 0) {
+			packet_append_data (connection->sock_receive->spare_packet, *end, copy_to_spare);
 
-            // check if we can handler the packet
-            size_t curr_packet_size = connection->sock_receive->spare_packet->data_size + sizeof (PacketHeader);
-            if (connection->sock_receive->spare_packet->header->packet_size == curr_packet_size) {
-                connection->sock_receive->spare_packet->client = client;
-                connection->sock_receive->spare_packet->connection = connection;
+			// check if we can handler the packet
+			size_t curr_packet_size = connection->sock_receive->spare_packet->data_size + sizeof (PacketHeader);
+			if (connection->sock_receive->spare_packet->header->packet_size == curr_packet_size) {
+				connection->sock_receive->spare_packet->client = client;
+				connection->sock_receive->spare_packet->connection = connection;
 
-                connection->full_packet = true;
-                client_packet_handler (connection->sock_receive->spare_packet);
+				connection->full_packet = true;
+				client_packet_handler (connection->sock_receive->spare_packet);
 
-                connection->sock_receive->spare_packet = NULL;
-                connection->sock_receive->missing_packet = 0;
-            }
+				connection->sock_receive->spare_packet = NULL;
+				connection->sock_receive->missing_packet = 0;
+			}
 
-            else connection->sock_receive->missing_packet -= copy_to_spare;
+			else connection->sock_receive->missing_packet -= copy_to_spare;
 
-            // offset for the buffer
-            if (copy_to_spare < buffer_size) *end += copy_to_spare;
-            *buffer_pos += copy_to_spare;
-        }
-    }
+			// offset for the buffer
+			if (copy_to_spare < buffer_size) *end += copy_to_spare;
+			*buffer_pos += copy_to_spare;
+		}
+	}
 
 }
 
 // splits the entry buffer in packets of the correct size
 static void client_receive_handle_buffer (
-    Client *client, Connection *connection,
-    char *buffer, size_t buffer_size
+	Client *client, Connection *connection,
+	char *buffer, size_t buffer_size
 ) {
 
-    if (buffer && (buffer_size > 0)) {
-        char *end = buffer;
-        size_t buffer_pos = 0;
+	if (buffer && (buffer_size > 0)) {
+		char *end = buffer;
+		size_t buffer_pos = 0;
 
-        SockReceive *sock_receive = connection->sock_receive;
+		SockReceive *sock_receive = connection->sock_receive;
 
-        client_receive_handle_spare_packet (
-            client, connection,
-            buffer_size, &end,
-            &buffer_pos
-        );
+		client_receive_handle_spare_packet (
+			client, connection,
+			buffer_size, &end,
+			&buffer_pos
+		);
 
-        PacketHeader *header = NULL;
-        size_t packet_size = 0;
-        // char *packet_data = NULL;
+		PacketHeader *header = NULL;
+		size_t packet_size = 0;
+		// char *packet_data = NULL;
 
-        size_t remaining_buffer_size = 0;
-        size_t packet_real_size = 0;
-        size_t to_copy_size = 0;
+		size_t remaining_buffer_size = 0;
+		size_t packet_real_size = 0;
+		size_t to_copy_size = 0;
 
-        bool spare_header = false;
+		bool spare_header = false;
 
-        while (buffer_pos < buffer_size) {
-            remaining_buffer_size = buffer_size - buffer_pos;
+		while (buffer_pos < buffer_size) {
+			remaining_buffer_size = buffer_size - buffer_pos;
 
-            if (sock_receive->complete_header) {
-                packet_header_copy (&header, (PacketHeader *) sock_receive->header);
-                // header = ((PacketHeader *) sock_receive->header);
-                // packet_header_print (header);
+			if (sock_receive->complete_header) {
+				packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+				// header = ((PacketHeader *) sock_receive->header);
+				// packet_header_print (header);
 
-                end += sock_receive->remaining_header;
-                buffer_pos += sock_receive->remaining_header;
-                // printf ("buffer pos after copy to header: %ld\n", buffer_pos);
+				end += sock_receive->remaining_header;
+				buffer_pos += sock_receive->remaining_header;
+				// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
 
-                // reset sock header values
-                free (sock_receive->header);
-                sock_receive->header = NULL;
-                sock_receive->header_end = NULL;
-                // sock_receive->curr_header_pos = 0;
-                // sock_receive->remaining_header = 0;
-                sock_receive->complete_header = false;
+				// reset sock header values
+				free (sock_receive->header);
+				sock_receive->header = NULL;
+				sock_receive->header_end = NULL;
+				// sock_receive->curr_header_pos = 0;
+				// sock_receive->remaining_header = 0;
+				sock_receive->complete_header = false;
 
-                spare_header = true;
-            }
+				spare_header = true;
+			}
 
-            else if (remaining_buffer_size >= sizeof (PacketHeader)) {
-                header = (PacketHeader *) end;
-                end += sizeof (PacketHeader);
-                buffer_pos += sizeof (PacketHeader);
+			else if (remaining_buffer_size >= sizeof (PacketHeader)) {
+				header = (PacketHeader *) end;
+				end += sizeof (PacketHeader);
+				buffer_pos += sizeof (PacketHeader);
 
-                // packet_header_print (header);
+				// packet_header_print (header);
 
-                spare_header = false;
-            }
+				spare_header = false;
+			}
 
-            if (header) {
-                // check the packet size
-                packet_size = header->packet_size;
-                if ((packet_size > 0) /* && (packet_size < 65536) */) {
-                    // printf ("packet_size: %ld\n", packet_size);
-                    // end += sizeof (PacketHeader);
-                    // buffer_pos += sizeof (PacketHeader);
-                    // printf ("first buffer pos: %ld\n", buffer_pos);
+			if (header) {
+				// check the packet size
+				packet_size = header->packet_size;
+				if ((packet_size > 0) /* && (packet_size < 65536) */) {
+					// printf ("packet_size: %ld\n", packet_size);
+					// end += sizeof (PacketHeader);
+					// buffer_pos += sizeof (PacketHeader);
+					// printf ("first buffer pos: %ld\n", buffer_pos);
 
-                    Packet *packet = packet_new ();
-                    if (packet) {
-                        packet_header_copy (&packet->header, header);
-                        packet->packet_size = header->packet_size;
-                        // packet->cerver = cerver;
-                        // packet->lobby = lobby;
-                        packet->client = client;
-                        packet->connection = connection;
+					Packet *packet = packet_new ();
+					if (packet) {
+						packet_header_copy (&packet->header, header);
+						packet->packet_size = header->packet_size;
+						// packet->cerver = cerver;
+						// packet->lobby = lobby;
+						packet->client = client;
+						packet->connection = connection;
 
-                        if (spare_header) {
-                            free (header);
-                            header = NULL;
-                        }
+						if (spare_header) {
+							free (header);
+							header = NULL;
+						}
 
-                        // check for packet size and only copy what is in the current buffer
-                        packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
-                        to_copy_size = 0;
-                        if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
-                            sock_receive->spare_packet = packet;
+						// check for packet size and only copy what is in the current buffer
+						packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
+						to_copy_size = 0;
+						if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
+							sock_receive->spare_packet = packet;
 
-                            if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
-                            else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+							if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
+							else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 
-                            sock_receive->missing_packet = packet_real_size - to_copy_size;
-                        }
+							sock_receive->missing_packet = packet_real_size - to_copy_size;
+						}
 
-                        else {
-                            if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
-                                to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-                            }
+						else {
+							if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
+								to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+							}
 
-                            else {
-                                to_copy_size = packet_real_size;
-                            }
+							else {
+								to_copy_size = packet_real_size;
+							}
 
-                            packet_delete (sock_receive->spare_packet);
-                            sock_receive->spare_packet = NULL;
-                        }
+							packet_delete (sock_receive->spare_packet);
+							sock_receive->spare_packet = NULL;
+						}
 
-                        // printf ("to copy size: %ld\n", to_copy_size);
-                        packet_set_data (packet, (void *) end, to_copy_size);
+						// printf ("to copy size: %ld\n", to_copy_size);
+						packet_set_data (packet, (void *) end, to_copy_size);
 
-                        end += to_copy_size;
-                        buffer_pos += to_copy_size;
-                        // printf ("second buffer pos: %ld\n", buffer_pos);
+						end += to_copy_size;
+						buffer_pos += to_copy_size;
+						// printf ("second buffer pos: %ld\n", buffer_pos);
 
-                        if (!sock_receive->spare_packet) {
-                            connection->full_packet = true;
-                            client_packet_handler (packet);
-                        }
-                    }
+						if (!sock_receive->spare_packet) {
+							connection->full_packet = true;
+							client_packet_handler (packet);
+						}
+					}
 
-                    else {
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                            "Failed to create a new packet in cerver_handle_receive_buffer ()"
-                        );
-                    }
-                }
+					else {
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+							"Failed to create a new packet in cerver_handle_receive_buffer ()"
+						);
+					}
+				}
 
-                else {
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                        "Got a packet of invalid size: %ld", packet_size
-                    );
+				else {
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+						"Got a packet of invalid size: %ld", packet_size
+					);
 
-                    break;
-                }
-            }
+					break;
+				}
+			}
 
-            else {
-                if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+			else {
+				if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
 
-                else {
-                    // copy the piece of possible header that was cut of between recv ()
-                    sock_receive->header = malloc (sizeof (PacketHeader));
-                    memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+				else {
+					// copy the piece of possible header that was cut of between recv ()
+					sock_receive->header = malloc (sizeof (PacketHeader));
+					memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
 
-                    sock_receive->header_end = (char *) sock_receive->header;
-                    sock_receive->header_end += remaining_buffer_size;
+					sock_receive->header_end = (char *) sock_receive->header;
+					sock_receive->header_end += remaining_buffer_size;
 
-                    // sock_receive->curr_header_pos = remaining_buffer_size;
-                    sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
+					// sock_receive->curr_header_pos = remaining_buffer_size;
+					sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
 
-                    // printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
-                    // printf ("remaining header: %d\n", sock_receive->remaining_header);
+					// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
+					// printf ("remaining header: %d\n", sock_receive->remaining_header);
 
-                    buffer_pos += remaining_buffer_size;
-                }
-            }
+					buffer_pos += remaining_buffer_size;
+				}
+			}
 
-            header = NULL;
-        }
-    }
+			header = NULL;
+		}
+	}
 
 }
 
@@ -3060,14 +3060,14 @@ static void client_receive_handle_buffer (
 // end sthe connection to prevent seg faults or signals for bad sock fd
 static void client_receive_handle_failed (Client *client, Connection *connection) {
 
-    if (connection->active) {
-        if (!client_connection_end (client, connection)) {
-            // check if the client has any other active connection
-            if (client->connections->size <= 0) {
-                client->running = false;
-            }
-        }
-    }
+	if (connection->active) {
+		if (!client_connection_end (client, connection)) {
+			// check if the client has any other active connection
+			if (client->connections->size <= 0) {
+				client->running = false;
+			}
+		}
+	}
 
 }
 
@@ -3075,83 +3075,83 @@ static void client_receive_handle_failed (Client *client, Connection *connection
 // returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
 unsigned int client_receive (Client *client, Connection *connection) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (client && connection) {
-        char *packet_buffer = (char *) calloc (connection->receive_packet_buffer_size, sizeof (char));
-        if (packet_buffer) {
-            ssize_t rc = recv (connection->socket->sock_fd, packet_buffer, connection->receive_packet_buffer_size, 0);
+	if (client && connection) {
+		char *packet_buffer = (char *) calloc (connection->receive_packet_buffer_size, sizeof (char));
+		if (packet_buffer) {
+			ssize_t rc = recv (connection->socket->sock_fd, packet_buffer, connection->receive_packet_buffer_size, 0);
 
-            switch (rc) {
-                case -1: {
-                    if (errno != EWOULDBLOCK) {
-                        #ifdef CLIENT_DEBUG
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                            "client_receive () - rc < 0 - sock fd: %d",
-                            connection->socket->sock_fd
-                        );
-                        perror ("Error");
-                        #endif
+			switch (rc) {
+				case -1: {
+					if (errno != EWOULDBLOCK) {
+						#ifdef CLIENT_DEBUG
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_NONE,
+							"client_receive () - rc < 0 - sock fd: %d",
+							connection->socket->sock_fd
+						);
+						perror ("Error");
+						#endif
 
-                        client_receive_handle_failed (client, connection);
-                    }
-                } break;
+						client_receive_handle_failed (client, connection);
+					}
+				} break;
 
-                case 0: {
-                    // man recv -> steam socket perfomed an orderly shutdown
-                    // but in dgram it might mean something?
-                    #ifdef CLIENT_DEBUG
-                    cerver_log (
-                        LOG_TYPE_DEBUG, LOG_TYPE_NONE,
-                        "client_receive () - rc == 0 - sock fd: %d",
-                        connection->socket->sock_fd
-                    );
-                    // perror ("Error");
-                    #endif
+				case 0: {
+					// man recv -> steam socket perfomed an orderly shutdown
+					// but in dgram it might mean something?
+					#ifdef CLIENT_DEBUG
+					cerver_log (
+						LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+						"client_receive () - rc == 0 - sock fd: %d",
+						connection->socket->sock_fd
+					);
+					// perror ("Error");
+					#endif
 
-                    client_receive_handle_failed (client, connection);
-                } break;
+					client_receive_handle_failed (client, connection);
+				} break;
 
-                default: {
-                    cerver_log (
-                        LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
-                        "Connection %s rc: %ld",
-                        connection->name->str, rc
-                    );
+				default: {
+					cerver_log (
+						LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+						"Connection %s rc: %ld",
+						connection->name->str, rc
+					);
 
-                    client->stats->n_receives_done += 1;
-                    client->stats->total_bytes_received += rc;
+					client->stats->n_receives_done += 1;
+					client->stats->total_bytes_received += rc;
 
-                    connection->stats->n_receives_done += 1;
-                    connection->stats->total_bytes_received += rc;
+					connection->stats->n_receives_done += 1;
+					connection->stats->total_bytes_received += rc;
 
-                    // handle the recived packet buffer -> split them in packets of the correct size
-                    client_receive_handle_buffer (
-                        client,
-                        connection,
-                        packet_buffer,
-                        rc
-                    );
+					// handle the recived packet buffer -> split them in packets of the correct size
+					client_receive_handle_buffer (
+						client,
+						connection,
+						packet_buffer,
+						rc
+					);
 
-                    retval = 0;
-                } break;
-            }
+					retval = 0;
+				} break;
+			}
 
-            free (packet_buffer);
-        }
+			free (packet_buffer);
+		}
 
-        else {
-            #ifdef CLIENT_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-                "Failed to allocate a new packet buffer!"
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CLIENT_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+				"Failed to allocate a new packet buffer!"
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -3162,21 +3162,21 @@ unsigned int client_receive (Client *client, Connection *connection) {
 // ends a connection with a cerver by sending a disconnect packet and the closing the connection
 static void client_connection_terminate (Client *client, Connection *connection) {
 
-    if (connection) {
-        if (connection->active) {
-            if (connection->cerver_report) {
-                // send a close connection packet
-                Packet *packet = packet_generate_request (PACKET_TYPE_CLIENT, CLIENT_PACKET_TYPE_CLOSE_CONNECTION, NULL, 0);
-                if (packet) {
-                    packet_set_network_values (packet, NULL, client, connection, NULL);
-                    if (packet_send (packet, 0, NULL, false)) {
-                        cerver_log_error ("Failed to send CLIENT_CLOSE_CONNECTION!");
-                    }
-                    packet_delete (packet);
-                }
-            }
-        }
-    }
+	if (connection) {
+		if (connection->active) {
+			if (connection->cerver_report) {
+				// send a close connection packet
+				Packet *packet = packet_generate_request (PACKET_TYPE_CLIENT, CLIENT_PACKET_TYPE_CLOSE_CONNECTION, NULL, 0);
+				if (packet) {
+					packet_set_network_values (packet, NULL, client, connection, NULL);
+					if (packet_send (packet, 0, NULL, false)) {
+						cerver_log_error ("Failed to send CLIENT_CLOSE_CONNECTION!");
+					}
+					packet_delete (packet);
+				}
+			}
+		}
+	}
 
 }
 
@@ -3185,16 +3185,16 @@ static void client_connection_terminate (Client *client, Connection *connection)
 // returns 0 on success, 1 on error
 int client_connection_stop (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        client_event_trigger (CLIENT_EVENT_CONNECTION_CLOSE, client, connection);
-        connection_end (connection);
+	if (client && connection) {
+		client_event_trigger (CLIENT_EVENT_CONNECTION_CLOSE, client, connection);
+		connection_end (connection);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -3203,14 +3203,14 @@ int client_connection_stop (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 int client_connection_close (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        client_connection_terminate (client, connection);
-        retval = client_connection_stop (client, connection);
-    }
+	if (client && connection) {
+		client_connection_terminate (client, connection);
+		retval = client_connection_stop (client, connection);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -3219,128 +3219,128 @@ int client_connection_close (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 int client_connection_end (Client *client, Connection *connection) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (client && connection) {
-        client_connection_close (client, connection);
+	if (client && connection) {
+		client_connection_close (client, connection);
 
-        dlist_remove (client->connections, connection, NULL);
+		dlist_remove (client->connections, connection, NULL);
 
-        if (connection->updating) {
-            // wait until connection has finished updating
-            pthread_mutex_lock (connection->mutex);
+		if (connection->updating) {
+			// wait until connection has finished updating
+			pthread_mutex_lock (connection->mutex);
 
-            while (connection->updating) {
-                // printf ("client_connection_end () waiting...\n");
-                pthread_cond_wait (connection->cond, connection->mutex);
-            }
+			while (connection->updating) {
+				// printf ("client_connection_end () waiting...\n");
+				pthread_cond_wait (connection->cond, connection->mutex);
+			}
 
-            pthread_mutex_unlock (connection->mutex);
-        }
+			pthread_mutex_unlock (connection->mutex);
+		}
 
-        connection_delete (connection);
+		connection_delete (connection);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static void client_app_handler_destroy (Client *client) {
 
-    if (client) {
-        if (client->app_packet_handler) {
-            if (!client->app_packet_handler->direct_handle) {
-                // stop app handler
-                bsem_post_all (client->app_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (client) {
+		if (client->app_packet_handler) {
+			if (!client->app_packet_handler->direct_handle) {
+				// stop app handler
+				bsem_post_all (client->app_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
 }
 
 static void client_app_error_handler_destroy (Client *client) {
 
-    if (client) {
-        if (client->app_error_packet_handler) {
-            if (!client->app_error_packet_handler->direct_handle) {
-                // stop app error handler
-                bsem_post_all (client->app_error_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (client) {
+		if (client->app_error_packet_handler) {
+			if (!client->app_error_packet_handler->direct_handle) {
+				// stop app error handler
+				bsem_post_all (client->app_error_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
 }
 
 static void client_custom_handler_destroy (Client *client) {
 
-    if (client) {
-        if (client->custom_packet_handler) {
-            if (!client->custom_packet_handler->direct_handle) {
-                // stop custom handler
-                bsem_post_all (client->custom_packet_handler->job_queue->has_jobs);
-            }
-        }
-    }
+	if (client) {
+		if (client->custom_packet_handler) {
+			if (!client->custom_packet_handler->direct_handle) {
+				// stop custom handler
+				bsem_post_all (client->custom_packet_handler->job_queue->has_jobs);
+			}
+		}
+	}
 
 }
 
 static void client_handlers_destroy (Client *client) {
 
-    if (client) {
-        cerver_log_debug (
-            "Client %s num_handlers_alive: %d",
-            client->name->str, client->num_handlers_alive
-        );
+	if (client) {
+		cerver_log_debug (
+			"Client %s num_handlers_alive: %d",
+			client->name->str, client->num_handlers_alive
+		);
 
-        client_app_handler_destroy (client);
+		client_app_handler_destroy (client);
 
-        client_app_error_handler_destroy (client);
+		client_app_error_handler_destroy (client);
 
-        client_custom_handler_destroy (client);
+		client_custom_handler_destroy (client);
 
-        // poll remaining handlers
-        while (client->num_handlers_alive) {
-            if (client->app_packet_handler)
-                bsem_post_all (client->app_packet_handler->job_queue->has_jobs);
+		// poll remaining handlers
+		while (client->num_handlers_alive) {
+			if (client->app_packet_handler)
+				bsem_post_all (client->app_packet_handler->job_queue->has_jobs);
 
-            if (client->app_error_packet_handler)
-                bsem_post_all (client->app_error_packet_handler->job_queue->has_jobs);
+			if (client->app_error_packet_handler)
+				bsem_post_all (client->app_error_packet_handler->job_queue->has_jobs);
 
-            if (client->custom_packet_handler)
-                bsem_post_all (client->custom_packet_handler->job_queue->has_jobs);
+			if (client->custom_packet_handler)
+				bsem_post_all (client->custom_packet_handler->job_queue->has_jobs);
 
-            sleep (1);
-        }
-    }
+			sleep (1);
+		}
+	}
 
 }
 
 static void *client_teardown_internal (void *client_ptr) {
 
-    if (client_ptr) {
-        Client *client = (Client *) client_ptr;
+	if (client_ptr) {
+		Client *client = (Client *) client_ptr;
 
-        pthread_mutex_lock (client->lock);
+		pthread_mutex_lock (client->lock);
 
-        // end any ongoing connection
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            client_connection_close (client, (Connection *) le->data);
-        }
+		// end any ongoing connection
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			client_connection_close (client, (Connection *) le->data);
+		}
 
-        client_handlers_destroy (client);
+		client_handlers_destroy (client);
 
-        // delete all connections
-        dlist_delete (client->connections);
-        client->connections = NULL;
+		// delete all connections
+		dlist_delete (client->connections);
+		client->connections = NULL;
 
-        pthread_mutex_unlock (client->lock);
+		pthread_mutex_unlock (client->lock);
 
-        client_delete (client);
-    }
+		client_delete (client);
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
@@ -3348,17 +3348,17 @@ static void *client_teardown_internal (void *client_ptr) {
 // returns 0 on success, 1 on error
 u8 client_teardown (Client *client) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client) {
-        client->running = false;
+	if (client) {
+		client->running = false;
 
-        client_teardown_internal (client);
+		client_teardown_internal (client);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -3367,12 +3367,12 @@ u8 client_teardown (Client *client) {
 // returns 0 on success creating thread, 1 on error
 u8 client_teardown_async (Client *client) {
 
-    pthread_t thread_id = 0;
-    return client ? thread_create_detachable (
-        &thread_id,
-        client_teardown_internal,
-        client
-    ) : 1;
+	pthread_t thread_id = 0;
+	return client ? thread_create_detachable (
+		&thread_id,
+		client_teardown_internal,
+		client
+	) : 1;
 
 }
 

--- a/src/cerver/connection.c
+++ b/src/cerver/connection.c
@@ -32,63 +32,63 @@ void connection_remove_auth_data (Connection *connection);
 
 ConnectionStats *connection_stats_new (void) {
 
-    ConnectionStats *stats = (ConnectionStats *) malloc (sizeof (ConnectionStats));
-    if (stats) {
-        memset (stats, 0, sizeof (ConnectionStats));
-        stats->received_packets = packets_per_type_new ();
-        stats->sent_packets = packets_per_type_new ();
-    }
+	ConnectionStats *stats = (ConnectionStats *) malloc (sizeof (ConnectionStats));
+	if (stats) {
+		memset (stats, 0, sizeof (ConnectionStats));
+		stats->received_packets = packets_per_type_new ();
+		stats->sent_packets = packets_per_type_new ();
+	}
 
-    return stats;
+	return stats;
 
 }
 
 static inline void connection_stats_delete (ConnectionStats *stats) {
 
-    if (stats) {
-        packets_per_type_delete (stats->received_packets);
-        packets_per_type_delete (stats->sent_packets);
+	if (stats) {
+		packets_per_type_delete (stats->received_packets);
+		packets_per_type_delete (stats->sent_packets);
 
-        free (stats);
-    }
+		free (stats);
+	}
 
 }
 
 void connection_stats_print (Connection *connection) {
 
-    if (connection) {
-        if (connection->stats) {
-            printf ("Threshold time:            %ld\n", connection->stats->threshold_time);
+	if (connection) {
+		if (connection->stats) {
+			printf ("Threshold time:            %ld\n", connection->stats->threshold_time);
 
-            printf ("N receives done:           %ld\n", connection->stats->n_receives_done);
+			printf ("N receives done:           %ld\n", connection->stats->n_receives_done);
 
-            printf ("Total bytes received:      %ld\n", connection->stats->total_bytes_received);
-            printf ("Total bytes sent:          %ld\n", connection->stats->total_bytes_sent);
+			printf ("Total bytes received:      %ld\n", connection->stats->total_bytes_received);
+			printf ("Total bytes sent:          %ld\n", connection->stats->total_bytes_sent);
 
-            printf ("N packets received:        %ld\n", connection->stats->n_packets_received);
-            printf ("N packets sent:            %ld\n", connection->stats->n_packets_sent);
+			printf ("N packets received:        %ld\n", connection->stats->n_packets_received);
+			printf ("N packets sent:            %ld\n", connection->stats->n_packets_sent);
 
-            printf ("\nReceived packets:\n");
-            packets_per_type_print (connection->stats->received_packets);
+			printf ("\nReceived packets:\n");
+			packets_per_type_print (connection->stats->received_packets);
 
-            printf ("\nSent packets:\n");
-            packets_per_type_print (connection->stats->sent_packets);
-        }
+			printf ("\nSent packets:\n");
+			packets_per_type_print (connection->stats->sent_packets);
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                "Connection does not have a reference to a connection stats!"
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_NONE,
+				"Connection does not have a reference to a connection stats!"
+			);
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_WARNING, LOG_TYPE_NONE,
-            "Can't get stats of a NULL connection!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_WARNING, LOG_TYPE_NONE,
+			"Can't get stats of a NULL connection!"
+		);
+	}
 
 }
 
@@ -98,190 +98,190 @@ void connection_stats_print (Connection *connection) {
 
 Connection *connection_new (void) {
 
-    Connection *connection = (Connection *) malloc (sizeof (Connection));
-    if (connection) {
-        connection->name = NULL;
+	Connection *connection = (Connection *) malloc (sizeof (Connection));
+	if (connection) {
+		connection->name = NULL;
 
-        connection->socket = NULL;
-        connection->port = 0;
-        connection->protocol = DEFAULT_CONNECTION_PROTOCOL;
-        connection->use_ipv6 = false;
+		connection->socket = NULL;
+		connection->port = 0;
+		connection->protocol = DEFAULT_CONNECTION_PROTOCOL;
+		connection->use_ipv6 = false;
 
-        connection->ip = NULL;
-        memset (&connection->address, 0, sizeof (struct sockaddr_storage));
+		connection->ip = NULL;
+		memset (&connection->address, 0, sizeof (struct sockaddr_storage));
 
-        connection->connected_timestamp = 0;
+		connection->connected_timestamp = 0;
 
-        connection->cerver_report = NULL;
+		connection->cerver_report = NULL;
 
-        connection->max_sleep = DEFAULT_CONNECTION_MAX_SLEEP;
-        connection->active = false;
-        connection->updating = false;
+		connection->max_sleep = DEFAULT_CONNECTION_MAX_SLEEP;
+		connection->active = false;
+		connection->updating = false;
 
-        connection->auth_tries = DEFAULT_AUTH_TRIES;
-        connection->bad_packets = 0;
+		connection->auth_tries = DEFAULT_AUTH_TRIES;
+		connection->bad_packets = 0;
 
-        connection->receive_packet_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
-        connection->sock_receive = NULL;
+		connection->receive_packet_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
+		connection->sock_receive = NULL;
 
-        connection->update_thread_id = 0;
-        connection->update_timeout = DEFAULT_CONNECTION_TIMEOUT;
+		connection->update_thread_id = 0;
+		connection->update_timeout = DEFAULT_CONNECTION_TIMEOUT;
 
-        connection->full_packet = false;
+		connection->full_packet = false;
 
-        connection->received_data = NULL;
-        connection->received_data_size = 0;
-        connection->received_data_delete = NULL;
+		connection->received_data = NULL;
+		connection->received_data_size = 0;
+		connection->received_data_delete = NULL;
 
-        connection->receive_packets = true;
-        connection->custom_receive = NULL;
-        connection->custom_receive_args = NULL;
-        connection->custom_receive_args_delete = NULL;
+		connection->receive_packets = true;
+		connection->custom_receive = NULL;
+		connection->custom_receive_args = NULL;
+		connection->custom_receive_args_delete = NULL;
 
-        connection->authenticated = false;
-        connection->auth_data = NULL;
-        connection->auth_data_size = 0;
-        connection->delete_auth_data = NULL;
-        connection->admin_auth = false;
-        connection->auth_packet = NULL;
+		connection->authenticated = false;
+		connection->auth_data = NULL;
+		connection->auth_data_size = 0;
+		connection->delete_auth_data = NULL;
+		connection->admin_auth = false;
+		connection->auth_packet = NULL;
 
-        connection->stats = NULL;
+		connection->stats = NULL;
 
-        connection->cond = NULL;
-        connection->mutex = NULL;
-    }
+		connection->cond = NULL;
+		connection->mutex = NULL;
+	}
 
-    return connection;
+	return connection;
 
 }
 
 void connection_delete (void *ptr) {
 
-    if (ptr) {
-        Connection *connection = (Connection *) ptr;
+	if (ptr) {
+		Connection *connection = (Connection *) ptr;
 
-        str_delete (connection->name);
+		str_delete (connection->name);
 
-        socket_delete (connection->socket);
+		socket_delete (connection->socket);
 
-        if (connection->active) connection_end (connection);
+		if (connection->active) connection_end (connection);
 
-        str_delete (connection->ip);
+		str_delete (connection->ip);
 
-        cerver_report_delete (connection->cerver_report);
+		cerver_report_delete (connection->cerver_report);
 
-        sock_receive_delete (connection->sock_receive);
+		sock_receive_delete (connection->sock_receive);
 
-        if (connection->received_data && connection->received_data_delete)
-            connection->received_data_delete (connection->received_data);
+		if (connection->received_data && connection->received_data_delete)
+			connection->received_data_delete (connection->received_data);
 
-        if (connection->custom_receive_args) {
-            if (connection->custom_receive_args_delete) {
-                connection->custom_receive_args_delete (connection->custom_receive_args);
-            }
-        }
+		if (connection->custom_receive_args) {
+			if (connection->custom_receive_args_delete) {
+				connection->custom_receive_args_delete (connection->custom_receive_args);
+			}
+		}
 
-        connection_remove_auth_data (connection);
+		connection_remove_auth_data (connection);
 
-        connection_stats_delete (connection->stats);
+		connection_stats_delete (connection->stats);
 
-        pthread_cond_delete (connection->cond);
-        pthread_mutex_delete (connection->mutex);
+		pthread_cond_delete (connection->cond);
+		pthread_mutex_delete (connection->mutex);
 
-        free (connection);
-    }
+		free (connection);
+	}
 
 }
 
 Connection *connection_create_empty (void) {
 
-    Connection *connection = connection_new ();
-    if (connection) {
-        connection->name = str_new ("no-name");
+	Connection *connection = connection_new ();
+	if (connection) {
+		connection->name = str_new ("no-name");
 
-        connection->socket = (Socket *) socket_create_empty ();
-        connection->sock_receive = sock_receive_new ();
-        connection->stats = connection_stats_new ();
-    }
+		connection->socket = (Socket *) socket_create_empty ();
+		connection->sock_receive = sock_receive_new ();
+		connection->stats = connection_stats_new ();
+	}
 
-    return connection;
+	return connection;
 
 }
 
 Connection *connection_create (const i32 sock_fd, const struct sockaddr_storage address,
-    Protocol protocol) {
+	Protocol protocol) {
 
-    Connection *connection = connection_create_empty ();
-    if (connection) {
-        connection->socket->sock_fd = sock_fd;
-        memcpy (&connection->address, &address, sizeof (struct sockaddr_storage));
-        connection->protocol = protocol;
+	Connection *connection = connection_create_empty ();
+	if (connection) {
+		connection->socket->sock_fd = sock_fd;
+		memcpy (&connection->address, &address, sizeof (struct sockaddr_storage));
+		connection->protocol = protocol;
 
-        connection_get_values (connection);
-    }
+		connection_get_values (connection);
+	}
 
-    return connection;
+	return connection;
 
 }
 
 // compare two connections by their socket fds
 int connection_comparator (const void *a, const void *b) {
 
-    if (a && b) {
-        Connection *con_a = (Connection *) a;
-        Connection *con_b = (Connection *) b;
+	if (a && b) {
+		Connection *con_a = (Connection *) a;
+		Connection *con_b = (Connection *) b;
 
-        if (con_a->socket && con_b->socket) {
-            if (con_a->socket->sock_fd < con_b->socket->sock_fd) return -1;
-            else if (con_a->socket->sock_fd == con_b->socket->sock_fd) return 0;
-            else return 1;
-        }
-    }
+		if (con_a->socket && con_b->socket) {
+			if (con_a->socket->sock_fd < con_b->socket->sock_fd) return -1;
+			else if (con_a->socket->sock_fd == con_b->socket->sock_fd) return 0;
+			else return 1;
+		}
+	}
 
-    return -1;
+	return -1;
 
 }
 
 // sets the connection's name, if it had a name before, it will be replaced
 void connection_set_name (Connection *connection, const char *name) {
 
-    if (connection) {
-        if (connection->name) str_delete (connection->name);
-        connection->name = name ? str_new (name) : NULL;
-    }
+	if (connection) {
+		if (connection->name) str_delete (connection->name);
+		connection->name = name ? str_new (name) : NULL;
+	}
 
 }
 
 // get from where the client is connecting
 void connection_get_values (Connection *connection) {
 
-    if (connection) {
-        connection->ip = str_new (sock_ip_to_string ((const struct sockaddr *) &connection->address));
-        connection->port = sock_ip_port ((const struct sockaddr *) &connection->address);
-    }
+	if (connection) {
+		connection->ip = str_new (sock_ip_to_string ((const struct sockaddr *) &connection->address));
+		connection->port = sock_ip_port ((const struct sockaddr *) &connection->address);
+	}
 
 }
 
 // sets the connection's newtwork values
 void connection_set_values (Connection *connection,
-    const char *ip_address, u16 port, Protocol protocol, bool use_ipv6) {
+	const char *ip_address, u16 port, Protocol protocol, bool use_ipv6) {
 
-    if (connection) {
-        if (connection->ip) str_delete (connection->ip);
-        connection->ip = ip_address ? str_new (ip_address) : NULL;
-        connection->port = port;
-        connection->protocol = protocol;
-        connection->use_ipv6 = use_ipv6;
+	if (connection) {
+		if (connection->ip) str_delete (connection->ip);
+		connection->ip = ip_address ? str_new (ip_address) : NULL;
+		connection->port = port;
+		connection->protocol = protocol;
+		connection->use_ipv6 = use_ipv6;
 
-        connection->active = false;
-    }
+		connection->active = false;
+	}
 
 }
 
 // sets the connection max sleep (wait time) to try to connect to the cerver
 void connection_set_max_sleep (Connection *connection, u32 max_sleep) {
 
-    if (connection) connection->max_sleep = max_sleep;
+	if (connection) connection->max_sleep = max_sleep;
 
 }
 
@@ -289,7 +289,7 @@ void connection_set_max_sleep (Connection *connection, u32 max_sleep) {
 // if true, a new thread is created that handled incoming packets
 void connection_set_receive (Connection *connection, bool receive) {
 
-    if (connection) connection->receive_packets = receive;
+	if (connection) connection->receive_packets = receive;
 
 }
 
@@ -297,7 +297,7 @@ void connection_set_receive (Connection *connection, bool receive) {
 // by default the value RECEIVE_PACKET_BUFFER_SIZE is used
 void connection_set_receive_buffer_size (Connection *connection, u32 size) {
 
-    if (connection) connection->receive_packet_buffer_size = size;
+	if (connection) connection->receive_packet_buffer_size = size;
 
 }
 
@@ -306,7 +306,7 @@ void connection_set_receive_buffer_size (Connection *connection, u32 size) {
 // note that this only has effect in connection_update ()
 void connection_set_update_timeout (Connection *connection, u32 timeout) {
 
-    if (connection) connection->update_timeout = timeout;
+	if (connection) connection->update_timeout = timeout;
 
 }
 
@@ -314,11 +314,11 @@ void connection_set_update_timeout (Connection *connection, u32 timeout) {
 // 01/01/2020 - a place to safely store the request response, like when using client_connection_request_to_cerver ()
 void connection_set_received_data (Connection *connection, void *data, size_t data_size, Action data_delete) {
 
-    if (connection) {
-        connection->received_data = data;
-        connection->received_data_size = data_size;
-        connection->received_data_delete = data_delete;
-    }
+	if (connection) {
+		connection->received_data = data;
+		connection->received_data_size = data_size;
+		connection->received_data_delete = data_delete;
+	}
 
 }
 
@@ -326,17 +326,17 @@ void connection_set_received_data (Connection *connection, void *data, size_t da
 // a reference to the client and connection will be passed to the action as ClientConnection structure
 // the method must return 0 on success & 1 on error
 void connection_set_custom_receive (
-    Connection *connection, 
-    delegate custom_receive, 
-    void *args, void (*args_delete)(void *)
+	Connection *connection,
+	delegate custom_receive,
+	void *args, void (*args_delete)(void *)
 ) {
 
-    if (connection) {
-        connection->custom_receive = custom_receive;
-        connection->custom_receive_args = args;
-        connection->custom_receive_args_delete = args_delete;
-        if (connection->custom_receive) connection->receive_packets = true;
-    }
+	if (connection) {
+		connection->custom_receive = custom_receive;
+		connection->custom_receive_args = args;
+		connection->custom_receive_args_delete = args_delete;
+		if (connection->custom_receive) connection->receive_packets = true;
+	}
 
 }
 
@@ -344,19 +344,19 @@ void connection_set_custom_receive (
 // and a method to destroy it once the connection has ended,
 // if delete_auth_data is NULL, the auth data won't be deleted
 void connection_set_auth_data (
-    Connection *connection,
-    void *auth_data, size_t auth_data_size, Action delete_auth_data,
-    bool admin_auth
+	Connection *connection,
+	void *auth_data, size_t auth_data_size, Action delete_auth_data,
+	bool admin_auth
 ) {
 
-    if (connection && auth_data) {
-        connection_remove_auth_data (connection);
+	if (connection && auth_data) {
+		connection_remove_auth_data (connection);
 
-        connection->auth_data = auth_data;
-        connection->auth_data_size = auth_data_size;
-        connection->delete_auth_data = delete_auth_data;
-        connection->admin_auth = admin_auth;
-    }
+		connection->auth_data = auth_data;
+		connection->auth_data_size = auth_data_size;
+		connection->delete_auth_data = delete_auth_data;
+		connection->admin_auth = admin_auth;
+	}
 
 }
 
@@ -365,21 +365,21 @@ void connection_set_auth_data (
 // the connection's auth data & delete method will be equal to NULL
 void connection_remove_auth_data (Connection *connection) {
 
-    if (connection) {
-        if (connection->auth_data) {
-            if (connection->delete_auth_data)
-                connection->delete_auth_data (connection->auth_data);
-        }
+	if (connection) {
+		if (connection->auth_data) {
+			if (connection->delete_auth_data)
+				connection->delete_auth_data (connection->auth_data);
+		}
 
-        if (connection->auth_packet) {
-            packet_delete (connection->auth_packet);
-            connection->auth_packet = NULL;
-        }
+		if (connection->auth_packet) {
+			packet_delete (connection->auth_packet);
+			connection->auth_packet = NULL;
+		}
 
-        connection->auth_data = NULL;
-        connection->auth_data_size = 0;
-        connection->delete_auth_data = NULL;
-    }
+		connection->auth_data = NULL;
+		connection->auth_data_size = 0;
+		connection->delete_auth_data = NULL;
+	}
 
 }
 
@@ -388,111 +388,111 @@ void connection_remove_auth_data (Connection *connection) {
 // returns 0 on success, 1 on error
 u8 connection_generate_auth_packet (Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (connection) {
-        if (connection->auth_data) {
-            connection->auth_packet = packet_generate_request (
-                PACKET_TYPE_AUTH,
-                connection->admin_auth ? AUTH_PACKET_TYPE_ADMIN_AUTH : AUTH_PACKET_TYPE_CLIENT_AUTH,
-                connection->auth_data, connection->auth_data_size
-            );
+	if (connection) {
+		if (connection->auth_data) {
+			connection->auth_packet = packet_generate_request (
+				PACKET_TYPE_AUTH,
+				connection->admin_auth ? AUTH_PACKET_TYPE_ADMIN_AUTH : AUTH_PACKET_TYPE_CLIENT_AUTH,
+				connection->auth_data, connection->auth_data_size
+			);
 
-            if (connection->auth_packet) retval = 0;
-        }
-    }
+			if (connection->auth_packet) retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sets up the new connection values
 u8 connection_init (Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (connection) {
-        if (!connection->active) {
-            // init the new connection socket
-            switch (connection->protocol) {
-                case IPPROTO_TCP:
-                    connection->socket->sock_fd = socket ((connection->use_ipv6 == 1 ? AF_INET6 : AF_INET), SOCK_STREAM, 0);
-                    break;
-                case IPPROTO_UDP:
-                    connection->socket->sock_fd = socket ((connection->use_ipv6 == 1 ? AF_INET6 : AF_INET), SOCK_DGRAM, 0);
-                    break;
+	if (connection) {
+		if (!connection->active) {
+			// init the new connection socket
+			switch (connection->protocol) {
+				case IPPROTO_TCP:
+					connection->socket->sock_fd = socket ((connection->use_ipv6 == 1 ? AF_INET6 : AF_INET), SOCK_STREAM, 0);
+					break;
+				case IPPROTO_UDP:
+					connection->socket->sock_fd = socket ((connection->use_ipv6 == 1 ? AF_INET6 : AF_INET), SOCK_DGRAM, 0);
+					break;
 
-                default: cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Unkonw protocol type!"); return 1;
-            }
+				default: cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Unkonw protocol type!"); return 1;
+			}
 
-            if (connection->socket->sock_fd > 0) {
-                // if (connection->async) {
-                //     if (sock_set_blocking (connection->sock_fd, connection->blocking)) {
-                //         connection->blocking = false;
+			if (connection->socket->sock_fd > 0) {
+				// if (connection->async) {
+				//     if (sock_set_blocking (connection->sock_fd, connection->blocking)) {
+				//         connection->blocking = false;
 
-                        // get the address ready
-                        if (connection->use_ipv6) {
-                            struct sockaddr_in6 *addr = (struct sockaddr_in6 *) &connection->address;
-                            addr->sin6_family = AF_INET6;
-                            addr->sin6_addr = in6addr_any;
-                            addr->sin6_port = htons (connection->port);
-                        }
+						// get the address ready
+						if (connection->use_ipv6) {
+							struct sockaddr_in6 *addr = (struct sockaddr_in6 *) &connection->address;
+							addr->sin6_family = AF_INET6;
+							addr->sin6_addr = in6addr_any;
+							addr->sin6_port = htons (connection->port);
+						}
 
-                        else {
-                            struct sockaddr_in *addr = (struct sockaddr_in *) &connection->address;
-                            addr->sin_family = AF_INET;
-                            addr->sin_addr.s_addr = inet_addr (connection->ip->str);
-                            addr->sin_port = htons (connection->port);
-                        }
+						else {
+							struct sockaddr_in *addr = (struct sockaddr_in *) &connection->address;
+							addr->sin_family = AF_INET;
+							addr->sin_addr.s_addr = inet_addr (connection->ip->str);
+							addr->sin_port = htons (connection->port);
+						}
 
-                        retval = 0;     // connection setup was successfull
-                    // }
+						retval = 0;     // connection setup was successfull
+					// }
 
-                    // else {
-                    //     #ifdef CLIENT_DEBUG
-                    //     cengine_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                    //         "Failed to set the socket to non blocking mode!");
-                    //     #endif
-                    //     close (connection->sock_fd);
-                //     }
-                // }
-            }
+					// else {
+					//     #ifdef CLIENT_DEBUG
+					//     cengine_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					//         "Failed to set the socket to non blocking mode!");
+					//     #endif
+					//     close (connection->sock_fd);
+				//     }
+				// }
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                    "Failed to create new socket!"
-                );
-            }
-        }
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					"Failed to create new socket!"
+				);
+			}
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_NONE,
-                "Failed to init connection -- it is already active!"
-            );
-        }
+		else {
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_NONE,
+				"Failed to init connection -- it is already active!"
+			);
+		}
 
-    }
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // try to connect a client to an address (server) with exponential backoff
 static u8 connection_try (Connection *connection, const struct sockaddr_storage address) {
 
-    u32 numsec;
-    for (numsec = 2; numsec <= connection->max_sleep; numsec <<= 1) {
-        if (!connect (connection->socket->sock_fd,
-            (const struct sockaddr *) &address,
-            sizeof (struct sockaddr)))
-            return 0;
+	u32 numsec;
+	for (numsec = 2; numsec <= connection->max_sleep; numsec <<= 1) {
+		if (!connect (connection->socket->sock_fd,
+			(const struct sockaddr *) &address,
+			sizeof (struct sockaddr)))
+			return 0;
 
-        if (numsec <= connection->max_sleep / 2) sleep (numsec);
-    }
+		if (numsec <= connection->max_sleep / 2) sleep (numsec);
+	}
 
-    return 1;
+	return 1;
 
 }
 
@@ -500,112 +500,112 @@ static u8 connection_try (Connection *connection, const struct sockaddr_storage 
 // returns 0 on success, 1 on error
 int connection_connect (Connection *connection) {
 
-    return (connection ? connection_try (connection, connection->address) : 1);
+	return (connection ? connection_try (connection, connection->address) : 1);
 
 }
 
 // ends a connection
 void connection_end (Connection *connection) {
 
-    if (connection) {
-        if (connection->active) {
-            close (connection->socket->sock_fd);
-            connection->socket->sock_fd = -1;
-            connection->active = false;
-        }
-    }
+	if (connection) {
+		if (connection->active) {
+			close (connection->socket->sock_fd);
+			connection->socket->sock_fd = -1;
+			connection->active = false;
+		}
+	}
 
 }
 
 void connection_drop (Cerver *cerver, Connection *connection) {
 
-    if (connection) {
-        // close the socket
-        connection_end (connection);
+	if (connection) {
+		// close the socket
+		connection_end (connection);
 
-        if (cerver) {
-            // move the socket to the cerver's socket pool to avoid destroying it
-            // to handle if any other thread is waiting to access the socket's mutex
-            cerver_sockets_pool_push (cerver, connection->socket);
-            connection->socket = NULL;
-        }
+		if (cerver) {
+			// move the socket to the cerver's socket pool to avoid destroying it
+			// to handle if any other thread is waiting to access the socket's mutex
+			cerver_sockets_pool_push (cerver, connection->socket);
+			connection->socket = NULL;
+		}
 
-        connection_delete (connection);
-    }
+		connection_delete (connection);
+	}
 
 }
 
 // gets the connection from the on hold connections map in cerver
 Connection *connection_get_by_sock_fd_from_on_hold (Cerver *cerver, const i32 sock_fd) {
 
-    Connection *connection = NULL;
+	Connection *connection = NULL;
 
-    if (cerver) {
-        const i32 *key = &sock_fd;
-        void *connection_data = htab_get (
-            cerver->on_hold_connection_sock_fd_map,
-            key, sizeof (i32)
-        );
+	if (cerver) {
+		const i32 *key = &sock_fd;
+		void *connection_data = htab_get (
+			cerver->on_hold_connection_sock_fd_map,
+			key, sizeof (i32)
+		);
 
-        if (connection_data) connection = (Connection *) connection_data;
-    }
+		if (connection_data) connection = (Connection *) connection_data;
+	}
 
-    return connection;
+	return connection;
 
 }
 
 // gets the connection from the client by its sock fd
 Connection *connection_get_by_sock_fd_from_client (Client *client, const i32 sock_fd) {
 
-    Connection *retval = NULL;
+	Connection *retval = NULL;
 
-    if (client) {
-        Connection *con = NULL;
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            con = (Connection *) le->data;
-            if (con->socket->sock_fd == sock_fd) {
-                retval = con;
-                break;
-            }
-        }
-    }
+	if (client) {
+		Connection *con = NULL;
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			con = (Connection *) le->data;
+			if (con->socket->sock_fd == sock_fd) {
+				retval = con;
+				break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets the connection from the admin cerver by its sock fd
 Connection *connection_get_by_sock_fd_from_admin (AdminCerver *admin_cerver, const i32 sock_fd) {
 
-    Connection *retval = NULL;
+	Connection *retval = NULL;
 
-    if (admin_cerver) {
-        Connection *con = NULL;
-        for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
-            for (ListElement *le_sub = dlist_start (((Admin *) le->data)->client->connections); le_sub; le_sub = le_sub->next) {
-                con = (Connection *) le_sub->data;
-                if (con->socket->sock_fd == sock_fd) {
-                    retval = con;
-                    break;
-                }
-            }
-        }
-    }
+	if (admin_cerver) {
+		Connection *con = NULL;
+		for (ListElement *le = dlist_start (admin_cerver->admins); le; le = le->next) {
+			for (ListElement *le_sub = dlist_start (((Admin *) le->data)->client->connections); le_sub; le_sub = le_sub->next) {
+				con = (Connection *) le_sub->data;
+				if (con->socket->sock_fd == sock_fd) {
+					retval = con;
+					break;
+				}
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // checks if the connection belongs to the client
 bool connection_check_owner (Client *client, Connection *connection) {
 
-    if (client && connection) {
-        for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-            if (connection->socket->sock_fd == ((Connection *) le->data)->socket->sock_fd) return true;
-        }
-    }
+	if (client && connection) {
+		for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+			if (connection->socket->sock_fd == ((Connection *) le->data)->socket->sock_fd) return true;
+		}
+	}
 
-    return false;
+	return false;
 
 }
 
@@ -613,33 +613,33 @@ bool connection_check_owner (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 connection_register_to_client (Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (client && connection) {
-        if (!dlist_insert_after (client->connections, dlist_end (client->connections), connection)) {
-            #ifdef CERVER_DEBUG
-            if (client->session_id) {
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-                    "Registered a new connection to client with session id: %s",
-                    client->session_id->str
-                );
-            }
+	if (client && connection) {
+		if (!dlist_insert_after (client->connections, dlist_end (client->connections), connection)) {
+			#ifdef CERVER_DEBUG
+			if (client->session_id) {
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+					"Registered a new connection to client with session id: %s",
+					client->session_id->str
+				);
+			}
 
-            else {
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-                    "Registered a new connection to client (id): %ld",
-                    client->id
-                );
-            }
-            #endif
+			else {
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
+					"Registered a new connection to client (id): %ld",
+					client->id
+				);
+			}
+			#endif
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -647,16 +647,16 @@ u8 connection_register_to_client (Client *client, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 connection_register_to_cerver (Cerver *cerver, Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client && connection) {
-        // map the socket fd with the client
-        const void *key = &connection->socket->sock_fd;
-        retval = (u8) htab_insert (cerver->client_sock_fd_map, key, sizeof (i32),
-            client, sizeof (Client));
-    }
+	if (cerver && client && connection) {
+		// map the socket fd with the client
+		const void *key = &connection->socket->sock_fd;
+		retval = (u8) htab_insert (cerver->client_sock_fd_map, key, sizeof (i32),
+			client, sizeof (Client));
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -664,32 +664,32 @@ u8 connection_register_to_cerver (Cerver *cerver, Client *client, Connection *co
 // returns 0 on success, 1 on error
 u8 connection_unregister_from_cerver (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        // remove the sock fd from each map
-        const void *key = &connection->socket->sock_fd;
-        if (htab_remove (cerver->client_sock_fd_map, key, sizeof (i32))) {
-            // cerver_log_success (
-            // 	"Removed sock fd %d from cerver's %s client sock map.",
-            //     connection->socket->sock_fd, cerver->info->name->str
-            // );
+	if (cerver && connection) {
+		// remove the sock fd from each map
+		const void *key = &connection->socket->sock_fd;
+		if (htab_remove (cerver->client_sock_fd_map, key, sizeof (i32))) {
+			// cerver_log_success (
+			// 	"Removed sock fd %d from cerver's %s client sock map.",
+			//     connection->socket->sock_fd, cerver->info->name->str
+			// );
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-                "Failed to remove sock fd %d from cerver's %s client sock map.",
-                connection->socket->sock_fd, cerver->info->name->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Failed to remove sock fd %d from cerver's %s client sock map.",
+				connection->socket->sock_fd, cerver->info->name->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -698,8 +698,8 @@ u8 connection_unregister_from_cerver (Cerver *cerver, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 connection_register_to_cerver_poll (Cerver *cerver, Connection *connection) {
 
-    return (cerver && connection) ?
-        cerver_poll_register_connection (cerver, connection) : 1;
+	return (cerver && connection) ?
+		cerver_poll_register_connection (cerver, connection) : 1;
 
 }
 
@@ -708,8 +708,8 @@ u8 connection_register_to_cerver_poll (Cerver *cerver, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 connection_unregister_from_cerver_poll (Cerver *cerver, Connection *connection) {
 
-    return (cerver && connection) ?
-        cerver_poll_unregister_connection (cerver, connection) : 1;
+	return (cerver && connection) ?
+		cerver_poll_unregister_connection (cerver, connection) : 1;
 
 }
 
@@ -719,15 +719,15 @@ u8 connection_unregister_from_cerver_poll (Cerver *cerver, Connection *connectio
 // returns 0 on success, 1 on error
 u8 connection_add_to_cerver (Cerver *cerver, Client *client, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client && connection) {
-        if (!connection_register_to_cerver_poll (cerver, connection)) {
-            retval = connection_register_to_cerver (cerver, client, connection);
-        }
-    }
+	if (cerver && client && connection) {
+		if (!connection_register_to_cerver_poll (cerver, connection)) {
+			retval = connection_register_to_cerver (cerver, client, connection);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -737,21 +737,21 @@ u8 connection_add_to_cerver (Cerver *cerver, Client *client, Connection *connect
 // returns 0 on success, 1 on error
 u8 connection_remove_from_cerver (Cerver *cerver, Connection *connection) {
 
-    u8 errors = 0;
+	u8 errors = 0;
 
-    if (cerver && connection) {
-        switch (cerver->handler_type) {
-            case CERVER_HANDLER_TYPE_POLL:
-                errors |= connection_unregister_from_cerver_poll (cerver, connection);
-                break;
+	if (cerver && connection) {
+		switch (cerver->handler_type) {
+			case CERVER_HANDLER_TYPE_POLL:
+				errors |= connection_unregister_from_cerver_poll (cerver, connection);
+				break;
 
-            default: break;
-        }
+			default: break;
+		}
 
-        errors |= connection_unregister_from_cerver (cerver, connection);
-    }
+		errors |= connection_unregister_from_cerver (cerver, connection);
+	}
 
-    return errors;
+	return errors;
 
 }
 
@@ -760,74 +760,74 @@ u8 connection_remove_from_cerver (Cerver *cerver, Connection *connection) {
 #pragma region receive
 
 static ConnectionCustomReceiveData *connection_custom_receive_data_new (
-    Client *client, Connection *connection, 
-    void *args
+	Client *client, Connection *connection,
+	void *args
 ) {
 
-    ConnectionCustomReceiveData *custom_data = (ConnectionCustomReceiveData *) malloc (sizeof (ConnectionCustomReceiveData));
-    if (custom_data) {
-        custom_data->client = client;
-        custom_data->connection = connection;
-        custom_data->args = args;
-    }
+	ConnectionCustomReceiveData *custom_data = (ConnectionCustomReceiveData *) malloc (sizeof (ConnectionCustomReceiveData));
+	if (custom_data) {
+		custom_data->client = client;
+		custom_data->connection = connection;
+		custom_data->args = args;
+	}
 
-    return custom_data;
+	return custom_data;
 
 }
 
 static inline void connection_custom_receive_data_delete (void *custom_data_ptr) {
 
-    if (custom_data_ptr) free (custom_data_ptr);
+	if (custom_data_ptr) free (custom_data_ptr);
 
 }
 
 // starts listening and receiving data in the connection sock
 void connection_update (void *ptr) {
 
-    if (ptr) {
-        ClientConnection *cc = (ClientConnection *) ptr;
-        // thread_set_name (c_string_create ("connection-%s", cc->connection->name->str));
+	if (ptr) {
+		ClientConnection *cc = (ClientConnection *) ptr;
+		// thread_set_name (c_string_create ("connection-%s", cc->connection->name->str));
 
-        ConnectionCustomReceiveData *custom_data = connection_custom_receive_data_new (
-            cc->client, cc->connection,
-            cc->connection->custom_receive_args
-        );
+		ConnectionCustomReceiveData *custom_data = connection_custom_receive_data_new (
+			cc->client, cc->connection,
+			cc->connection->custom_receive_args
+		);
 
-        if (!cc->connection->sock_receive) cc->connection->sock_receive = sock_receive_new ();
+		if (!cc->connection->sock_receive) cc->connection->sock_receive = sock_receive_new ();
 
-        (void) sock_set_timeout (cc->connection->socket->sock_fd, cc->connection->update_timeout);
+		(void) sock_set_timeout (cc->connection->socket->sock_fd, cc->connection->update_timeout);
 
-        cc->connection->updating = true;
+		cc->connection->updating = true;
 
-        while (cc->client->running && cc->connection->active) {
-            // pthread_mutex_lock (cc->client->lock);
+		while (cc->client->running && cc->connection->active) {
+			// pthread_mutex_lock (cc->client->lock);
 
-            if (cc->connection->custom_receive) {
-                // if a custom receive method is set, use that one directly
-                if (cc->connection->custom_receive (custom_data)) {
-                    // break;      // an error has ocurred
-                }
-            }
+			if (cc->connection->custom_receive) {
+				// if a custom receive method is set, use that one directly
+				if (cc->connection->custom_receive (custom_data)) {
+					// break;      // an error has ocurred
+				}
+			}
 
-            else {
-                // use the default receive method that expects cerver type packages
-                if (client_receive (cc->client, cc->connection)) {
-                    // break;      // an error has ocurred
-                }
-            }
+			else {
+				// use the default receive method that expects cerver type packages
+				if (client_receive (cc->client, cc->connection)) {
+					// break;      // an error has ocurred
+				}
+			}
 
-            // pthread_mutex_unlock (cc->client->lock);
-        }
+			// pthread_mutex_unlock (cc->client->lock);
+		}
 
-        // signal waiting thread
-        pthread_mutex_lock (cc->connection->mutex);
-        cc->connection->updating = false;
-        pthread_cond_signal (cc->connection->cond);
-        pthread_mutex_unlock (cc->connection->mutex);
+		// signal waiting thread
+		pthread_mutex_lock (cc->connection->mutex);
+		cc->connection->updating = false;
+		pthread_cond_signal (cc->connection->cond);
+		pthread_mutex_unlock (cc->connection->mutex);
 
-        connection_custom_receive_data_delete (custom_data);
-        client_connection_aux_delete (cc);
-    }
+		connection_custom_receive_data_delete (custom_data);
+		client_connection_aux_delete (cc);
+	}
 
 }
 

--- a/src/cerver/errors.c
+++ b/src/cerver/errors.c
@@ -22,13 +22,13 @@ u8 cerver_error_event_unregister (Cerver *cerver, const CerverErrorType error_ty
 // get the description for the current error type
 const char *cerver_error_type_description (CerverErrorType type) {
 
-    switch (type) {
-        #define XX(num, name, description) case CERVER_ERROR_##name: return #description;
-        CERVER_ERROR_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, description) case CERVER_ERROR_##name: return #description;
+		CERVER_ERROR_MAP(XX)
+		#undef XX
+	}
 
-    return cerver_error_type_description (CERVER_ERROR_UNKNOWN);
+	return cerver_error_type_description (CERVER_ERROR_UNKNOWN);
 
 }
 
@@ -38,52 +38,52 @@ const char *cerver_error_type_description (CerverErrorType type) {
 
 static CerverErrorEventData *cerver_error_event_data_new (void) {
 
-    CerverErrorEventData *error_event_data = (CerverErrorEventData *) malloc (sizeof (CerverErrorEventData));
-    if (error_event_data) {
-        error_event_data->cerver = NULL;
+	CerverErrorEventData *error_event_data = (CerverErrorEventData *) malloc (sizeof (CerverErrorEventData));
+	if (error_event_data) {
+		error_event_data->cerver = NULL;
 
-        error_event_data->client = NULL;
-        error_event_data->connection = NULL;
+		error_event_data->client = NULL;
+		error_event_data->connection = NULL;
 
-        error_event_data->action_args = NULL;
+		error_event_data->action_args = NULL;
 
-        error_event_data->error_message = NULL;
-    }
+		error_event_data->error_message = NULL;
+	}
 
-    return error_event_data;
+	return error_event_data;
 
 }
 
 void cerver_error_event_data_delete (CerverErrorEventData *error_event_data) {
 
-    if (error_event_data) {
-        str_delete (error_event_data->error_message);
+	if (error_event_data) {
+		str_delete (error_event_data->error_message);
 
-        free (error_event_data);
-    }
+		free (error_event_data);
+	}
 
 }
 
 static CerverErrorEventData *cerver_error_event_data_create (
-    const Cerver *cerver,
-    const Client *client, const Connection *connection,
-    void *action_args,
-    const char *error_message
+	const Cerver *cerver,
+	const Client *client, const Connection *connection,
+	void *action_args,
+	const char *error_message
 ) {
 
-    CerverErrorEventData *error_event_data = cerver_error_event_data_new ();
-    if (error_event_data) {
-        error_event_data->cerver = cerver;
+	CerverErrorEventData *error_event_data = cerver_error_event_data_new ();
+	if (error_event_data) {
+		error_event_data->cerver = cerver;
 
-        error_event_data->client = client;
-        error_event_data->connection = connection;
+		error_event_data->client = client;
+		error_event_data->connection = connection;
 
-        error_event_data->action_args = action_args;
+		error_event_data->action_args = action_args;
 
-        error_event_data->error_message = error_message ? str_new (error_message) : NULL;
-    }
+		error_event_data->error_message = error_message ? str_new (error_message) : NULL;
+	}
 
-    return error_event_data;
+	return error_event_data;
 
 }
 
@@ -93,34 +93,34 @@ static CerverErrorEventData *cerver_error_event_data_create (
 
 static CerverErrorEvent *cerver_error_event_new (void) {
 
-    CerverErrorEvent *cerver_error_event = (CerverErrorEvent *) malloc (sizeof (CerverErrorEvent));
-    if (cerver_error_event) {
-        cerver_error_event->type = CERVER_ERROR_NONE;
+	CerverErrorEvent *cerver_error_event = (CerverErrorEvent *) malloc (sizeof (CerverErrorEvent));
+	if (cerver_error_event) {
+		cerver_error_event->type = CERVER_ERROR_NONE;
 
-        cerver_error_event->create_thread = false;
-        cerver_error_event->drop_after_trigger = false;
+		cerver_error_event->create_thread = false;
+		cerver_error_event->drop_after_trigger = false;
 
-        cerver_error_event->action = NULL;
-        cerver_error_event->action_args = NULL;
-        cerver_error_event->delete_action_args = NULL;
-    }
+		cerver_error_event->action = NULL;
+		cerver_error_event->action_args = NULL;
+		cerver_error_event->delete_action_args = NULL;
+	}
 
-    return cerver_error_event;
+	return cerver_error_event;
 
 }
 
 void cerver_error_event_delete (void *event_ptr) {
 
-    if (event_ptr) {
-        CerverErrorEvent *event = (CerverErrorEvent *) event_ptr;
+	if (event_ptr) {
+		CerverErrorEvent *event = (CerverErrorEvent *) event_ptr;
 
-        if (event->action_args) {
-            if (event->delete_action_args)
-                event->delete_action_args (event->action_args);
-        }
+		if (event->action_args) {
+			if (event->delete_action_args)
+				event->delete_action_args (event->action_args);
+		}
 
-        free (event);
-    }
+		free (event);
+	}
 
 }
 
@@ -130,36 +130,36 @@ void cerver_error_event_delete (void *event_ptr) {
 // that should be free using the cerver_error_event_data_delete () method
 // returns 0 on success, 1 on error
 u8 cerver_error_event_register (
-    Cerver *cerver,
-    const CerverErrorType error_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	Cerver *cerver,
+	const CerverErrorType error_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        CerverErrorEvent *error = cerver_error_event_new ();
-        if (error) {
-            error->type = error_type;
+	if (cerver) {
+		CerverErrorEvent *error = cerver_error_event_new ();
+		if (error) {
+			error->type = error_type;
 
-            error->create_thread = create_thread;
-            error->drop_after_trigger = drop_after_trigger;
+			error->create_thread = create_thread;
+			error->drop_after_trigger = drop_after_trigger;
 
-            error->action = action;
-            error->action_args = action_args;
-            error->delete_action_args = delete_action_args;
+			error->action = action;
+			error->action_args = action_args;
+			error->delete_action_args = delete_action_args;
 
-            // search if there is an action already registred for that error and remove it
-            (void) cerver_error_event_unregister (cerver, error_type);
+			// search if there is an action already registred for that error and remove it
+			(void) cerver_error_event_unregister (cerver, error_type);
 
-            cerver->errors[error_type] = error;
+			cerver->errors[error_type] = error;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -168,63 +168,63 @@ u8 cerver_error_event_register (
 // returns 0 on success, 1 on error or if error is NOT registered
 u8 cerver_error_event_unregister (Cerver *cerver, const CerverErrorType error_type) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (cerver->errors[error_type]) {
-            cerver_error_event_delete (cerver->errors[error_type]);
-            cerver->errors[error_type] = NULL;
+	if (cerver) {
+		if (cerver->errors[error_type]) {
+			cerver_error_event_delete (cerver->errors[error_type]);
+			cerver->errors[error_type] = NULL;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // triggers all the actions that are registred to an error
 void cerver_error_event_trigger (
-    const CerverErrorType error_type,
-    const Cerver *cerver,
-    const Client *client, const Connection *connection,
-    const char *error_message
+	const CerverErrorType error_type,
+	const Cerver *cerver,
+	const Client *client, const Connection *connection,
+	const char *error_message
 ) {
 
-    if (cerver) {
-        CerverErrorEvent *error = cerver->errors[error_type];
-        if (error) {
-            // trigger the action
-            if (error->action) {
-                if (error->create_thread) {
-                    pthread_t thread_id = 0;
-                    thread_create_detachable (
-                        &thread_id,
-                        (void *(*)(void *)) error->action,
-                        cerver_error_event_data_create (
-                            cerver,
-                            client, connection,
-                            error->action_args,
-                            error_message
-                        )
-                    );
-                }
+	if (cerver) {
+		CerverErrorEvent *error = cerver->errors[error_type];
+		if (error) {
+			// trigger the action
+			if (error->action) {
+				if (error->create_thread) {
+					pthread_t thread_id = 0;
+					thread_create_detachable (
+						&thread_id,
+						(void *(*)(void *)) error->action,
+						cerver_error_event_data_create (
+							cerver,
+							client, connection,
+							error->action_args,
+							error_message
+						)
+					);
+				}
 
-                else {
-                    error->action (cerver_error_event_data_create (
-                        cerver,
-                        client, connection,
-                        error->action_args,
-                        error_message
-                    ));
-                }
+				else {
+					error->action (cerver_error_event_data_create (
+						cerver,
+						client, connection,
+						error->action_args,
+						error_message
+					));
+				}
 
-                if (error->drop_after_trigger) {
-                    (void) cerver_error_event_unregister ((Cerver *) cerver, error_type);
-                }
-            }
-        }
-    }
+				if (error->drop_after_trigger) {
+					(void) cerver_error_event_unregister ((Cerver *) cerver, error_type);
+				}
+			}
+		}
+	}
 
 }
 
@@ -236,52 +236,52 @@ void cerver_error_event_trigger (
 // handles error packets
 void cerver_error_packet_handler (Packet *packet) {
 
-    if (packet->data_size >= sizeof (SError)) {
-        char *end = (char *) packet->data;
-        SError *s_error = (SError *) end;
+	if (packet->data_size >= sizeof (SError)) {
+		char *end = (char *) packet->data;
+		SError *s_error = (SError *) end;
 
-        switch (s_error->error_type) {
-            case CERVER_ERROR_NONE: break;
+		switch (s_error->error_type) {
+			case CERVER_ERROR_NONE: break;
 
-            case CERVER_ERROR_PACKET_ERROR:
-                cerver_error_event_trigger (
-                    CERVER_ERROR_PACKET_ERROR,
-                    packet->cerver, packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CERVER_ERROR_PACKET_ERROR:
+				cerver_error_event_trigger (
+					CERVER_ERROR_PACKET_ERROR,
+					packet->cerver, packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            case CERVER_ERROR_GET_FILE:
-                cerver_error_event_trigger (
-                    CERVER_ERROR_GET_FILE,
-                    packet->cerver, packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CERVER_ERROR_SEND_FILE:
-                cerver_error_event_trigger (
-                    CERVER_ERROR_SEND_FILE,
-                    packet->cerver, packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
-            case CERVER_ERROR_FILE_NOT_FOUND:
-                client_error_trigger (
-                    CERVER_ERROR_FILE_NOT_FOUND,
-                    packet->client, packet->connection,
-                    s_error->msg
-                );
-                break;
+			case CERVER_ERROR_GET_FILE:
+				cerver_error_event_trigger (
+					CERVER_ERROR_GET_FILE,
+					packet->cerver, packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CERVER_ERROR_SEND_FILE:
+				cerver_error_event_trigger (
+					CERVER_ERROR_SEND_FILE,
+					packet->cerver, packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
+			case CERVER_ERROR_FILE_NOT_FOUND:
+				client_error_trigger (
+					CERVER_ERROR_FILE_NOT_FOUND,
+					packet->client, packet->connection,
+					s_error->msg
+				);
+				break;
 
-            default: {
-                cerver_error_event_trigger (
-                    CERVER_ERROR_UNKNOWN,
-                    packet->cerver, packet->client, packet->connection,
-                    s_error->msg
-                );
-            } break;
-        }
-    }
+			default: {
+				cerver_error_event_trigger (
+					CERVER_ERROR_UNKNOWN,
+					packet->cerver, packet->client, packet->connection,
+					s_error->msg
+				);
+			} break;
+		}
+	}
 
 }
 
@@ -292,50 +292,50 @@ void cerver_error_packet_handler (Packet *packet) {
 // creates an error packet ready to be sent
 Packet *error_packet_generate (const CerverErrorType type, const char *msg) {
 
-    Packet *packet = packet_new ();
-    if (packet) {
-        size_t packet_len = sizeof (PacketHeader) + sizeof (SError);
+	Packet *packet = packet_new ();
+	if (packet) {
+		size_t packet_len = sizeof (PacketHeader) + sizeof (SError);
 
-        packet->packet = malloc (packet_len);
-        packet->packet_size = packet_len;
+		packet->packet = malloc (packet_len);
+		packet->packet_size = packet_len;
 
-        char *end = (char *) packet->packet;
-        PacketHeader *header = (PacketHeader *) end;
-        header->packet_type = PACKET_TYPE_ERROR;
-        header->packet_size = packet_len;
+		char *end = (char *) packet->packet;
+		PacketHeader *header = (PacketHeader *) end;
+		header->packet_type = PACKET_TYPE_ERROR;
+		header->packet_size = packet_len;
 
-        header->request_type = REQUEST_PACKET_TYPE_NONE;
+		header->request_type = REQUEST_PACKET_TYPE_NONE;
 
-        end += sizeof (PacketHeader);
+		end += sizeof (PacketHeader);
 
-        SError *s_error = (SError *) end;
-        s_error->error_type = type;
-        s_error->timestamp = time (NULL);
-        memset (s_error->msg, 0, ERROR_MESSAGE_LENGTH);
-        if (msg) strncpy (s_error->msg, msg, ERROR_MESSAGE_LENGTH);
-    }
+		SError *s_error = (SError *) end;
+		s_error->error_type = type;
+		s_error->timestamp = time (NULL);
+		memset (s_error->msg, 0, ERROR_MESSAGE_LENGTH);
+		if (msg) strncpy (s_error->msg, msg, ERROR_MESSAGE_LENGTH);
+	}
 
-    return packet;
+	return packet;
 
 }
 
 // creates and send a new error packet
 // returns 0 on success, 1 on error
 u8 error_packet_generate_and_send (
-    const CerverErrorType type, const char *msg,
-    Cerver *cerver, Client *client, Connection *connection
+	const CerverErrorType type, const char *msg,
+	Cerver *cerver, Client *client, Connection *connection
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    Packet *error_packet = error_packet_generate (type, msg);
-    if (error_packet) {
-        packet_set_network_values (error_packet, cerver, client, connection, NULL);
-        retval = packet_send (error_packet, 0, NULL, false);
-        packet_delete (error_packet);
-    }
+	Packet *error_packet = error_packet_generate (type, msg);
+	if (error_packet) {
+		packet_set_network_values (error_packet, cerver, client, connection, NULL);
+		retval = packet_send (error_packet, 0, NULL, false);
+		packet_delete (error_packet);
+	}
 
-    return retval;
+	return retval;
 
 }
 

--- a/src/cerver/events.c
+++ b/src/cerver/events.c
@@ -20,13 +20,13 @@ u8 cerver_event_unregister (Cerver *cerver, const CerverEventType event_type);
 // get the description for the current event type
 const char *cerver_event_type_description (CerverEventType type) {
 
-    switch (type) {
-        #define XX(num, name, description) case CERVER_EVENT_##name: return #description;
-        CERVER_EVENT_MAP(XX)
-        #undef XX
-    }
+	switch (type) {
+		#define XX(num, name, description) case CERVER_EVENT_##name: return #description;
+		CERVER_EVENT_MAP(XX)
+		#undef XX
+	}
 
-    return cerver_event_type_description (CERVER_EVENT_UNKNOWN);
+	return cerver_event_type_description (CERVER_EVENT_UNKNOWN);
 
 }
 
@@ -36,45 +36,45 @@ const char *cerver_event_type_description (CerverEventType type) {
 
 static CerverEventData *cerver_event_data_new (void) {
 
-    CerverEventData *event_data = (CerverEventData *) malloc (sizeof (CerverEventData));
-    if (event_data) {
-        event_data->cerver = NULL;
+	CerverEventData *event_data = (CerverEventData *) malloc (sizeof (CerverEventData));
+	if (event_data) {
+		event_data->cerver = NULL;
 
-        event_data->client = NULL;
-        event_data->connection = NULL;
+		event_data->client = NULL;
+		event_data->connection = NULL;
 
-        event_data->action_args = NULL;
-        event_data->delete_action_args = NULL;
-    }
+		event_data->action_args = NULL;
+		event_data->delete_action_args = NULL;
+	}
 
-    return event_data;
+	return event_data;
 
 }
 
 void cerver_event_data_delete (CerverEventData *event_data) {
 
-    if (event_data) free (event_data);
+	if (event_data) free (event_data);
 
 }
 
 static CerverEventData *cerver_event_data_create (
-    const Cerver *cerver,
-    const Client *client, const Connection *connection,
-    CerverEvent *event
+	const Cerver *cerver,
+	const Client *client, const Connection *connection,
+	CerverEvent *event
 ) {
 
-    CerverEventData *event_data = cerver_event_data_new ();
-    if (event_data) {
-        event_data->cerver = cerver;
+	CerverEventData *event_data = cerver_event_data_new ();
+	if (event_data) {
+		event_data->cerver = cerver;
 
-        event_data->client = client;
-        event_data->connection = connection;
+		event_data->client = client;
+		event_data->connection = connection;
 
-        event_data->action_args = event->action_args;
-        event_data->delete_action_args = event->delete_action_args;
-    }
+		event_data->action_args = event->action_args;
+		event_data->delete_action_args = event->delete_action_args;
+	}
 
-    return event_data;
+	return event_data;
 
 }
 
@@ -84,34 +84,34 @@ static CerverEventData *cerver_event_data_create (
 
 static CerverEvent *cerver_event_new (void) {
 
-    CerverEvent *cerver_event = (CerverEvent *) malloc (sizeof (CerverEvent));
-    if (cerver_event) {
-        cerver_event->type = CERVER_EVENT_NONE;
+	CerverEvent *cerver_event = (CerverEvent *) malloc (sizeof (CerverEvent));
+	if (cerver_event) {
+		cerver_event->type = CERVER_EVENT_NONE;
 
-        cerver_event->create_thread = false;
-        cerver_event->drop_after_trigger = false;
+		cerver_event->create_thread = false;
+		cerver_event->drop_after_trigger = false;
 
-        cerver_event->action = NULL;
-        cerver_event->action_args = NULL;
-        cerver_event->delete_action_args = NULL;
-    }
+		cerver_event->action = NULL;
+		cerver_event->action_args = NULL;
+		cerver_event->delete_action_args = NULL;
+	}
 
-    return cerver_event;
+	return cerver_event;
 
 }
 
 void cerver_event_delete (void *event_ptr) {
 
-    if (event_ptr) {
-        CerverEvent *event = (CerverEvent *) event_ptr;
+	if (event_ptr) {
+		CerverEvent *event = (CerverEvent *) event_ptr;
 
-        if (event->action_args) {
-            if (event->delete_action_args)
-                event->delete_action_args (event->action_args);
-        }
+		if (event->action_args) {
+			if (event->delete_action_args)
+				event->delete_action_args (event->action_args);
+		}
 
-        free (event);
-    }
+		free (event);
+	}
 
 }
 
@@ -121,36 +121,36 @@ void cerver_event_delete (void *event_ptr) {
 // that should be free using the cerver_event_data_delete () method
 // returns 0 on success, 1 on error
 u8 cerver_event_register (
-    Cerver *cerver,
-    const CerverEventType event_type,
-    Action action, void *action_args, Action delete_action_args,
-    bool create_thread, bool drop_after_trigger
+	Cerver *cerver,
+	const CerverEventType event_type,
+	Action action, void *action_args, Action delete_action_args,
+	bool create_thread, bool drop_after_trigger
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        CerverEvent *event = cerver_event_new ();
-        if (event) {
-            event->type = event_type;
+	if (cerver) {
+		CerverEvent *event = cerver_event_new ();
+		if (event) {
+			event->type = event_type;
 
-            event->create_thread = create_thread;
-            event->drop_after_trigger = drop_after_trigger;
+			event->create_thread = create_thread;
+			event->drop_after_trigger = drop_after_trigger;
 
-            event->action = action;
-            event->action_args = action_args;
-            event->delete_action_args = delete_action_args;
+			event->action = action;
+			event->action_args = action_args;
+			event->delete_action_args = delete_action_args;
 
-            // search if there is an action already registred for that event and remove it
-            (void) cerver_event_unregister (cerver, event_type);
+			// search if there is an action already registred for that event and remove it
+			(void) cerver_event_unregister (cerver, event_type);
 
-            cerver->events[event_type] = event;
+			cerver->events[event_type] = event;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -159,60 +159,60 @@ u8 cerver_event_register (
 // returns 0 on success, 1 on error or if event is NOT registered
 u8 cerver_event_unregister (Cerver *cerver, const CerverEventType event_type) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        if (cerver->events[event_type]) {
-            cerver_event_delete (cerver->events[event_type]);
-            cerver->events[event_type] = NULL;
+	if (cerver) {
+		if (cerver->events[event_type]) {
+			cerver_event_delete (cerver->events[event_type]);
+			cerver->events[event_type] = NULL;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // triggers all the actions that are registred to an event
 void cerver_event_trigger (
-    const CerverEventType event_type,
-    const Cerver *cerver,
-    const Client *client, const Connection *connection
+	const CerverEventType event_type,
+	const Cerver *cerver,
+	const Client *client, const Connection *connection
 ) {
 
-    if (cerver) {
-        CerverEvent *event = cerver->events[event_type];
-        if (event) {
-            // trigger the action
-            if (event->action) {
-                if (event->create_thread) {
-                    pthread_t thread_id = 0;
-                    thread_create_detachable (
-                        &thread_id,
-                        (void *(*)(void *)) event->action,
-                        cerver_event_data_create (
-                            cerver,
-                            client, connection,
-                            event
-                        )
-                    );
-                }
+	if (cerver) {
+		CerverEvent *event = cerver->events[event_type];
+		if (event) {
+			// trigger the action
+			if (event->action) {
+				if (event->create_thread) {
+					pthread_t thread_id = 0;
+					thread_create_detachable (
+						&thread_id,
+						(void *(*)(void *)) event->action,
+						cerver_event_data_create (
+							cerver,
+							client, connection,
+							event
+						)
+					);
+				}
 
-                else {
-                    event->action (cerver_event_data_create (
-                        cerver,
-                        client, connection,
-                        event
-                    ));
-                }
+				else {
+					event->action (cerver_event_data_create (
+						cerver,
+						client, connection,
+						event
+					));
+				}
 
-                if (event->drop_after_trigger) {
-                    (void) cerver_event_unregister ((Cerver *) cerver, event_type);
-                }
-            }
-        }
-    }
+				if (event->drop_after_trigger) {
+					(void) cerver_event_unregister ((Cerver *) cerver, event_type);
+				}
+			}
+		}
+	}
 
 }
 

--- a/src/cerver/events.c
+++ b/src/cerver/events.c
@@ -15,47 +15,66 @@
 
 u8 cerver_event_unregister (Cerver *cerver, const CerverEventType event_type);
 
+#pragma region types
+
+// get the description for the current event type
+const char *cerver_event_type_description (CerverEventType type) {
+
+    switch (type) {
+        #define XX(num, name, description) case CERVER_EVENT_##name: return #description;
+        CERVER_EVENT_MAP(XX)
+        #undef XX
+    }
+
+    return cerver_event_type_description (CERVER_EVENT_UNKNOWN);
+
+}
+
+#pragma endregion
+
 #pragma region data
 
 static CerverEventData *cerver_event_data_new (void) {
 
-	CerverEventData *event_data = (CerverEventData *) malloc (sizeof (CerverEventData));
-	if (event_data) {
-		event_data->cerver = NULL;
+    CerverEventData *event_data = (CerverEventData *) malloc (sizeof (CerverEventData));
+    if (event_data) {
+        event_data->cerver = NULL;
 
-		event_data->client = NULL;
-		event_data->connection = NULL;
+        event_data->client = NULL;
+        event_data->connection = NULL;
 
-		event_data->action_args = NULL;
-		event_data->delete_action_args = NULL;
-	}
+        event_data->action_args = NULL;
+        event_data->delete_action_args = NULL;
+    }
 
-	return event_data;
+    return event_data;
 
 }
 
 void cerver_event_data_delete (CerverEventData *event_data) {
 
-	if (event_data) free (event_data);
+    if (event_data) free (event_data);
 
 }
 
-static CerverEventData *cerver_event_data_create (const Cerver *cerver,
-	const Client *client, const Connection *connection, 
-	CerverEvent *event) {
+static CerverEventData *cerver_event_data_create (
+    const Cerver *cerver,
+    const Client *client, const Connection *connection,
+    CerverEvent *event
+) {
 
-	CerverEventData *event_data = cerver_event_data_new ();
-	if (event_data) {
-		event_data->cerver = cerver;
+    CerverEventData *event_data = cerver_event_data_new ();
+    if (event_data) {
+        event_data->cerver = cerver;
 
-		event_data->client = client;
-		event_data->connection = connection;
+        event_data->client = client;
+        event_data->connection = connection;
 
-		event_data->action_args = event->action_args;
-		event_data->delete_action_args = event->delete_action_args;
-	}
+        event_data->action_args = event->action_args;
+        event_data->delete_action_args = event->delete_action_args;
+    }
 
-	return event_data;
+    return event_data;
 
 }
 
@@ -65,127 +84,89 @@ static CerverEventData *cerver_event_data_create (const Cerver *cerver,
 
 static CerverEvent *cerver_event_new (void) {
 
-	CerverEvent *cerver_event = (CerverEvent *) malloc (sizeof (CerverEvent));
-	if (cerver_event) {
-		cerver_event->type = CERVER_EVENT_NONE;
+    CerverEvent *cerver_event = (CerverEvent *) malloc (sizeof (CerverEvent));
+    if (cerver_event) {
+        cerver_event->type = CERVER_EVENT_NONE;
 
-		cerver_event->create_thread = false;
-		cerver_event->drop_after_trigger = false;
+        cerver_event->create_thread = false;
+        cerver_event->drop_after_trigger = false;
 
-		cerver_event->action = NULL;
-		cerver_event->action_args = NULL;
-		cerver_event->delete_action_args = NULL;
-	}
+        cerver_event->action = NULL;
+        cerver_event->action_args = NULL;
+        cerver_event->delete_action_args = NULL;
+    }
 
-	return cerver_event;
+    return cerver_event;
 
 }
 
 void cerver_event_delete (void *event_ptr) {
 
-	if (event_ptr) {
-		CerverEvent *event = (CerverEvent *) event_ptr;
-		
-		if (event->action_args) {
-			if (event->delete_action_args)
-				event->delete_action_args (event->action_args);
-		}
+    if (event_ptr) {
+        CerverEvent *event = (CerverEvent *) event_ptr;
 
-		free (event);
-	}
-
-}
-
-static CerverEvent *cerver_event_get (const Cerver *cerver, const CerverEventType event_type, 
-    ListElement **le_ptr) {
-
-    if (cerver) {
-        if (cerver->events) {
-            CerverEvent *event = NULL;
-            for (ListElement *le = dlist_start (cerver->events); le; le = le->next) {
-                event = (CerverEvent *) le->data;
-                if (event->type == event_type) {
-                    if (le_ptr) *le_ptr = le;
-                    return event;
-                } 
-            }
+        if (event->action_args) {
+            if (event->delete_action_args)
+                event->delete_action_args (event->action_args);
         }
-    }
 
-    return NULL;
-
-}
-
-static void cerver_event_pop (DoubleList *list, ListElement *le) {
-
-    if (le) {
-        void *data = dlist_remove_element (list, le);
-        if (data) cerver_event_delete (data);
+        free (event);
     }
 
 }
 
 // registers an action to be triggered when the specified event occurs
 // if there is an existing action registered to an event, it will be overrided
-// a newly allocated CerverEventData structure will be passed to your method 
+// a newly allocated CerverEventData structure will be passed to your method
 // that should be free using the cerver_event_data_delete () method
 // returns 0 on success, 1 on error
-u8 cerver_event_register (Cerver *cerver, const CerverEventType event_type, 
-    Action action, void *action_args, Action delete_action_args, 
-    bool create_thread, bool drop_after_trigger) {
+u8 cerver_event_register (
+    Cerver *cerver,
+    const CerverEventType event_type,
+    Action action, void *action_args, Action delete_action_args,
+    bool create_thread, bool drop_after_trigger
+) {
 
     u8 retval = 1;
 
     if (cerver) {
-        if (cerver->events) {
-            CerverEvent *event = cerver_event_new ();
-            if (event) {
-                event->type = event_type;
+        CerverEvent *event = cerver_event_new ();
+        if (event) {
+            event->type = event_type;
 
-                event->create_thread = create_thread;
-                event->drop_after_trigger = drop_after_trigger;
+            event->create_thread = create_thread;
+            event->drop_after_trigger = drop_after_trigger;
 
-                event->action = action;
-                event->action_args = action_args;
-                event->delete_action_args = delete_action_args;
+            event->action = action;
+            event->action_args = action_args;
+            event->delete_action_args = delete_action_args;
 
-                // search if there is an action already registred for that event and remove it
-                (void) cerver_event_unregister (cerver, event_type);
+            // search if there is an action already registred for that event and remove it
+            (void) cerver_event_unregister (cerver, event_type);
 
-                if (!dlist_insert_after (
-                    cerver->events, 
-                    dlist_end (cerver->events),
-                    event
-                )) {
-                    retval = 0;
-                }
-            }
+            cerver->events[event_type] = event;
+
+            retval = 0;
         }
     }
 
     return retval;
-    
+
 }
 
 // unregister the action associated with an event
 // deletes the action args using the delete_action_args () if NOT NULL
-// returns 0 on success, 1 on error
+// returns 0 on success, 1 on error or if event is NOT registered
 u8 cerver_event_unregister (Cerver *cerver, const CerverEventType event_type) {
 
     u8 retval = 1;
 
     if (cerver) {
-        if (cerver->events) {
-            CerverEvent *event = NULL;
-            for (ListElement *le = dlist_start (cerver->events); le; le = le->next) {
-                event = (CerverEvent *) le->data;
-                if (event->type == event_type) {
-                    cerver_event_delete (dlist_remove_element (cerver->events, le));
-                    retval = 0;
+        if (cerver->events[event_type]) {
+            cerver_event_delete (cerver->events[event_type]);
+            cerver->events[event_type] = NULL;
 
-                    break;
-                }
-            }
+            retval = 0;
         }
     }
 
@@ -194,12 +175,14 @@ u8 cerver_event_unregister (Cerver *cerver, const CerverEventType event_type) {
 }
 
 // triggers all the actions that are registred to an event
-void cerver_event_trigger (const CerverEventType event_type, const Cerver *cerver, 
-	const Client *client, const Connection *connection) {
+void cerver_event_trigger (
+    const CerverEventType event_type,
+    const Cerver *cerver,
+    const Client *client, const Connection *connection
+) {
 
     if (cerver) {
-        ListElement *le = NULL;
-        CerverEvent *event = cerver_event_get (cerver, event_type, &le);
+        CerverEvent *event = cerver->events[event_type];
         if (event) {
             // trigger the action
             if (event->action) {
@@ -207,9 +190,9 @@ void cerver_event_trigger (const CerverEventType event_type, const Cerver *cerve
                     pthread_t thread_id = 0;
                     thread_create_detachable (
                         &thread_id,
-                        (void *(*)(void *)) event->action, 
+                        (void *(*)(void *)) event->action,
                         cerver_event_data_create (
-							cerver,
+                            cerver,
                             client, connection,
                             event
                         )
@@ -218,13 +201,15 @@ void cerver_event_trigger (const CerverEventType event_type, const Cerver *cerve
 
                 else {
                     event->action (cerver_event_data_create (
-						cerver,
-                        client, connection, 
+                        cerver,
+                        client, connection,
                         event
                     ));
                 }
-                
-                if (event->drop_after_trigger) cerver_event_pop (cerver->events, le);
+
+                if (event->drop_after_trigger) {
+                    (void) cerver_event_unregister ((Cerver *) cerver, event_type);
+                }
             }
         }
     }

--- a/src/cerver/files.c
+++ b/src/cerver/files.c
@@ -2,60 +2,347 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+
 #define _XOPEN_SOURCE 700
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <dirent.h>
 
-#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/sendfile.h>
 
 #include "cerver/types/types.h"
 #include "cerver/types/string.h"
 
 #include "cerver/collections/dlist.h"
 
+#include "cerver/cerver.h"
+#include "cerver/client.h"
+#include "cerver/errors.h"
+#include "cerver/files.h"
 #include "cerver/network.h"
 #include "cerver/packets.h"
 
+#include "cerver/threads/thread.h"
+
 #include "cerver/utils/utils.h"
 #include "cerver/utils/log.h"
+
+bool file_exists (const char *filename);
+
+static ssize_t file_send_actual (
+    Cerver *cerver, Client *client, Connection *connection,
+    int file_fd, const char *actual_filename, size_t filelen
+);
+
+static int file_send_open (const char *filename, struct stat *filestatus, const char **actual_filename);
+
+static u8 file_cerver_receive (
+    Cerver *cerver, Client *client, Connection *connection,
+    FileHeader *file_header,
+    const char *file_data, size_t file_data_len,
+    char **saved_filename
+);
+
+u8 file_receive_actual (
+    Client *client, Connection *connection,
+    FileHeader *file_header,
+    const char *file_data, size_t file_data_len,
+    char **saved_filename
+);
+
+#pragma region cerver
+
+static FileCerverStats *file_cerver_stats_new (void) {
+
+    FileCerverStats *stats = (FileCerverStats *) malloc (sizeof (FileCerverStats));
+    if (stats) {
+        stats->n_files_requests = 0;
+        stats->n_success_files_requests = 0;
+        stats->n_bad_files_requests = 0;
+        stats->n_files_sent = 0;
+        stats->n_bad_files_sent = 0;
+        stats->n_bytes_sent = 0;
+
+        stats->n_files_upload_requests = 0;
+        stats->n_success_files_uploaded = 0;
+        stats->n_bad_files_upload_requests = 0;
+        stats->n_bad_files_received = 0;
+        stats->n_bytes_received = 0;
+    }
+
+    return stats;
+
+}
+
+static void file_cerver_stats_delete (FileCerverStats *stats) {
+
+    if (stats) free (stats);
+
+}
+
+FileCerver *file_cerver_new (void) {
+
+    FileCerver *file_cerver = (FileCerver *) malloc (sizeof (FileCerver));
+    if (file_cerver) {
+        file_cerver->cerver = NULL;
+
+        file_cerver->n_paths = 0;
+        for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++)
+            file_cerver->paths[i] = NULL;
+
+        file_cerver->uploads_path = NULL;
+
+        file_cerver->file_upload_handler = file_cerver_receive;
+
+        file_cerver->file_upload_cb = NULL;
+
+        file_cerver->stats = NULL;
+    }
+
+    return file_cerver;
+
+}
+
+void file_cerver_delete (void *file_cerver_ptr) {
+
+    if (file_cerver_ptr) {
+        FileCerver *file_cerver = (FileCerver *) file_cerver_ptr;
+
+        for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++) {
+            if (file_cerver->paths[i]) str_delete (file_cerver->paths[i]);
+        }
+
+        str_delete (file_cerver->uploads_path);
+
+        file_cerver_stats_delete (file_cerver->stats);
+
+        free (file_cerver_ptr);
+    }
+
+}
+
+FileCerver *file_cerver_create (Cerver *cerver) {
+
+    FileCerver *file_cerver = file_cerver_new ();
+    if (file_cerver) {
+        file_cerver->cerver = cerver;
+
+        file_cerver->stats = file_cerver_stats_new ();
+    }
+
+    return file_cerver;
+
+}
+
+// adds a new file path to take into account when a client request for a file
+// returns 0 on success, 1 on error
+u8 file_cerver_add_path (FileCerver *file_cerver, const char *path) {
+
+    u8 retval = 1;
+
+    if (file_cerver && path) {
+        if (file_cerver->n_paths < FILE_CERVER_MAX_PATHS) {
+            file_cerver->paths[file_cerver->n_paths] = str_new (path);
+            file_cerver->n_paths += 1;
+        }
+    }
+
+    return retval;
+
+}
+
+// sets the default uploads path to be used when a client sends a file
+void file_cerver_set_uploads_path (FileCerver *file_cerver, const char *uploads_path) {
+
+    if (file_cerver && uploads_path) {
+        str_delete (file_cerver->uploads_path);
+        file_cerver->uploads_path = str_new (uploads_path);
+    }
+
+}
+
+// sets a custom method to bed used to handle a file upload
+// in this method, file contents must be consumed from the sock fd
+// and return 0 on success and 1 on error
+void file_cerver_set_file_upload_handler (
+    FileCerver *file_cerver,
+    u8 (*file_upload_handler) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        struct _FileHeader *,
+        const char *file_data, size_t file_data_len,
+        char **saved_filename
+    )
+) {
+
+    if (file_cerver) {
+        file_cerver->file_upload_handler = file_upload_handler;
+    }
+
+}
+
+// sets a callback to be executed after a file has been successfully uploaded by a client
+void file_cerver_set_file_upload_cb (
+    FileCerver *file_cerver,
+    void (*file_upload_cb) (
+        struct _Cerver *, struct _Client *, struct _Connection *,
+        const char *saved_filename
+    )
+) {
+
+    if (file_cerver) {
+        file_cerver->file_upload_cb = file_upload_cb;
+    }
+
+}
+
+// search for the requested file in the configured paths
+// returns the actual filename (path + directory) where it was found, NULL on error
+String *file_cerver_search_file (FileCerver *file_cerver, const char *filename) {
+
+    String *retval = NULL;
+
+    if (file_cerver && filename) {
+        char filename_query[DEFAULT_FILENAME_LEN * 2] = { 0 };
+        for (unsigned int i = 0; i < file_cerver->n_paths; i++) {
+            (void) snprintf (
+                filename_query, DEFAULT_FILENAME_LEN * 2,
+                "%s/%s",
+                file_cerver->paths[i]->str, filename
+            );
+
+            if (file_exists (filename_query)) {
+                retval = str_new (filename_query);
+                break;
+            }
+        }
+    }
+
+    return retval;
+
+}
+
+// opens a file and sends the content back to the client
+// first the FileHeader in a regular packet, then the file contents between sockets
+// if the file is not found, a CERVER_ERROR_FILE_NOT_FOUND error packet will be sent
+// returns the number of bytes sent, or -1 on error
+ssize_t file_cerver_send_file (
+    Cerver *cerver, Client *client, Connection *connection,
+    const char *filename
+) {
+
+    ssize_t retval = -1;
+
+    if (filename && connection) {
+        const char *actual_filename = NULL;
+        struct stat filestatus = { 0 };
+        int file_fd = file_send_open (filename, &filestatus, &actual_filename);
+        if (file_fd > 0) {
+            retval = file_send_actual (
+                cerver, client, connection,
+                file_fd, actual_filename, filestatus.st_size
+            );
+
+            close (file_fd);
+        }
+
+        else {
+            (void) error_packet_generate_and_send (
+                CERVER_ERROR_FILE_NOT_FOUND, "File not found",
+                cerver, client, connection
+            );
+        }
+    }
+
+    return retval;
+
+}
+
+static u8 file_cerver_receive (
+    Cerver *cerver, Client *client, Connection *connection,
+    FileHeader *file_header,
+    const char *file_data, size_t file_data_len,
+    char **saved_filename
+) {
+
+    u8 retval = 1;
+
+    FileCerver *file_cerver = (FileCerver *) cerver->cerver_data;
+
+    // generate a custom filename taking into account the uploads path
+    *saved_filename = c_string_create (
+        "%s/%ld-%d-%s", 
+        file_cerver->uploads_path->str, 
+        time (NULL), random_int_in_range (0, 1000),
+        file_header->filename
+    );
+
+    if (*saved_filename) {
+        retval = file_receive_actual (
+            client, connection,
+            file_header,
+            file_data, file_data_len,
+            saved_filename
+        );
+    }
+
+    return retval;
+
+}
+
+void file_cerver_stats_print (FileCerver *file_cerver) {
+
+    if (file_cerver) {
+        printf ("Files requests:                %ld\n", file_cerver->stats->n_files_requests);
+        printf ("Success requests:              %ld\n", file_cerver->stats->n_success_files_requests);
+        printf ("Bad requests:                  %ld\n\n", file_cerver->stats->n_bad_files_requests);
+        printf ("Files sent:                    %ld\n\n", file_cerver->stats->n_files_sent);
+        printf ("Failed files sent:             %ld\n\n", file_cerver->stats->n_bad_files_sent);
+        printf ("Files bytes sent:              %ld\n\n", file_cerver->stats->n_bytes_sent);
+
+        printf ("Files upload requests:         %ld\n", file_cerver->stats->n_files_upload_requests);
+        printf ("Success uploads:               %ld\n", file_cerver->stats->n_success_files_uploaded);
+        printf ("Bad uploads:                   %ld\n", file_cerver->stats->n_bad_files_upload_requests);
+        printf ("Bad files received:            %ld\n", file_cerver->stats->n_bad_files_received);
+        printf ("Files bytes received:          %ld\n\n", file_cerver->stats->n_bytes_received);
+    }
+
+}
+
+#pragma endregion
+
+#pragma region main
 
 // check if a directory already exists, and if not, creates it
 // returns 0 on success, 1 on error
 unsigned int files_create_dir (const char *dir_path, mode_t mode) {
 
-	unsigned int retval = 1;
+    unsigned int retval = 1;
 
-	if (dir_path) {
-		struct stat st = { 0 };
-		int ret = stat (dir_path, &st);
-		switch (ret) {
-			case -1: {
-				if (!mkdir (dir_path, mode)) {
-					retval = 0;		// success
-				}
+    if (dir_path) {
+        struct stat st = { 0 };
+        int ret = stat (dir_path, &st);
+        switch (ret) {
+            case -1: {
+                if (!mkdir (dir_path, mode)) {
+                    retval = 0;		// success
+                }
 
-				else {
-					char *s = c_string_create ("Failed to create dir %s!", dir_path);
-					if (s) {
-                        cerver_log_error (s);
-						free (s);
-					}
-				}
-			} break;
-			case 0: {
-				char *s = c_string_create ("Dir %s already exists!", dir_path);
-				if (s) {
-                    cerver_log_warning (s);
-					free (s);
-				}
-			} break;
+                else {
+                    cerver_log_error ("Failed to create dir %s!", dir_path);
+                }
+            } break;
+            case 0: {
+                cerver_log_warning ("Dir %s already exists!", dir_path);
+            } break;
 
-			default: break;
-		}
-	}
+            default: break;
+        }
+    }
 
-	return retval;
+    return retval;
 
 }
 
@@ -81,7 +368,7 @@ char *files_get_file_extension (const char *filename) {
                 }
             }
         }
-        
+
     }
 
     return retval;
@@ -94,7 +381,7 @@ DoubleList *files_get_from_dir (const char *dir) {
     DoubleList *images = NULL;
 
     if (dir) {
-		images = dlist_init (str_delete, str_comparator);
+        images = dlist_init (str_delete, str_comparator);
 
         DIR *dp = opendir (dir);
         if (dp) {
@@ -112,11 +399,7 @@ DoubleList *files_get_from_dir (const char *dir) {
         }
 
         else {
-			char *status = c_string_create ("Failed to open dir %s", dir);
-			if (status) {
-				cerver_log_error (status);
-				free (status);
-			}
+            cerver_log_error ("Failed to open dir %s", dir);
         }
     }
 
@@ -130,7 +413,7 @@ static String *file_get_line (FILE *file) {
 
     if (file) {
         if (!feof (file)) {
-            char line[1024];
+            char line[1024] = { 0 };
             if (fgets (line, 1024, file)) {
                 size_t curr = strlen(line);
                 if(line[curr - 1] == '\n') line[curr - 1] = '\0';
@@ -153,7 +436,7 @@ DoubleList *file_get_lines (const char *filename) {
         FILE *file = fopen (filename, "r");
         if (file) {
             lines = dlist_init (str_delete, str_comparator);
-            
+
             String *line = NULL;
             while ((line = file_get_line (file))) {
                 dlist_insert_after (lines, dlist_end (lines), line);
@@ -163,11 +446,7 @@ DoubleList *file_get_lines (const char *filename) {
         }
 
         else {
-            char *status = c_string_create ("Failed to open file: %s", filename);
-            if (status) {
-                cerver_log_error (status);
-                free (status);
-            }
+            cerver_log_error ("Failed to open file: %s", filename);
         }
     }
 
@@ -198,18 +477,17 @@ FILE *file_open_as_file (const char *filename, const char *modes, struct stat *f
 
     if (filename) {
         memset (filestatus, 0, sizeof (struct stat));
-        if (!stat (filename, filestatus)) 
+        if (!stat (filename, filestatus))
             fp = fopen (filename, modes);
 
         else {
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("File %s not found!", filename);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-                free (s);
-            }
+            #ifdef FILES_DEBUG
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_FILE,
+                "File %s not found!", filename
+            );
             #endif
-        } 
+        }
     }
 
     return fp;
@@ -231,12 +509,11 @@ char *file_read (const char *filename, size_t *file_size) {
 
             // read the entire file into the buffer
             if (fread (file_contents, filestatus.st_size, 1, fp) != 1) {
-                #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Failed to read file (%s) contents!");
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-                    free (s);
-                }
+                #ifdef FILES_DEBUG
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_FILE,
+                    "Failed to read file (%s) contents!"
+                );
                 #endif
 
                 free (file_contents);
@@ -246,12 +523,11 @@ char *file_read (const char *filename, size_t *file_size) {
         }
 
         else {
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Unable to open file %s.", filename);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-                free (s);
-            }
+            #ifdef FILES_DEBUG
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_FILE,
+                "Unable to open file %s.", filename
+            );
             #endif
         }
     }
@@ -268,50 +544,363 @@ int file_open_as_fd (const char *filename, struct stat *filestatus, int flags) {
 
     if (filename) {
         memset (filestatus, 0, sizeof (struct stat));
-        if (!stat (filename, filestatus)) 
+        if (!stat (filename, filestatus)) {
             retval = open (filename, flags);
-
-        else {
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("File %s not found!", filename);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-                free (s);
-            }
-            #endif
-        } 
+        }
     }
 
     return retval;
 
 }
 
-// sends a file to the sock fd
+#pragma endregion
+
+#pragma region send
+
+// sends a first packet with file info
 // returns 0 on success, 1 on error
-int file_send (const char *filename, int sock_fd) {
+static u8 file_send_header (
+    Cerver *cerver, Client *client, Connection *connection,
+    const char *filename, size_t filelen
+) {
 
-    int retval = 1;
+    u8 retval = 1;
 
-    if (filename) {
+    Packet *packet = packet_new ();
+    if (packet) {
+        size_t packet_len = sizeof (PacketHeader) + sizeof (FileHeader);
+
+        packet->packet = malloc (packet_len);
+        packet->packet_size = packet_len;
+
+        char *end = (char *) packet->packet;
+        PacketHeader *header = (PacketHeader *) end;
+        header->packet_type = PACKET_TYPE_REQUEST;
+        header->packet_size = packet_len;
+
+        header->request_type = REQUEST_PACKET_TYPE_SEND_FILE;
+
+        end += sizeof (PacketHeader);
+
+        FileHeader *file_header = (FileHeader *) end;
+        strncpy (file_header->filename, filename, DEFAULT_FILENAME_LEN);
+        file_header->len = filelen;
+
+        packet_set_network_values (packet, cerver, client, connection, NULL);
+
+        retval = packet_send_unsafe (packet, 0, NULL, false);
+
+        packet_delete (packet);
+    }
+
+    return retval;
+
+}
+
+static ssize_t file_send_actual (
+    Cerver *cerver, Client *client, Connection *connection,
+    int file_fd, const char *actual_filename, size_t filelen
+) {
+
+    ssize_t retval = 0;
+
+    pthread_mutex_lock (connection->socket->write_mutex);
+
+    // send a first packet with file info
+    if (!file_send_header (
+        cerver, client, connection,
+        actual_filename, filelen
+    )) {
+        // send the actual file
+        retval = sendfile (connection->socket->sock_fd, file_fd, NULL, filelen);
+    }
+
+    else {
+        cerver_log (
+            LOG_TYPE_ERROR, LOG_TYPE_FILE, 
+            "file_send_actual () - failed to send file header"
+        );
+    }
+
+    pthread_mutex_unlock (connection->socket->write_mutex);
+
+    return retval;
+
+}
+
+static int file_send_open (
+    const char *filename, struct stat *filestatus,
+    const char **actual_filename
+) {
+
+    int file_fd = -1;
+
+    char *last = strrchr (filename, '/');
+    *actual_filename = last ? last + 1 : NULL;
+    if (actual_filename) {
         // try to open the file
-        struct stat filestatus;
-        int fd = file_open_as_fd (filename, &filestatus, O_RDONLY);
-        if (fd >= 0) {
-            // send a first packet with file info
-            // TODO:
+        file_fd = file_open_as_fd (filename, filestatus, O_RDONLY);
+        if (file_fd <= 0) {
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_FILE,
+                "file_send () - Failed to open file %s", filename
+            );
+        }
+    }
+
+    else {
+        cerver_log_error ("file_send () - failed to get actual filename");
+    }
+
+    return file_fd;
+
+}
+
+// opens a file and sends its contents
+// first the FileHeader in a regular packet, then the file contents between sockets
+// returns the number of bytes sent, or -1 on error
+ssize_t file_send (
+    Cerver *cerver, Client *client, Connection *connection,
+    const char *filename
+) {
+
+    ssize_t retval = -1;
+
+    if (filename && connection) {
+        const char *actual_filename = NULL;
+        struct stat filestatus = { 0 };
+        int file_fd = file_send_open (filename, &filestatus, &actual_filename);
+        if (file_fd > 0) {
+            retval = file_send_actual (
+                cerver, client, connection,
+                file_fd, actual_filename, filestatus.st_size
+            );
+
+            close (file_fd);
+        }
+    }
+
+    return retval;
+
+}
+
+// sends the file contents of the file referenced by a fd
+// first the FileHeader in a regular packet, then the file contents between sockets
+// returns the number of bytes sent, or -1 on error
+ssize_t file_send_by_fd (
+    Cerver *cerver, Client *client, Connection *connection,
+    int file_fd, const char *actual_filename, size_t filelen
+) {
+
+    ssize_t retval = -1;
+
+    if (client && connection && actual_filename) {
+        retval = file_send_actual (
+            cerver, client, connection,
+            file_fd, actual_filename, filelen
+        );
+    }
+
+    return retval;
+
+}
+
+#pragma endregion
+
+#pragma region receive
+
+// move from socket to pipe buffer
+static inline u8 file_receive_internal_receive (
+    Connection *connection, int pipefd, int buff_size,
+    ssize_t *received
+) {
+
+    u8 retval = 1;
+
+    *received = splice (
+        connection->socket->sock_fd, NULL,
+        pipefd, NULL,
+        buff_size,
+        SPLICE_F_MOVE | SPLICE_F_MORE
+    );
+
+    switch (*received) {
+        case -1: {
+            #ifdef FILES_DEBUG
+            perror ("file_receive_internal_receive () - splice () = -1");
+            #endif
+        } break;
+
+        case 0: {
+            #ifdef FILES_DEBUG
+            perror ("file_receive_internal_receive () - splice () = 0");
+            #endif
+        } break;
+
+        default: {
+            #ifdef FILES_DEBUG
+            cerver_log_debug ("file_receive_internal_receive () - spliced %ld bytes", *received);
+            #endif
+
+            retval = 0;
+        } break;
+    }
+
+    return retval;
+
+}
+
+// move from pipe buffer to file
+static inline u8 file_receive_internal_move (
+    int pipefd, int file_fd, int buff_size,
+    ssize_t *moved
+) {
+
+    u8 retval = 1;
+
+    *moved = splice (
+        pipefd, NULL,
+        file_fd, NULL,
+        buff_size,
+        SPLICE_F_MOVE | SPLICE_F_MORE
+    );
+
+    switch (*moved) {
+        case -1: {
+            #ifdef FILES_DEBUG
+            perror ("file_receive_internal_move () - splice () = -1");
+            #endif
+        } break;
+
+        case 0: {
+            #ifdef FILES_DEBUG
+            perror ("file_receive_internal_move () - splice () = 0");
+            #endif
+        } break;
+
+        default: {
+            #ifdef FILES_DEBUG
+            cerver_log_debug ("file_receive_internal_move () - spliced %ld bytes", *moved);
+            #endif
+
+            retval = 0;
+        } break;
+    }
+
+    return retval;
+
+}
+
+static u8 file_receive_internal (Connection *connection, size_t filelen, int file_fd) {
+
+    u8 retval = 1;
+
+    int buff_size = 4096;
+    int pipefds[2] = { 0 };
+    ssize_t received = 0;
+    ssize_t moved = 0;
+    if (!pipe (pipefds)) {
+        size_t len = filelen;
+        while (len > 0) {
+            if (buff_size > len) buff_size = len;
+
+            if (file_receive_internal_receive (connection, pipefds[1], buff_size, &received)) break;
+
+            if (file_receive_internal_move (pipefds[0], file_fd, buff_size, &moved)) break;
+
+            len -= buff_size;
         }
 
-        else {
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Failed to open file %s.", filename);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-                free (s);
-            }
-            #endif
-        }        
+        close (pipefds[0]);
+        close (pipefds[1]);
+
+        if (len <= 0) retval = 0;
     }
 
     return retval;
 
 }
+
+// opens the file using an already created filename
+// and use the fd to receive and save the file
+u8 file_receive_actual (
+    Client *client, Connection *connection,
+    FileHeader *file_header,
+    const char *file_data, size_t file_data_len,
+    char **saved_filename
+) {
+
+    u8 retval = 1;
+
+    int file_fd = open (*saved_filename, O_CREAT | O_WRONLY | O_TRUNC, 0777);
+    if (file_fd > 0) {
+        // ssize_t received = splice (
+        // 	connection->socket->sock_fd, NULL,
+        // 	file_fd, NULL,
+        // 	file_header->len,
+        // 	0
+        // );
+
+        // we received some part of the file when reading packets,
+        // they should be the first ones to be saved into the file
+        if (file_data && file_data_len) {
+            ssize_t wrote = write (file_fd, file_data, file_data_len);
+            if (wrote < 0) {
+                cerver_log_error ("file_receive_actual () - write () has failed!");
+                perror ("Error");
+                printf ("\n");
+            }
+
+            else {
+                #ifdef FILES_DEBUG
+                printf (
+                    "\n\nwrote %ld of file_data_len %ld\n\n",
+                    wrote,
+                    file_data_len
+                );
+                #endif
+            }
+        }
+
+        // there is still more data to be received
+        if (file_data_len < file_header->len) {
+            size_t real_filelen = file_header->len - file_data_len;
+            #ifdef FILES_DEBUG
+            printf (
+                "\nfilelen: %ld - file data len %ld = %ld\n\n", 
+                file_header->len, file_data_len, real_filelen
+            );
+            #endif
+            if (!file_receive_internal (
+                connection,
+                real_filelen,
+                file_fd
+            )) {
+                #ifdef FILES_DEBUG
+                cerver_log_success ("file_receive_internal () has finished");
+                #endif
+
+                retval = 0;
+            }
+
+            else {
+                free (*saved_filename);
+                *saved_filename = NULL;
+            }
+        }
+
+        close (file_fd);
+    }
+
+    else {
+        cerver_log_error ("file_receive_actual () - failed to open file");
+
+        free (*saved_filename);
+        *saved_filename = NULL;
+    }
+
+    return retval;
+
+}
+
+#pragma endregion

--- a/src/cerver/files.c
+++ b/src/cerver/files.c
@@ -33,107 +33,107 @@
 bool file_exists (const char *filename);
 
 static ssize_t file_send_actual (
-    Cerver *cerver, Client *client, Connection *connection,
-    int file_fd, const char *actual_filename, size_t filelen
+	Cerver *cerver, Client *client, Connection *connection,
+	int file_fd, const char *actual_filename, size_t filelen
 );
 
 static int file_send_open (const char *filename, struct stat *filestatus, const char **actual_filename);
 
 static u8 file_cerver_receive (
-    Cerver *cerver, Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Cerver *cerver, Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 );
 
 u8 file_receive_actual (
-    Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 );
 
 #pragma region cerver
 
 static FileCerverStats *file_cerver_stats_new (void) {
 
-    FileCerverStats *stats = (FileCerverStats *) malloc (sizeof (FileCerverStats));
-    if (stats) {
-        stats->n_files_requests = 0;
-        stats->n_success_files_requests = 0;
-        stats->n_bad_files_requests = 0;
-        stats->n_files_sent = 0;
-        stats->n_bad_files_sent = 0;
-        stats->n_bytes_sent = 0;
+	FileCerverStats *stats = (FileCerverStats *) malloc (sizeof (FileCerverStats));
+	if (stats) {
+		stats->n_files_requests = 0;
+		stats->n_success_files_requests = 0;
+		stats->n_bad_files_requests = 0;
+		stats->n_files_sent = 0;
+		stats->n_bad_files_sent = 0;
+		stats->n_bytes_sent = 0;
 
-        stats->n_files_upload_requests = 0;
-        stats->n_success_files_uploaded = 0;
-        stats->n_bad_files_upload_requests = 0;
-        stats->n_bad_files_received = 0;
-        stats->n_bytes_received = 0;
-    }
+		stats->n_files_upload_requests = 0;
+		stats->n_success_files_uploaded = 0;
+		stats->n_bad_files_upload_requests = 0;
+		stats->n_bad_files_received = 0;
+		stats->n_bytes_received = 0;
+	}
 
-    return stats;
+	return stats;
 
 }
 
 static void file_cerver_stats_delete (FileCerverStats *stats) {
 
-    if (stats) free (stats);
+	if (stats) free (stats);
 
 }
 
 FileCerver *file_cerver_new (void) {
 
-    FileCerver *file_cerver = (FileCerver *) malloc (sizeof (FileCerver));
-    if (file_cerver) {
-        file_cerver->cerver = NULL;
+	FileCerver *file_cerver = (FileCerver *) malloc (sizeof (FileCerver));
+	if (file_cerver) {
+		file_cerver->cerver = NULL;
 
-        file_cerver->n_paths = 0;
-        for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++)
-            file_cerver->paths[i] = NULL;
+		file_cerver->n_paths = 0;
+		for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++)
+			file_cerver->paths[i] = NULL;
 
-        file_cerver->uploads_path = NULL;
+		file_cerver->uploads_path = NULL;
 
-        file_cerver->file_upload_handler = file_cerver_receive;
+		file_cerver->file_upload_handler = file_cerver_receive;
 
-        file_cerver->file_upload_cb = NULL;
+		file_cerver->file_upload_cb = NULL;
 
-        file_cerver->stats = NULL;
-    }
+		file_cerver->stats = NULL;
+	}
 
-    return file_cerver;
+	return file_cerver;
 
 }
 
 void file_cerver_delete (void *file_cerver_ptr) {
 
-    if (file_cerver_ptr) {
-        FileCerver *file_cerver = (FileCerver *) file_cerver_ptr;
+	if (file_cerver_ptr) {
+		FileCerver *file_cerver = (FileCerver *) file_cerver_ptr;
 
-        for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++) {
-            if (file_cerver->paths[i]) str_delete (file_cerver->paths[i]);
-        }
+		for (unsigned int i = 0; i < FILE_CERVER_MAX_PATHS; i++) {
+			if (file_cerver->paths[i]) str_delete (file_cerver->paths[i]);
+		}
 
-        str_delete (file_cerver->uploads_path);
+		str_delete (file_cerver->uploads_path);
 
-        file_cerver_stats_delete (file_cerver->stats);
+		file_cerver_stats_delete (file_cerver->stats);
 
-        free (file_cerver_ptr);
-    }
+		free (file_cerver_ptr);
+	}
 
 }
 
 FileCerver *file_cerver_create (Cerver *cerver) {
 
-    FileCerver *file_cerver = file_cerver_new ();
-    if (file_cerver) {
-        file_cerver->cerver = cerver;
+	FileCerver *file_cerver = file_cerver_new ();
+	if (file_cerver) {
+		file_cerver->cerver = cerver;
 
-        file_cerver->stats = file_cerver_stats_new ();
-    }
+		file_cerver->stats = file_cerver_stats_new ();
+	}
 
-    return file_cerver;
+	return file_cerver;
 
 }
 
@@ -141,26 +141,26 @@ FileCerver *file_cerver_create (Cerver *cerver) {
 // returns 0 on success, 1 on error
 u8 file_cerver_add_path (FileCerver *file_cerver, const char *path) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (file_cerver && path) {
-        if (file_cerver->n_paths < FILE_CERVER_MAX_PATHS) {
-            file_cerver->paths[file_cerver->n_paths] = str_new (path);
-            file_cerver->n_paths += 1;
-        }
-    }
+	if (file_cerver && path) {
+		if (file_cerver->n_paths < FILE_CERVER_MAX_PATHS) {
+			file_cerver->paths[file_cerver->n_paths] = str_new (path);
+			file_cerver->n_paths += 1;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sets the default uploads path to be used when a client sends a file
 void file_cerver_set_uploads_path (FileCerver *file_cerver, const char *uploads_path) {
 
-    if (file_cerver && uploads_path) {
-        str_delete (file_cerver->uploads_path);
-        file_cerver->uploads_path = str_new (uploads_path);
-    }
+	if (file_cerver && uploads_path) {
+		str_delete (file_cerver->uploads_path);
+		file_cerver->uploads_path = str_new (uploads_path);
+	}
 
 }
 
@@ -168,33 +168,33 @@ void file_cerver_set_uploads_path (FileCerver *file_cerver, const char *uploads_
 // in this method, file contents must be consumed from the sock fd
 // and return 0 on success and 1 on error
 void file_cerver_set_file_upload_handler (
-    FileCerver *file_cerver,
-    u8 (*file_upload_handler) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        struct _FileHeader *,
-        const char *file_data, size_t file_data_len,
-        char **saved_filename
-    )
+	FileCerver *file_cerver,
+	u8 (*file_upload_handler) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
+	)
 ) {
 
-    if (file_cerver) {
-        file_cerver->file_upload_handler = file_upload_handler;
-    }
+	if (file_cerver) {
+		file_cerver->file_upload_handler = file_upload_handler;
+	}
 
 }
 
 // sets a callback to be executed after a file has been successfully uploaded by a client
 void file_cerver_set_file_upload_cb (
-    FileCerver *file_cerver,
-    void (*file_upload_cb) (
-        struct _Cerver *, struct _Client *, struct _Connection *,
-        const char *saved_filename
-    )
+	FileCerver *file_cerver,
+	void (*file_upload_cb) (
+		struct _Cerver *, struct _Client *, struct _Connection *,
+		const char *saved_filename
+	)
 ) {
 
-    if (file_cerver) {
-        file_cerver->file_upload_cb = file_upload_cb;
-    }
+	if (file_cerver) {
+		file_cerver->file_upload_cb = file_upload_cb;
+	}
 
 }
 
@@ -202,25 +202,25 @@ void file_cerver_set_file_upload_cb (
 // returns the actual filename (path + directory) where it was found, NULL on error
 String *file_cerver_search_file (FileCerver *file_cerver, const char *filename) {
 
-    String *retval = NULL;
+	String *retval = NULL;
 
-    if (file_cerver && filename) {
-        char filename_query[DEFAULT_FILENAME_LEN * 2] = { 0 };
-        for (unsigned int i = 0; i < file_cerver->n_paths; i++) {
-            (void) snprintf (
-                filename_query, DEFAULT_FILENAME_LEN * 2,
-                "%s/%s",
-                file_cerver->paths[i]->str, filename
-            );
+	if (file_cerver && filename) {
+		char filename_query[DEFAULT_FILENAME_LEN * 2] = { 0 };
+		for (unsigned int i = 0; i < file_cerver->n_paths; i++) {
+			(void) snprintf (
+				filename_query, DEFAULT_FILENAME_LEN * 2,
+				"%s/%s",
+				file_cerver->paths[i]->str, filename
+			);
 
-            if (file_exists (filename_query)) {
-                retval = str_new (filename_query);
-                break;
-            }
-        }
-    }
+			if (file_exists (filename_query)) {
+				retval = str_new (filename_query);
+				break;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -229,85 +229,85 @@ String *file_cerver_search_file (FileCerver *file_cerver, const char *filename) 
 // if the file is not found, a CERVER_ERROR_FILE_NOT_FOUND error packet will be sent
 // returns the number of bytes sent, or -1 on error
 ssize_t file_cerver_send_file (
-    Cerver *cerver, Client *client, Connection *connection,
-    const char *filename
+	Cerver *cerver, Client *client, Connection *connection,
+	const char *filename
 ) {
 
-    ssize_t retval = -1;
+	ssize_t retval = -1;
 
-    if (filename && connection) {
-        const char *actual_filename = NULL;
-        struct stat filestatus = { 0 };
-        int file_fd = file_send_open (filename, &filestatus, &actual_filename);
-        if (file_fd > 0) {
-            retval = file_send_actual (
-                cerver, client, connection,
-                file_fd, actual_filename, filestatus.st_size
-            );
+	if (filename && connection) {
+		const char *actual_filename = NULL;
+		struct stat filestatus = { 0 };
+		int file_fd = file_send_open (filename, &filestatus, &actual_filename);
+		if (file_fd > 0) {
+			retval = file_send_actual (
+				cerver, client, connection,
+				file_fd, actual_filename, filestatus.st_size
+			);
 
-            close (file_fd);
-        }
+			close (file_fd);
+		}
 
-        else {
-            (void) error_packet_generate_and_send (
-                CERVER_ERROR_FILE_NOT_FOUND, "File not found",
-                cerver, client, connection
-            );
-        }
-    }
+		else {
+			(void) error_packet_generate_and_send (
+				CERVER_ERROR_FILE_NOT_FOUND, "File not found",
+				cerver, client, connection
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 file_cerver_receive (
-    Cerver *cerver, Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Cerver *cerver, Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    FileCerver *file_cerver = (FileCerver *) cerver->cerver_data;
+	FileCerver *file_cerver = (FileCerver *) cerver->cerver_data;
 
-    // generate a custom filename taking into account the uploads path
-    *saved_filename = c_string_create (
-        "%s/%ld-%d-%s", 
-        file_cerver->uploads_path->str, 
-        time (NULL), random_int_in_range (0, 1000),
-        file_header->filename
-    );
+	// generate a custom filename taking into account the uploads path
+	*saved_filename = c_string_create (
+		"%s/%ld-%d-%s",
+		file_cerver->uploads_path->str,
+		time (NULL), random_int_in_range (0, 1000),
+		file_header->filename
+	);
 
-    if (*saved_filename) {
-        retval = file_receive_actual (
-            client, connection,
-            file_header,
-            file_data, file_data_len,
-            saved_filename
-        );
-    }
+	if (*saved_filename) {
+		retval = file_receive_actual (
+			client, connection,
+			file_header,
+			file_data, file_data_len,
+			saved_filename
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 void file_cerver_stats_print (FileCerver *file_cerver) {
 
-    if (file_cerver) {
-        printf ("Files requests:                %ld\n", file_cerver->stats->n_files_requests);
-        printf ("Success requests:              %ld\n", file_cerver->stats->n_success_files_requests);
-        printf ("Bad requests:                  %ld\n\n", file_cerver->stats->n_bad_files_requests);
-        printf ("Files sent:                    %ld\n\n", file_cerver->stats->n_files_sent);
-        printf ("Failed files sent:             %ld\n\n", file_cerver->stats->n_bad_files_sent);
-        printf ("Files bytes sent:              %ld\n\n", file_cerver->stats->n_bytes_sent);
+	if (file_cerver) {
+		printf ("Files requests:                %ld\n", file_cerver->stats->n_files_requests);
+		printf ("Success requests:              %ld\n", file_cerver->stats->n_success_files_requests);
+		printf ("Bad requests:                  %ld\n\n", file_cerver->stats->n_bad_files_requests);
+		printf ("Files sent:                    %ld\n\n", file_cerver->stats->n_files_sent);
+		printf ("Failed files sent:             %ld\n\n", file_cerver->stats->n_bad_files_sent);
+		printf ("Files bytes sent:              %ld\n\n", file_cerver->stats->n_bytes_sent);
 
-        printf ("Files upload requests:         %ld\n", file_cerver->stats->n_files_upload_requests);
-        printf ("Success uploads:               %ld\n", file_cerver->stats->n_success_files_uploaded);
-        printf ("Bad uploads:                   %ld\n", file_cerver->stats->n_bad_files_upload_requests);
-        printf ("Bad files received:            %ld\n", file_cerver->stats->n_bad_files_received);
-        printf ("Files bytes received:          %ld\n\n", file_cerver->stats->n_bytes_received);
-    }
+		printf ("Files upload requests:         %ld\n", file_cerver->stats->n_files_upload_requests);
+		printf ("Success uploads:               %ld\n", file_cerver->stats->n_success_files_uploaded);
+		printf ("Bad uploads:                   %ld\n", file_cerver->stats->n_bad_files_upload_requests);
+		printf ("Bad files received:            %ld\n", file_cerver->stats->n_bad_files_received);
+		printf ("Files bytes received:          %ld\n\n", file_cerver->stats->n_bytes_received);
+	}
 
 }
 
@@ -319,30 +319,30 @@ void file_cerver_stats_print (FileCerver *file_cerver) {
 // returns 0 on success, 1 on error
 unsigned int files_create_dir (const char *dir_path, mode_t mode) {
 
-    unsigned int retval = 1;
+	unsigned int retval = 1;
 
-    if (dir_path) {
-        struct stat st = { 0 };
-        int ret = stat (dir_path, &st);
-        switch (ret) {
-            case -1: {
-                if (!mkdir (dir_path, mode)) {
-                    retval = 0;		// success
-                }
+	if (dir_path) {
+		struct stat st = { 0 };
+		int ret = stat (dir_path, &st);
+		switch (ret) {
+			case -1: {
+				if (!mkdir (dir_path, mode)) {
+					retval = 0;		// success
+				}
 
-                else {
-                    cerver_log_error ("Failed to create dir %s!", dir_path);
-                }
-            } break;
-            case 0: {
-                cerver_log_warning ("Dir %s already exists!", dir_path);
-            } break;
+				else {
+					cerver_log_error ("Failed to create dir %s!", dir_path);
+				}
+			} break;
+			case 0: {
+				cerver_log_warning ("Dir %s already exists!", dir_path);
+			} break;
 
-            default: break;
-        }
-    }
+			default: break;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -350,147 +350,147 @@ unsigned int files_create_dir (const char *dir_path, mode_t mode) {
 // NULL if no file extension
 char *files_get_file_extension (const char *filename) {
 
-    char *retval = NULL;
+	char *retval = NULL;
 
-    if (filename) {
-        char *ptr = strrchr ((char *) filename, '.');
-        if (ptr) {
-            // *ptr++;
-            size_t ext_len = 0;
-            char *p = ptr;
-            while (*p++) ext_len++;
+	if (filename) {
+		char *ptr = strrchr ((char *) filename, '.');
+		if (ptr) {
+			// *ptr++;
+			size_t ext_len = 0;
+			char *p = ptr;
+			while (*p++) ext_len++;
 
-            if (ext_len) {
-                retval = (char *) calloc (ext_len + 1, sizeof (char));
-                if (retval) {
-                    memcpy (retval, ptr + 1, ext_len);
-                    retval[ext_len] = '\0';
-                }
-            }
-        }
+			if (ext_len) {
+				retval = (char *) calloc (ext_len + 1, sizeof (char));
+				if (retval) {
+					memcpy (retval, ptr + 1, ext_len);
+					retval[ext_len] = '\0';
+				}
+			}
+		}
 
-    }
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // returns a list of strings containg the names of all the files in the directory
 DoubleList *files_get_from_dir (const char *dir) {
 
-    DoubleList *images = NULL;
+	DoubleList *images = NULL;
 
-    if (dir) {
-        images = dlist_init (str_delete, str_comparator);
+	if (dir) {
+		images = dlist_init (str_delete, str_comparator);
 
-        DIR *dp = opendir (dir);
-        if (dp) {
-            struct dirent *ep = NULL;
-            String *file = NULL;
-            while ((ep = readdir (dp)) != NULL) {
-                if (strcmp (ep->d_name, ".") && strcmp (ep->d_name, "..")) {
-                    file = str_create ("%s/%s", dir, ep->d_name);
+		DIR *dp = opendir (dir);
+		if (dp) {
+			struct dirent *ep = NULL;
+			String *file = NULL;
+			while ((ep = readdir (dp)) != NULL) {
+				if (strcmp (ep->d_name, ".") && strcmp (ep->d_name, "..")) {
+					file = str_create ("%s/%s", dir, ep->d_name);
 
-                    dlist_insert_after (images, dlist_end (images), file);
-                }
-            }
+					dlist_insert_after (images, dlist_end (images), file);
+				}
+			}
 
-            (void) closedir (dp);
-        }
+			(void) closedir (dp);
+		}
 
-        else {
-            cerver_log_error ("Failed to open dir %s", dir);
-        }
-    }
+		else {
+			cerver_log_error ("Failed to open dir %s", dir);
+		}
+	}
 
-    return images;
+	return images;
 
 }
 
 static String *file_get_line (FILE *file) {
 
-    String *str = NULL;
+	String *str = NULL;
 
-    if (file) {
-        if (!feof (file)) {
-            char line[1024] = { 0 };
-            if (fgets (line, 1024, file)) {
-                size_t curr = strlen(line);
-                if(line[curr - 1] == '\n') line[curr - 1] = '\0';
+	if (file) {
+		if (!feof (file)) {
+			char line[1024] = { 0 };
+			if (fgets (line, 1024, file)) {
+				size_t curr = strlen(line);
+				if(line[curr - 1] == '\n') line[curr - 1] = '\0';
 
-                str = str_new (line);
-            }
-        }
-    }
+				str = str_new (line);
+			}
+		}
+	}
 
-    return str;
+	return str;
 
 }
 
 // reads eachone of the file's lines into a newly created string and returns them inside a dlist
 DoubleList *file_get_lines (const char *filename) {
 
-    DoubleList *lines = NULL;
+	DoubleList *lines = NULL;
 
-    if (filename) {
-        FILE *file = fopen (filename, "r");
-        if (file) {
-            lines = dlist_init (str_delete, str_comparator);
+	if (filename) {
+		FILE *file = fopen (filename, "r");
+		if (file) {
+			lines = dlist_init (str_delete, str_comparator);
 
-            String *line = NULL;
-            while ((line = file_get_line (file))) {
-                dlist_insert_after (lines, dlist_end (lines), line);
-            }
+			String *line = NULL;
+			while ((line = file_get_line (file))) {
+				dlist_insert_after (lines, dlist_end (lines), line);
+			}
 
-            fclose (file);
-        }
+			fclose (file);
+		}
 
-        else {
-            cerver_log_error ("Failed to open file: %s", filename);
-        }
-    }
+		else {
+			cerver_log_error ("Failed to open file: %s", filename);
+		}
+	}
 
-    return lines;
+	return lines;
 
 }
 
 // returns true if the filename exists
 bool file_exists (const char *filename) {
 
-    bool retval = false;
+	bool retval = false;
 
-    if (filename) {
-        struct stat filestatus = { 0 };
-        if (!stat (filename, &filestatus)) {
-            retval = true;
-        }
-    }
+	if (filename) {
+		struct stat filestatus = { 0 };
+		if (!stat (filename, &filestatus)) {
+			retval = true;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // opens a file and returns it as a FILE
 FILE *file_open_as_file (const char *filename, const char *modes, struct stat *filestatus) {
 
-    FILE *fp = NULL;
+	FILE *fp = NULL;
 
-    if (filename) {
-        memset (filestatus, 0, sizeof (struct stat));
-        if (!stat (filename, filestatus))
-            fp = fopen (filename, modes);
+	if (filename) {
+		memset (filestatus, 0, sizeof (struct stat));
+		if (!stat (filename, filestatus))
+			fp = fopen (filename, modes);
 
-        else {
-            #ifdef FILES_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_FILE,
-                "File %s not found!", filename
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef FILES_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"File %s not found!", filename
+			);
+			#endif
+		}
+	}
 
-    return fp;
+	return fp;
 
 }
 
@@ -498,41 +498,41 @@ FILE *file_open_as_file (const char *filename, const char *modes, struct stat *f
 // sets file size to the amount of bytes read
 char *file_read (const char *filename, size_t *file_size) {
 
-    char *file_contents = NULL;
+	char *file_contents = NULL;
 
-    if (filename) {
-        struct stat filestatus = { 0 };
-        FILE *fp = file_open_as_file (filename, "rt", &filestatus);
-        if (fp) {
-            *file_size = filestatus.st_size;
-            file_contents = (char *) malloc (filestatus.st_size);
+	if (filename) {
+		struct stat filestatus = { 0 };
+		FILE *fp = file_open_as_file (filename, "rt", &filestatus);
+		if (fp) {
+			*file_size = filestatus.st_size;
+			file_contents = (char *) malloc (filestatus.st_size);
 
-            // read the entire file into the buffer
-            if (fread (file_contents, filestatus.st_size, 1, fp) != 1) {
-                #ifdef FILES_DEBUG
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_FILE,
-                    "Failed to read file (%s) contents!"
-                );
-                #endif
+			// read the entire file into the buffer
+			if (fread (file_contents, filestatus.st_size, 1, fp) != 1) {
+				#ifdef FILES_DEBUG
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_FILE,
+					"Failed to read file (%s) contents!"
+				);
+				#endif
 
-                free (file_contents);
-            }
+				free (file_contents);
+			}
 
-            fclose (fp);
-        }
+			fclose (fp);
+		}
 
-        else {
-            #ifdef FILES_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_FILE,
-                "Unable to open file %s.", filename
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef FILES_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"Unable to open file %s.", filename
+			);
+			#endif
+		}
+	}
 
-    return file_contents;
+	return file_contents;
 
 }
 
@@ -540,16 +540,16 @@ char *file_read (const char *filename, size_t *file_size) {
 // returns fd on success, -1 on error
 int file_open_as_fd (const char *filename, struct stat *filestatus, int flags) {
 
-    int retval = -1;
+	int retval = -1;
 
-    if (filename) {
-        memset (filestatus, 0, sizeof (struct stat));
-        if (!stat (filename, filestatus)) {
-            retval = open (filename, flags);
-        }
-    }
+	if (filename) {
+		memset (filestatus, 0, sizeof (struct stat));
+		if (!stat (filename, filestatus)) {
+			retval = open (filename, flags);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -560,99 +560,99 @@ int file_open_as_fd (const char *filename, struct stat *filestatus, int flags) {
 // sends a first packet with file info
 // returns 0 on success, 1 on error
 static u8 file_send_header (
-    Cerver *cerver, Client *client, Connection *connection,
-    const char *filename, size_t filelen
+	Cerver *cerver, Client *client, Connection *connection,
+	const char *filename, size_t filelen
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    Packet *packet = packet_new ();
-    if (packet) {
-        size_t packet_len = sizeof (PacketHeader) + sizeof (FileHeader);
+	Packet *packet = packet_new ();
+	if (packet) {
+		size_t packet_len = sizeof (PacketHeader) + sizeof (FileHeader);
 
-        packet->packet = malloc (packet_len);
-        packet->packet_size = packet_len;
+		packet->packet = malloc (packet_len);
+		packet->packet_size = packet_len;
 
-        char *end = (char *) packet->packet;
-        PacketHeader *header = (PacketHeader *) end;
-        header->packet_type = PACKET_TYPE_REQUEST;
-        header->packet_size = packet_len;
+		char *end = (char *) packet->packet;
+		PacketHeader *header = (PacketHeader *) end;
+		header->packet_type = PACKET_TYPE_REQUEST;
+		header->packet_size = packet_len;
 
-        header->request_type = REQUEST_PACKET_TYPE_SEND_FILE;
+		header->request_type = REQUEST_PACKET_TYPE_SEND_FILE;
 
-        end += sizeof (PacketHeader);
+		end += sizeof (PacketHeader);
 
-        FileHeader *file_header = (FileHeader *) end;
-        strncpy (file_header->filename, filename, DEFAULT_FILENAME_LEN);
-        file_header->len = filelen;
+		FileHeader *file_header = (FileHeader *) end;
+		strncpy (file_header->filename, filename, DEFAULT_FILENAME_LEN);
+		file_header->len = filelen;
 
-        packet_set_network_values (packet, cerver, client, connection, NULL);
+		packet_set_network_values (packet, cerver, client, connection, NULL);
 
-        retval = packet_send_unsafe (packet, 0, NULL, false);
+		retval = packet_send_unsafe (packet, 0, NULL, false);
 
-        packet_delete (packet);
-    }
+		packet_delete (packet);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static ssize_t file_send_actual (
-    Cerver *cerver, Client *client, Connection *connection,
-    int file_fd, const char *actual_filename, size_t filelen
+	Cerver *cerver, Client *client, Connection *connection,
+	int file_fd, const char *actual_filename, size_t filelen
 ) {
 
-    ssize_t retval = 0;
+	ssize_t retval = 0;
 
-    pthread_mutex_lock (connection->socket->write_mutex);
+	pthread_mutex_lock (connection->socket->write_mutex);
 
-    // send a first packet with file info
-    if (!file_send_header (
-        cerver, client, connection,
-        actual_filename, filelen
-    )) {
-        // send the actual file
-        retval = sendfile (connection->socket->sock_fd, file_fd, NULL, filelen);
-    }
+	// send a first packet with file info
+	if (!file_send_header (
+		cerver, client, connection,
+		actual_filename, filelen
+	)) {
+		// send the actual file
+		retval = sendfile (connection->socket->sock_fd, file_fd, NULL, filelen);
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_FILE, 
-            "file_send_actual () - failed to send file header"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_FILE,
+			"file_send_actual () - failed to send file header"
+		);
+	}
 
-    pthread_mutex_unlock (connection->socket->write_mutex);
+	pthread_mutex_unlock (connection->socket->write_mutex);
 
-    return retval;
+	return retval;
 
 }
 
 static int file_send_open (
-    const char *filename, struct stat *filestatus,
-    const char **actual_filename
+	const char *filename, struct stat *filestatus,
+	const char **actual_filename
 ) {
 
-    int file_fd = -1;
+	int file_fd = -1;
 
-    char *last = strrchr (filename, '/');
-    *actual_filename = last ? last + 1 : NULL;
-    if (actual_filename) {
-        // try to open the file
-        file_fd = file_open_as_fd (filename, filestatus, O_RDONLY);
-        if (file_fd <= 0) {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_FILE,
-                "file_send () - Failed to open file %s", filename
-            );
-        }
-    }
+	char *last = strrchr (filename, '/');
+	*actual_filename = last ? last + 1 : NULL;
+	if (actual_filename) {
+		// try to open the file
+		file_fd = file_open_as_fd (filename, filestatus, O_RDONLY);
+		if (file_fd <= 0) {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"file_send () - Failed to open file %s", filename
+			);
+		}
+	}
 
-    else {
-        cerver_log_error ("file_send () - failed to get actual filename");
-    }
+	else {
+		cerver_log_error ("file_send () - failed to get actual filename");
+	}
 
-    return file_fd;
+	return file_fd;
 
 }
 
@@ -660,27 +660,27 @@ static int file_send_open (
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 ssize_t file_send (
-    Cerver *cerver, Client *client, Connection *connection,
-    const char *filename
+	Cerver *cerver, Client *client, Connection *connection,
+	const char *filename
 ) {
 
-    ssize_t retval = -1;
+	ssize_t retval = -1;
 
-    if (filename && connection) {
-        const char *actual_filename = NULL;
-        struct stat filestatus = { 0 };
-        int file_fd = file_send_open (filename, &filestatus, &actual_filename);
-        if (file_fd > 0) {
-            retval = file_send_actual (
-                cerver, client, connection,
-                file_fd, actual_filename, filestatus.st_size
-            );
+	if (filename && connection) {
+		const char *actual_filename = NULL;
+		struct stat filestatus = { 0 };
+		int file_fd = file_send_open (filename, &filestatus, &actual_filename);
+		if (file_fd > 0) {
+			retval = file_send_actual (
+				cerver, client, connection,
+				file_fd, actual_filename, filestatus.st_size
+			);
 
-            close (file_fd);
-        }
-    }
+			close (file_fd);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -688,20 +688,20 @@ ssize_t file_send (
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 ssize_t file_send_by_fd (
-    Cerver *cerver, Client *client, Connection *connection,
-    int file_fd, const char *actual_filename, size_t filelen
+	Cerver *cerver, Client *client, Connection *connection,
+	int file_fd, const char *actual_filename, size_t filelen
 ) {
 
-    ssize_t retval = -1;
+	ssize_t retval = -1;
 
-    if (client && connection && actual_filename) {
-        retval = file_send_actual (
-            cerver, client, connection,
-            file_fd, actual_filename, filelen
-        );
-    }
+	if (client && connection && actual_filename) {
+		retval = file_send_actual (
+			cerver, client, connection,
+			file_fd, actual_filename, filelen
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -711,195 +711,195 @@ ssize_t file_send_by_fd (
 
 // move from socket to pipe buffer
 static inline u8 file_receive_internal_receive (
-    Connection *connection, int pipefd, int buff_size,
-    ssize_t *received
+	Connection *connection, int pipefd, int buff_size,
+	ssize_t *received
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    *received = splice (
-        connection->socket->sock_fd, NULL,
-        pipefd, NULL,
-        buff_size,
-        SPLICE_F_MOVE | SPLICE_F_MORE
-    );
+	*received = splice (
+		connection->socket->sock_fd, NULL,
+		pipefd, NULL,
+		buff_size,
+		SPLICE_F_MOVE | SPLICE_F_MORE
+	);
 
-    switch (*received) {
-        case -1: {
-            #ifdef FILES_DEBUG
-            perror ("file_receive_internal_receive () - splice () = -1");
-            #endif
-        } break;
+	switch (*received) {
+		case -1: {
+			#ifdef FILES_DEBUG
+			perror ("file_receive_internal_receive () - splice () = -1");
+			#endif
+		} break;
 
-        case 0: {
-            #ifdef FILES_DEBUG
-            perror ("file_receive_internal_receive () - splice () = 0");
-            #endif
-        } break;
+		case 0: {
+			#ifdef FILES_DEBUG
+			perror ("file_receive_internal_receive () - splice () = 0");
+			#endif
+		} break;
 
-        default: {
-            #ifdef FILES_DEBUG
-            cerver_log_debug ("file_receive_internal_receive () - spliced %ld bytes", *received);
-            #endif
+		default: {
+			#ifdef FILES_DEBUG
+			cerver_log_debug ("file_receive_internal_receive () - spliced %ld bytes", *received);
+			#endif
 
-            retval = 0;
-        } break;
-    }
+			retval = 0;
+		} break;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // move from pipe buffer to file
 static inline u8 file_receive_internal_move (
-    int pipefd, int file_fd, int buff_size,
-    ssize_t *moved
+	int pipefd, int file_fd, int buff_size,
+	ssize_t *moved
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    *moved = splice (
-        pipefd, NULL,
-        file_fd, NULL,
-        buff_size,
-        SPLICE_F_MOVE | SPLICE_F_MORE
-    );
+	*moved = splice (
+		pipefd, NULL,
+		file_fd, NULL,
+		buff_size,
+		SPLICE_F_MOVE | SPLICE_F_MORE
+	);
 
-    switch (*moved) {
-        case -1: {
-            #ifdef FILES_DEBUG
-            perror ("file_receive_internal_move () - splice () = -1");
-            #endif
-        } break;
+	switch (*moved) {
+		case -1: {
+			#ifdef FILES_DEBUG
+			perror ("file_receive_internal_move () - splice () = -1");
+			#endif
+		} break;
 
-        case 0: {
-            #ifdef FILES_DEBUG
-            perror ("file_receive_internal_move () - splice () = 0");
-            #endif
-        } break;
+		case 0: {
+			#ifdef FILES_DEBUG
+			perror ("file_receive_internal_move () - splice () = 0");
+			#endif
+		} break;
 
-        default: {
-            #ifdef FILES_DEBUG
-            cerver_log_debug ("file_receive_internal_move () - spliced %ld bytes", *moved);
-            #endif
+		default: {
+			#ifdef FILES_DEBUG
+			cerver_log_debug ("file_receive_internal_move () - spliced %ld bytes", *moved);
+			#endif
 
-            retval = 0;
-        } break;
-    }
+			retval = 0;
+		} break;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 file_receive_internal (Connection *connection, size_t filelen, int file_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    int buff_size = 4096;
-    int pipefds[2] = { 0 };
-    ssize_t received = 0;
-    ssize_t moved = 0;
-    if (!pipe (pipefds)) {
-        size_t len = filelen;
-        while (len > 0) {
-            if (buff_size > len) buff_size = len;
+	int buff_size = 4096;
+	int pipefds[2] = { 0 };
+	ssize_t received = 0;
+	ssize_t moved = 0;
+	if (!pipe (pipefds)) {
+		size_t len = filelen;
+		while (len > 0) {
+			if (buff_size > len) buff_size = len;
 
-            if (file_receive_internal_receive (connection, pipefds[1], buff_size, &received)) break;
+			if (file_receive_internal_receive (connection, pipefds[1], buff_size, &received)) break;
 
-            if (file_receive_internal_move (pipefds[0], file_fd, buff_size, &moved)) break;
+			if (file_receive_internal_move (pipefds[0], file_fd, buff_size, &moved)) break;
 
-            len -= buff_size;
-        }
+			len -= buff_size;
+		}
 
-        close (pipefds[0]);
-        close (pipefds[1]);
+		close (pipefds[0]);
+		close (pipefds[1]);
 
-        if (len <= 0) retval = 0;
-    }
+		if (len <= 0) retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // opens the file using an already created filename
 // and use the fd to receive and save the file
 u8 file_receive_actual (
-    Client *client, Connection *connection,
-    FileHeader *file_header,
-    const char *file_data, size_t file_data_len,
-    char **saved_filename
+	Client *client, Connection *connection,
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    int file_fd = open (*saved_filename, O_CREAT | O_WRONLY | O_TRUNC, 0777);
-    if (file_fd > 0) {
-        // ssize_t received = splice (
-        // 	connection->socket->sock_fd, NULL,
-        // 	file_fd, NULL,
-        // 	file_header->len,
-        // 	0
-        // );
+	int file_fd = open (*saved_filename, O_CREAT | O_WRONLY | O_TRUNC, 0777);
+	if (file_fd > 0) {
+		// ssize_t received = splice (
+		// 	connection->socket->sock_fd, NULL,
+		// 	file_fd, NULL,
+		// 	file_header->len,
+		// 	0
+		// );
 
-        // we received some part of the file when reading packets,
-        // they should be the first ones to be saved into the file
-        if (file_data && file_data_len) {
-            ssize_t wrote = write (file_fd, file_data, file_data_len);
-            if (wrote < 0) {
-                cerver_log_error ("file_receive_actual () - write () has failed!");
-                perror ("Error");
-                printf ("\n");
-            }
+		// we received some part of the file when reading packets,
+		// they should be the first ones to be saved into the file
+		if (file_data && file_data_len) {
+			ssize_t wrote = write (file_fd, file_data, file_data_len);
+			if (wrote < 0) {
+				cerver_log_error ("file_receive_actual () - write () has failed!");
+				perror ("Error");
+				printf ("\n");
+			}
 
-            else {
-                #ifdef FILES_DEBUG
-                printf (
-                    "\n\nwrote %ld of file_data_len %ld\n\n",
-                    wrote,
-                    file_data_len
-                );
-                #endif
-            }
-        }
+			else {
+				#ifdef FILES_DEBUG
+				printf (
+					"\n\nwrote %ld of file_data_len %ld\n\n",
+					wrote,
+					file_data_len
+				);
+				#endif
+			}
+		}
 
-        // there is still more data to be received
-        if (file_data_len < file_header->len) {
-            size_t real_filelen = file_header->len - file_data_len;
-            #ifdef FILES_DEBUG
-            printf (
-                "\nfilelen: %ld - file data len %ld = %ld\n\n", 
-                file_header->len, file_data_len, real_filelen
-            );
-            #endif
-            if (!file_receive_internal (
-                connection,
-                real_filelen,
-                file_fd
-            )) {
-                #ifdef FILES_DEBUG
-                cerver_log_success ("file_receive_internal () has finished");
-                #endif
+		// there is still more data to be received
+		if (file_data_len < file_header->len) {
+			size_t real_filelen = file_header->len - file_data_len;
+			#ifdef FILES_DEBUG
+			printf (
+				"\nfilelen: %ld - file data len %ld = %ld\n\n",
+				file_header->len, file_data_len, real_filelen
+			);
+			#endif
+			if (!file_receive_internal (
+				connection,
+				real_filelen,
+				file_fd
+			)) {
+				#ifdef FILES_DEBUG
+				cerver_log_success ("file_receive_internal () has finished");
+				#endif
 
-                retval = 0;
-            }
+				retval = 0;
+			}
 
-            else {
-                free (*saved_filename);
-                *saved_filename = NULL;
-            }
-        }
+			else {
+				free (*saved_filename);
+				*saved_filename = NULL;
+			}
+		}
 
-        close (file_fd);
-    }
+		close (file_fd);
+	}
 
-    else {
-        cerver_log_error ("file_receive_actual () - failed to open file");
+	else {
+		cerver_log_error ("file_receive_actual () - failed to open file");
 
-        free (*saved_filename);
-        *saved_filename = NULL;
-    }
+		free (*saved_filename);
+		*saved_filename = NULL;
+	}
 
-    return retval;
+	return retval;
 
 }
 

--- a/src/cerver/game/game.c
+++ b/src/cerver/game/game.c
@@ -54,12 +54,11 @@ void game_cerver_stats_print (Cerver *cerver) {
         }
 
         else {
-            char *s = c_string_create ("Can't print game stats of cerver %s -- it is not a game cerver.",
-                cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+                "Can't print game stats of cerver %s -- it is not a game cerver.",
+                cerver->info->name->str
+            );
         }
     }
 
@@ -172,22 +171,20 @@ void game_cerver_register_lobby (GameCerver *game_cerver, Lobby *lobby) {
             game_cerver->stats->current_active_lobbys += 1;
 
             #ifdef CERVER_DEBUG
-            char *status = c_string_create ("Lobby %s was registered to cerver %s.", 
-                lobby->id->str, game_cerver->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+                "Lobby %s was registered to cerver %s.", 
+                lobby->id->str, game_cerver->cerver->info->name->str
+            );
             #endif
         }
 
         else {
-            char *status = c_string_create ("Lobby %s is already registered to cerver %s.", 
-                lobby->id->str, game_cerver->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_NONE, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_NONE,
+                "Lobby %s is already registered to cerver %s.", 
+                lobby->id->str, game_cerver->cerver->info->name->str
+            );
         }
     }
 
@@ -201,25 +198,23 @@ void game_cerver_unregister_lobby (GameCerver *game_cerver, Lobby *lobby) {
                 dlist_get_element (game_cerver->current_lobbys, lobby, NULL));
 
         if (lobby_data) {
-            #ifdef CERVER_DEBUG
             Lobby *l = (Lobby *) lobby_data;
-            char *status = c_string_create ("Unregistered lobby %s from cerver %s", 
-                l->id->str, game_cerver->cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, status);
-                free (status);
-            }
+            #ifdef CERVER_DEBUG
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "Unregistered lobby %s from cerver %s", 
+                l->id->str, game_cerver->cerver->info->name->str
+            );
             #endif
 
             game_cerver->stats->current_active_lobbys--;
 
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Current active lobbys in cerver %s: %d.",
-                game_cerver->cerver->info->name->str, game_cerver->stats->current_active_lobbys);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "Current active lobbys in cerver %s: %d.",
+                game_cerver->cerver->info->name->str, game_cerver->stats->current_active_lobbys
+            );
             #endif
         }
     }
@@ -240,12 +235,11 @@ static void game_lobby_create (Packet *packet) {
             SStringS *stype = (SStringS *) end;
 
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Client %ld requested to create a new lobby in cerver %s of type: %s",
-                packet->client->id, packet->cerver->info->name->str, stype->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "Client %ld requested to create a new lobby in cerver %s of type: %s",
+                packet->client->id, packet->cerver->info->name->str, stype->str
+            );
             #endif
 
             // check that the game type exists and get the configuration
@@ -263,12 +257,11 @@ static void game_lobby_create (Packet *packet) {
                     game_cerver->stats->lobbys_created += 1;
 
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Created new lobby! Sending back to client %ld...",
-                        packet->client->id);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+                        "Created new lobby! Sending back to client %ld...",
+                        packet->client->id
+                    );
                     #endif
 
                     lobby_send (lobby, true, packet->cerver, packet->client, packet->connection);
@@ -277,12 +270,11 @@ static void game_lobby_create (Packet *packet) {
                 // failed to create lobby -- cerver error
                 else {
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Failed to create a new lobby in cerver %s!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                        "Failed to create a new lobby in cerver %s!",
+                        packet->cerver->info->name->str
+                    );
                     #endif
                     // send error packet to client
                     Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Cerver error while creating lobby!");
@@ -297,12 +289,11 @@ static void game_lobby_create (Packet *packet) {
             // the requested game type was not found in cerver, send and error to client
             else {
                 #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Failed to find %s game type in cerver %s!",
-                    stype->str, packet->cerver->info->name->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                    "Failed to find %s game type in cerver %s!",
+                    stype->str, packet->cerver->info->name->str
+                );
                 #endif
                 Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Bad game type!");
                 if (error_packet) {
@@ -315,8 +306,10 @@ static void game_lobby_create (Packet *packet) {
 
         else {
             #ifdef CERVER_DEBUG
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Failed to retreive game type to create lobby!");
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
+                "Failed to retreive game type to create lobby!"
+            );
             #endif
             // send error packet back to client
             Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "No game type provided!");
@@ -334,24 +327,22 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
 
     if (packet && lj) {
         #ifdef CERVER_DEBUG
-        char *s = c_string_create ("Client %ld requested to join lobby with id ""%s"" in cerver %s.",
-            packet->client->id, lj->lobby_id.str, packet->cerver->info->name->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-            free (s);
-        }
+        cerver_log (
+            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+            "Client %ld requested to join lobby with id ""%s"" in cerver %s.",
+            packet->client->id, lj->lobby_id.str, packet->cerver->info->name->str
+        );
         #endif
 
         Lobby *lobby = lobby_search_by_id (packet->cerver, lj->lobby_id.str);
         if (lobby) {
             // check that the lobby is of the pecified type
             #ifdef CERVER_DEBUG
-            char *status = c_string_create ("game_lobby_join_specific () -- found lobby type: %s -- requested lobby type: %s", 
-                lobby->game_type->name->str, lj->game_type.str);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, status);
-                free (status);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "game_lobby_join_specific () -- found lobby type: %s -- requested lobby type: %s", 
+                lobby->game_type->name->str, lj->game_type.str
+            );
             #endif
 
             if (!strcmp (lobby->game_type->name->str, lj->game_type.str)) {
@@ -370,12 +361,11 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
 
                     // success joinning the lobby, send back the lobby
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Client %ld joined lobby with id: %s",
-                        packet->client->id, lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+                        "Client %ld joined lobby with id: %s",
+                        packet->client->id, lobby->id->str
+                    );
                     #endif
 
                     lobby_send (lobby, false, packet->cerver, packet->client, packet->connection);
@@ -384,13 +374,13 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
                 else {
                     // client failed to join the lobby - cerver error
                     // #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Client %ld failed to join lobby %s!",
-                        packet->client->id, lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                        "Client %ld failed to join lobby %s!",
+                        packet->client->id, lobby->id->str
+                    );
                     // #endif
+
                     Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
                     if (error_packet) {
                         packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
@@ -402,12 +392,11 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
 
             // lobby with id does not match the requested game type
             else {
-                char *s = c_string_create ("Client %ld failed to join lobby %s -- types doen't match!",
-                    packet->client->id, lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                    "Client %ld failed to join lobby %s -- types doen't match!",
+                    packet->client->id, lobby->id->str
+                );
 
                 Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
                 if (error_packet) {
@@ -421,13 +410,13 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
         else {
             // failed to get the lobby with matching id
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Failed to get lobby with id: <%s> in cerver %s!", 
-                lj->lobby_id.str, packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Failed to get lobby with id: <%s> in cerver %s!", 
+                lj->lobby_id.str, packet->cerver->info->name->str
+            );
             #endif
+
             Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Not lobby found with id!");
             if (error_packet) {
                 packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
@@ -447,12 +436,11 @@ static void game_lobby_join_search (Packet *packet, LobbyJoin *lj) {
 
     if (packet && lj) {
         #ifdef CERVER_DEBUG
-        char *s = c_string_create ("Client %ld request to join a lobby of type: %s in cerver %s",
-            packet->client->id, lj->game_type.str, packet->cerver->info->name->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-            free (s);
-        }
+        cerver_log (
+            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+            "Client %ld request to join a lobby of type: %s in cerver %s",
+            packet->client->id, lj->game_type.str, packet->cerver->info->name->str
+        );
         #endif
     }
 
@@ -473,9 +461,12 @@ static void game_lobby_join (Packet *packet) {
 
         else {
             #ifdef CERVER_DEBUG
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Failed to retreive info to join lobby!");
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
+                "Failed to retreive info to join lobby!"
+            );
             #endif
+
             // send error packet back to client
             Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to get lobby!");
             if (error_packet) {
@@ -512,12 +503,11 @@ static void game_lobby_start (Packet *packet) {
             SStringS *lobby_id = (SStringS *) end;
 
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Client %ld requested to start lobby with id ""%s"" in cerver %s.",
-                packet->client->id, lobby_id->str, packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "Client %ld requested to start lobby with id ""%s"" in cerver %s.",
+                packet->client->id, lobby_id->str, packet->cerver->info->name->str
+            );
             #endif
 
             Lobby *lobby = lobby_search_by_id (packet->cerver, lobby_id->str);
@@ -528,16 +518,15 @@ static void game_lobby_start (Packet *packet) {
                     lobby->game_type->start (lobby);
                     if (!lobby_start (packet->cerver, lobby)) {
                         #ifdef CERVER_DEBUG
-                        char *s = c_string_create ("Lobby %s has started in cerver %s!",
-                            lobby->id->str, packet->cerver->info->name->str);
-                        if (s) {
-                            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_GAME, s);
-                            free (s);
-                        }
+                        cerver_log (
+                            LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+                            "Lobby %s has started in cerver %s!",
+                            lobby->id->str, packet->cerver->info->name->str
+                        );
                         #endif
 
                         // send success packet back to client
-                        Packet *success_packet = packet_generate_request (GAME_PACKET, GAME_START, NULL, 0);
+                        Packet *success_packet = packet_generate_request (PACKET_TYPE_GAME, GAME_PACKET_TYPE_GAME_START, NULL, 0);
                         if (success_packet) {
                             packet_set_network_values (success_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
                             packet_send (success_packet, 0, NULL, false);
@@ -548,11 +537,9 @@ static void game_lobby_start (Packet *packet) {
                     // failed to start the lobby - cerver error
                     else {
                         #ifdef CERVER_DEBUG
-                        if (s) {
-                            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                            free (s);
-                        }
+                        cerver_log_error ("Failed to start game in lobby!");
                         #endif
+
                         Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, 
                             "Failed to start game in lobby!");
                         if (error_packet) {
@@ -566,13 +553,13 @@ static void game_lobby_start (Packet *packet) {
                 // if the player is not the owner, the lobby cannot be started!
                 else {
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("A common player tried to start lobby %s.", 
-                        lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_GAME,
+                        "A common player tried to start lobby %s.", 
+                        lobby->id->str
+                    );
                     #endif
+
                     Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "You are not the lobby owner!");
                     if (error_packet) {
                         packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
@@ -585,13 +572,13 @@ static void game_lobby_start (Packet *packet) {
             // failed to get the lobby with matching id
             else {
                 #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Failed to get lobby with id: ""%s"" in cerver %s!", 
-                    lobby_id->str, packet->cerver->info->name->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                    "Failed to get lobby with id: ""%s"" in cerver %s!", 
+                    lobby_id->str, packet->cerver->info->name->str
+                );
                 #endif
+
                 Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Not lobby found with id!");
                 if (error_packet) {
                     packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
@@ -602,7 +589,8 @@ static void game_lobby_start (Packet *packet) {
         }
 
         else {
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to retreive info to start lobby!");
+            cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to retreive info to start lobby!");
+
             Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Failed to get lobby!");
             if (error_packet) {
                 packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
@@ -620,21 +608,23 @@ void game_packet_handler (Packet *packet) {
     if (packet) {
         if (packet->header) {
             switch (packet->header->request_type) {
-                case GAME_LOBBY_CREATE: game_lobby_create (packet); break;
-                case GAME_LOBBY_JOIN: game_lobby_join (packet); break;
-                case GAME_LOBBY_LEAVE: game_lobby_leave (packet); break;
-                case GAME_LOBBY_UPDATE: break;
-                case GAME_LOBBY_DESTROY: break;
-
                 // prepares lobby's game data structures
-                case GAME_INIT: game_lobby_init (packet); break;
+                case GAME_PACKET_TYPE_GAME_INIT: game_lobby_init (packet); break;
 
                 // initializes the lobby's handler & update (starts the game)
-                case GAME_START: game_lobby_start (packet); break;
+                case GAME_PACKET_TYPE_GAME_START: game_lobby_start (packet); break;
+
+                case GAME_PACKET_TYPE_LOBBY_CREATE: game_lobby_create (packet); break;
+                case GAME_PACKET_TYPE_LOBBY_JOIN: game_lobby_join (packet); break;
+                case GAME_PACKET_TYPE_LOBBY_LEAVE: game_lobby_leave (packet); break;
+                case GAME_PACKET_TYPE_LOBBY_UPDATE: break;
+                case GAME_PACKET_TYPE_LOBBY_DESTROY: break;
 
                 default:
-                    cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                        "Got a game packet of unknown type!");
+                    cerver_log (
+                        LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+                        "Got a game packet of unknown type!"
+                    );
                     break;
             }
         }

--- a/src/cerver/game/game.c
+++ b/src/cerver/game/game.c
@@ -31,85 +31,85 @@ static inline void lobby_player_delete (void *lp_ptr);
 
 static GameCerverStats *game_cerver_stats_new (void) {
 
-    GameCerverStats *stats = (GameCerverStats *) malloc (sizeof (GameCerverStats));
-    if (stats) memset (stats, 0, sizeof (GameCerverStats));
-    return stats;
+	GameCerverStats *stats = (GameCerverStats *) malloc (sizeof (GameCerverStats));
+	if (stats) memset (stats, 0, sizeof (GameCerverStats));
+	return stats;
 
 }
 
 static void game_cerver_stats_delete (GameCerverStats *stats) {
 
-    if (stats) free (stats);
+	if (stats) free (stats);
 
 }
 
 void game_cerver_stats_print (Cerver *cerver) {
 
-    if (cerver) {
-        if (cerver->type == CERVER_TYPE_GAME) {
-            GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+	if (cerver) {
+		if (cerver->type == CERVER_TYPE_GAME) {
+			GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
 
-            printf ("Current active lobbys:         %d\n", game_cerver->stats->current_active_lobbys);
-            printf ("Total lobbys created:          %d\n", game_cerver->stats->lobbys_created);
-        }
+			printf ("Current active lobbys:         %d\n", game_cerver->stats->current_active_lobbys);
+			printf ("Total lobbys created:          %d\n", game_cerver->stats->lobbys_created);
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-                "Can't print game stats of cerver %s -- it is not a game cerver.",
-                cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+				"Can't print game stats of cerver %s -- it is not a game cerver.",
+				cerver->info->name->str
+			);
+		}
+	}
 
 }
 
 GameCerver *game_new (void) {
 
-    GameCerver *game = (GameCerver *) malloc (sizeof (GameCerver));
-    if (game) {
-        game->cerver = NULL;
+	GameCerver *game = (GameCerver *) malloc (sizeof (GameCerver));
+	if (game) {
+		game->cerver = NULL;
 
-        game->current_lobbys = dlist_init (lobby_delete, lobby_comparator);
+		game->current_lobbys = dlist_init (lobby_delete, lobby_comparator);
 
-        game->lobby_id_generator = lobby_default_id_generator;
-        game->player_comparator = NULL;
+		game->lobby_id_generator = lobby_default_id_generator;
+		game->player_comparator = NULL;
 
-        game->game_types = dlist_init (game_type_delete, NULL);
+		game->game_types = dlist_init (game_type_delete, NULL);
 
-        game->load_game_data = NULL;
-        game->delete_game_data = NULL;
-        game->game_data = NULL;
+		game->load_game_data = NULL;
+		game->delete_game_data = NULL;
+		game->game_data = NULL;
 
-        game->final_game_action = NULL;
-        game->final_action_args = NULL;
+		game->final_game_action = NULL;
+		game->final_action_args = NULL;
 
-        game->stats = game_cerver_stats_new ();
-    }
+		game->stats = game_cerver_stats_new ();
+	}
 
-    return game;
+	return game;
 
 }
 
 void game_delete (void *game_ptr) {
 
-    if (game_ptr) {
-        GameCerver *game = (GameCerver *) game_ptr;
+	if (game_ptr) {
+		GameCerver *game = (GameCerver *) game_ptr;
 
-        dlist_delete (game->current_lobbys);
+		dlist_delete (game->current_lobbys);
 
-        dlist_delete (game->game_types);
+		dlist_delete (game->game_types);
 
-        if (game->game_data) {
-            if (game->delete_game_data)
-                game->delete_game_data (game->game_data);
-            else free (game->game_data);
-        }
+		if (game->game_data) {
+			if (game->delete_game_data)
+				game->delete_game_data (game->game_data);
+			else free (game->game_data);
+		}
 
-        game_cerver_stats_delete (game->stats);
+		game_cerver_stats_delete (game->stats);
 
-        free (game);
-    }
+		free (game);
+	}
 
 }
 
@@ -118,44 +118,44 @@ void game_delete (void *game_ptr) {
 // sets the game cerver's cerver reference
 void game_set_cerver_reference (GameCerver *game_cerver, Cerver *cerver) {
 
-    if (game_cerver) game_cerver->cerver = cerver;
+	if (game_cerver) game_cerver->cerver = cerver;
 
 }
 
 // option to set the game cerver lobby id generator
 void game_set_lobby_id_generator (GameCerver *game_cerver, void *(*lobby_id_generator) (const void *)) {
 
-    if (game_cerver) game_cerver->lobby_id_generator = lobby_id_generator;
+	if (game_cerver) game_cerver->lobby_id_generator = lobby_id_generator;
 
 }
 
 // option to set the game cerver comparator
 void game_set_player_comparator (GameCerver *game_cerver, Comparator player_comparator) {
 
-    if (game_cerver) game_cerver->player_comparator = player_comparator;
+	if (game_cerver) game_cerver->player_comparator = player_comparator;
 
 }
 
 // sets a way to get and destroy game cerver game data
-void game_set_load_game_data (GameCerver *game_cerver, 
-    Action load_game_data, Action delete_game_data) {
+void game_set_load_game_data (GameCerver *game_cerver,
+	Action load_game_data, Action delete_game_data) {
 
-    if (game_cerver) {
-        game_cerver->load_game_data = load_game_data;
-        game_cerver->delete_game_data = delete_game_data;
-    }
+	if (game_cerver) {
+		game_cerver->load_game_data = load_game_data;
+		game_cerver->delete_game_data = delete_game_data;
+	}
 
 }
 
 // option to set an action to be performed right before the game cerver teardown
 // eg. send a message to all players
-void game_set_final_action (GameCerver *game_cerver, 
-    Action final_action, void *final_action_args) {
+void game_set_final_action (GameCerver *game_cerver,
+	Action final_action, void *final_action_args) {
 
-    if (game_cerver) {
-        game_cerver->final_game_action = final_action;
-        game_cerver->final_action_args = final_action_args;
-    }
+	if (game_cerver) {
+		game_cerver->final_game_action = final_action;
+		game_cerver->final_action_args = final_action_args;
+	}
 
 }
 
@@ -164,60 +164,60 @@ void game_set_final_action (GameCerver *game_cerver,
 // registers a new lobby to the game cerver
 void game_cerver_register_lobby (GameCerver *game_cerver, Lobby *lobby) {
 
-    if (game_cerver && lobby) {
-        // check if the lobby is already registered to the game cerver
-        if (!dlist_search (game_cerver->current_lobbys, lobby, NULL)) {
-            dlist_insert_after (game_cerver->current_lobbys, dlist_end (game_cerver->current_lobbys), lobby);
-            game_cerver->stats->current_active_lobbys += 1;
+	if (game_cerver && lobby) {
+		// check if the lobby is already registered to the game cerver
+		if (!dlist_search (game_cerver->current_lobbys, lobby, NULL)) {
+			dlist_insert_after (game_cerver->current_lobbys, dlist_end (game_cerver->current_lobbys), lobby);
+			game_cerver->stats->current_active_lobbys += 1;
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_NONE,
-                "Lobby %s was registered to cerver %s.", 
-                lobby->id->str, game_cerver->cerver->info->name->str
-            );
-            #endif
-        }
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+				"Lobby %s was registered to cerver %s.",
+				lobby->id->str, game_cerver->cerver->info->name->str
+			);
+			#endif
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_NONE,
-                "Lobby %s is already registered to cerver %s.", 
-                lobby->id->str, game_cerver->cerver->info->name->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_NONE,
+				"Lobby %s is already registered to cerver %s.",
+				lobby->id->str, game_cerver->cerver->info->name->str
+			);
+		}
+	}
 
 }
 
 // unregisters a lobby from the game cerver
 void game_cerver_unregister_lobby (GameCerver *game_cerver, Lobby *lobby) {
 
-    if (game_cerver && lobby) {
-        void *lobby_data = dlist_remove_element (game_cerver->current_lobbys, 
-                dlist_get_element (game_cerver->current_lobbys, lobby, NULL));
+	if (game_cerver && lobby) {
+		void *lobby_data = dlist_remove_element (game_cerver->current_lobbys,
+				dlist_get_element (game_cerver->current_lobbys, lobby, NULL));
 
-        if (lobby_data) {
-            Lobby *l = (Lobby *) lobby_data;
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "Unregistered lobby %s from cerver %s", 
-                l->id->str, game_cerver->cerver->info->name->str
-            );
-            #endif
+		if (lobby_data) {
+			Lobby *l = (Lobby *) lobby_data;
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"Unregistered lobby %s from cerver %s",
+				l->id->str, game_cerver->cerver->info->name->str
+			);
+			#endif
 
-            game_cerver->stats->current_active_lobbys--;
+			game_cerver->stats->current_active_lobbys--;
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "Current active lobbys in cerver %s: %d.",
-                game_cerver->cerver->info->name->str, game_cerver->stats->current_active_lobbys
-            );
-            #endif
-        }
-    }
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"Current active lobbys in cerver %s: %d.",
+				game_cerver->cerver->info->name->str, game_cerver->stats->current_active_lobbys
+			);
+			#endif
+		}
+	}
 
 }
 
@@ -229,202 +229,202 @@ void game_cerver_unregister_lobby (GameCerver *game_cerver, Lobby *lobby) {
 
 static void game_lobby_create (Packet *packet) {
 
-    if (packet) {
-        if (packet->data_size >= sizeof (SStringS)) {
-            char *end = (char *) packet->data;
-            SStringS *stype = (SStringS *) end;
+	if (packet) {
+		if (packet->data_size >= sizeof (SStringS)) {
+			char *end = (char *) packet->data;
+			SStringS *stype = (SStringS *) end;
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "Client %ld requested to create a new lobby in cerver %s of type: %s",
-                packet->client->id, packet->cerver->info->name->str, stype->str
-            );
-            #endif
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"Client %ld requested to create a new lobby in cerver %s of type: %s",
+				packet->client->id, packet->cerver->info->name->str, stype->str
+			);
+			#endif
 
-            // check that the game type exists and get the configuration
-            GameCerver *game_cerver = (GameCerver *) packet->cerver->cerver_data;
-            GameType *game_type = game_type_get_by_name (game_cerver->game_types, stype->str);
-            if (game_type) {
-                Lobby *lobby = lobby_create (packet->cerver, packet->client,
-                    game_type->use_default_handler, game_type->custom_handler, game_type->max_players);
-                if (lobby) {
-                    lobby->game_type = game_type;
+			// check that the game type exists and get the configuration
+			GameCerver *game_cerver = (GameCerver *) packet->cerver->cerver_data;
+			GameType *game_type = game_type_get_by_name (game_cerver->game_types, stype->str);
+			if (game_type) {
+				Lobby *lobby = lobby_create (packet->cerver, packet->client,
+					game_type->use_default_handler, game_type->custom_handler, game_type->max_players);
+				if (lobby) {
+					lobby->game_type = game_type;
 
-                    // register the lobby to the cerver
-                    game_cerver_register_lobby (game_cerver, lobby);
+					// register the lobby to the cerver
+					game_cerver_register_lobby (game_cerver, lobby);
 
-                    game_cerver->stats->lobbys_created += 1;
+					game_cerver->stats->lobbys_created += 1;
 
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
-                        "Created new lobby! Sending back to client %ld...",
-                        packet->client->id
-                    );
-                    #endif
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+						"Created new lobby! Sending back to client %ld...",
+						packet->client->id
+					);
+					#endif
 
-                    lobby_send (lobby, true, packet->cerver, packet->client, packet->connection);
-                }
+					lobby_send (lobby, true, packet->cerver, packet->client, packet->connection);
+				}
 
-                // failed to create lobby -- cerver error
-                else {
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                        "Failed to create a new lobby in cerver %s!",
-                        packet->cerver->info->name->str
-                    );
-                    #endif
-                    // send error packet to client
-                    Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Cerver error while creating lobby!");
-                    if (error_packet) {
-                        packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                        packet_send (error_packet, 0, NULL, false);
-                        packet_delete (error_packet);
-                    }
-                }
-            }
+				// failed to create lobby -- cerver error
+				else {
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_GAME,
+						"Failed to create a new lobby in cerver %s!",
+						packet->cerver->info->name->str
+					);
+					#endif
+					// send error packet to client
+					Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Cerver error while creating lobby!");
+					if (error_packet) {
+						packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+						packet_send (error_packet, 0, NULL, false);
+						packet_delete (error_packet);
+					}
+				}
+			}
 
-            // the requested game type was not found in cerver, send and error to client
-            else {
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                    "Failed to find %s game type in cerver %s!",
-                    stype->str, packet->cerver->info->name->str
-                );
-                #endif
-                Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Bad game type!");
-                if (error_packet) {
-                    packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                    packet_send (error_packet, 0, NULL, false);
-                    packet_delete (error_packet);
-                }
-            }
-        }
+			// the requested game type was not found in cerver, send and error to client
+			else {
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_GAME,
+					"Failed to find %s game type in cerver %s!",
+					stype->str, packet->cerver->info->name->str
+				);
+				#endif
+				Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "Bad game type!");
+				if (error_packet) {
+					packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+					packet_send (error_packet, 0, NULL, false);
+					packet_delete (error_packet);
+				}
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Failed to retreive game type to create lobby!"
-            );
-            #endif
-            // send error packet back to client
-            Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "No game type provided!");
-            if (error_packet) {
-                packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                packet_send (error_packet, 0, NULL, false);
-                packet_delete (error_packet);
-            }
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Failed to retreive game type to create lobby!"
+			);
+			#endif
+			// send error packet back to client
+			Packet *error_packet = error_packet_generate (CERVER_ERROR_CREATE_LOBBY, "No game type provided!");
+			if (error_packet) {
+				packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+				packet_send (error_packet, 0, NULL, false);
+				packet_delete (error_packet);
+			}
+		}
+	}
 
 }
 
 static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
 
-    if (packet && lj) {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-            "Client %ld requested to join lobby with id ""%s"" in cerver %s.",
-            packet->client->id, lj->lobby_id.str, packet->cerver->info->name->str
-        );
-        #endif
+	if (packet && lj) {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+			"Client %ld requested to join lobby with id ""%s"" in cerver %s.",
+			packet->client->id, lj->lobby_id.str, packet->cerver->info->name->str
+		);
+		#endif
 
-        Lobby *lobby = lobby_search_by_id (packet->cerver, lj->lobby_id.str);
-        if (lobby) {
-            // check that the lobby is of the pecified type
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "game_lobby_join_specific () -- found lobby type: %s -- requested lobby type: %s", 
-                lobby->game_type->name->str, lj->game_type.str
-            );
-            #endif
+		Lobby *lobby = lobby_search_by_id (packet->cerver, lj->lobby_id.str);
+		if (lobby) {
+			// check that the lobby is of the pecified type
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"game_lobby_join_specific () -- found lobby type: %s -- requested lobby type: %s",
+				lobby->game_type->name->str, lj->game_type.str
+			);
+			#endif
 
-            if (!strcmp (lobby->game_type->name->str, lj->game_type.str)) {
-                if (!lobby_join (packet->cerver, packet->client, lobby)) {
-                    Player *query = player_new ();
-                    if (query) {
-                        query->client = packet->client;
-                        LobbyPlayer *lp = lobby_player_new (lobby, player_get_from_lobby (lobby, query));
-                        if (lp) {
-                            if (lobby->game_type->on_lobby_join) lobby->game_type->on_lobby_join (lp);
-                            lobby_player_delete (lp);
-                        }
+			if (!strcmp (lobby->game_type->name->str, lj->game_type.str)) {
+				if (!lobby_join (packet->cerver, packet->client, lobby)) {
+					Player *query = player_new ();
+					if (query) {
+						query->client = packet->client;
+						LobbyPlayer *lp = lobby_player_new (lobby, player_get_from_lobby (lobby, query));
+						if (lp) {
+							if (lobby->game_type->on_lobby_join) lobby->game_type->on_lobby_join (lp);
+							lobby_player_delete (lp);
+						}
 
-                        free (query);
-                    }
+						free (query);
+					}
 
-                    // success joinning the lobby, send back the lobby
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
-                        "Client %ld joined lobby with id: %s",
-                        packet->client->id, lobby->id->str
-                    );
-                    #endif
+					// success joinning the lobby, send back the lobby
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+						"Client %ld joined lobby with id: %s",
+						packet->client->id, lobby->id->str
+					);
+					#endif
 
-                    lobby_send (lobby, false, packet->cerver, packet->client, packet->connection);
-                }
+					lobby_send (lobby, false, packet->cerver, packet->client, packet->connection);
+				}
 
-                else {
-                    // client failed to join the lobby - cerver error
-                    // #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                        "Client %ld failed to join lobby %s!",
-                        packet->client->id, lobby->id->str
-                    );
-                    // #endif
+				else {
+					// client failed to join the lobby - cerver error
+					// #ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_GAME,
+						"Client %ld failed to join lobby %s!",
+						packet->client->id, lobby->id->str
+					);
+					// #endif
 
-                    Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
-                    if (error_packet) {
-                        packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                        packet_send (error_packet, 0, NULL, false);
-                        packet_delete (error_packet);
-                    }
-                }
-            }
+					Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
+					if (error_packet) {
+						packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+						packet_send (error_packet, 0, NULL, false);
+						packet_delete (error_packet);
+					}
+				}
+			}
 
-            // lobby with id does not match the requested game type
-            else {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                    "Client %ld failed to join lobby %s -- types doen't match!",
-                    packet->client->id, lobby->id->str
-                );
+			// lobby with id does not match the requested game type
+			else {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_GAME,
+					"Client %ld failed to join lobby %s -- types doen't match!",
+					packet->client->id, lobby->id->str
+				);
 
-                Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
-                if (error_packet) {
-                    packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                    packet_send (error_packet, 0, NULL, false);
-                    packet_delete (error_packet);
-                }
-            }
-        }
+				Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to join lobby!");
+				if (error_packet) {
+					packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+					packet_send (error_packet, 0, NULL, false);
+					packet_delete (error_packet);
+				}
+			}
+		}
 
-        else {
-            // failed to get the lobby with matching id
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Failed to get lobby with id: <%s> in cerver %s!", 
-                lj->lobby_id.str, packet->cerver->info->name->str
-            );
-            #endif
+		else {
+			// failed to get the lobby with matching id
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Failed to get lobby with id: <%s> in cerver %s!",
+				lj->lobby_id.str, packet->cerver->info->name->str
+			);
+			#endif
 
-            Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Not lobby found with id!");
-            if (error_packet) {
-                packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                packet_send (error_packet, 0, NULL, false);
-                packet_delete (error_packet);
-            }
-        }
-    }
+			Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Not lobby found with id!");
+			if (error_packet) {
+				packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+				packet_send (error_packet, 0, NULL, false);
+				packet_delete (error_packet);
+			}
+		}
+	}
 
 }
 
@@ -434,201 +434,201 @@ static void game_lobby_join_specific (Packet *packet, LobbyJoin *lj) {
 // TODO: what to do if non is found? create a new one? or just return an error?
 static void game_lobby_join_search (Packet *packet, LobbyJoin *lj) {
 
-    if (packet && lj) {
-        #ifdef CERVER_DEBUG
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-            "Client %ld request to join a lobby of type: %s in cerver %s",
-            packet->client->id, lj->game_type.str, packet->cerver->info->name->str
-        );
-        #endif
-    }
+	if (packet && lj) {
+		#ifdef CERVER_DEBUG
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+			"Client %ld request to join a lobby of type: %s in cerver %s",
+			packet->client->id, lj->game_type.str, packet->cerver->info->name->str
+		);
+		#endif
+	}
 
 }
 
 static void game_lobby_join (Packet *packet) {
 
-    if (packet) {
-        if (packet->data_size >= sizeof (LobbyJoin)) {
-            char *end = (char *) packet->data;
-            LobbyJoin *lj = (LobbyJoin *) end;
+	if (packet) {
+		if (packet->data_size >= sizeof (LobbyJoin)) {
+			char *end = (char *) packet->data;
+			LobbyJoin *lj = (LobbyJoin *) end;
 
-            // check if we have to search a lobby for the player
-            // or he wants to join an specific lobby 
-            if (lj->lobby_id.len > 0) game_lobby_join_specific (packet, lj);
-            else game_lobby_join_search (packet, lj);
-        }
+			// check if we have to search a lobby for the player
+			// or he wants to join an specific lobby
+			if (lj->lobby_id.len > 0) game_lobby_join_specific (packet, lj);
+			else game_lobby_join_search (packet, lj);
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Failed to retreive info to join lobby!"
-            );
-            #endif
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Failed to retreive info to join lobby!"
+			);
+			#endif
 
-            // send error packet back to client
-            Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to get lobby!");
-            if (error_packet) {
-                packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                packet_send (error_packet, 0, NULL, false);
-                packet_delete (error_packet);
-            }
-        }
-    }
+			// send error packet back to client
+			Packet *error_packet = error_packet_generate (CERVER_ERROR_JOIN_LOBBY, "Failed to get lobby!");
+			if (error_packet) {
+				packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+				packet_send (error_packet, 0, NULL, false);
+				packet_delete (error_packet);
+			}
+		}
+	}
 
 }
 
 static void game_lobby_leave (Packet *packet) {
 
-    if (packet) {
-        // FIXME:
-    }
+	if (packet) {
+		// FIXME:
+	}
 
 }
 
 // prepares lobby's game data structures
 static void game_lobby_init (Packet *packet) {
 
-    // TODO:
+	// TODO:
 
 }
 
 // initializes the lobby update (starts the game)
 static void game_lobby_start (Packet *packet) {
 
-    if (packet) {
-        if (packet->data_size >= sizeof (SStringS)) {
-            char *end = (char *) packet->data;
-            SStringS *lobby_id = (SStringS *) end;
+	if (packet) {
+		if (packet->data_size >= sizeof (SStringS)) {
+			char *end = (char *) packet->data;
+			SStringS *lobby_id = (SStringS *) end;
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "Client %ld requested to start lobby with id ""%s"" in cerver %s.",
-                packet->client->id, lobby_id->str, packet->cerver->info->name->str
-            );
-            #endif
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"Client %ld requested to start lobby with id ""%s"" in cerver %s.",
+				packet->client->id, lobby_id->str, packet->cerver->info->name->str
+			);
+			#endif
 
-            Lobby *lobby = lobby_search_by_id (packet->cerver, lobby_id->str);
-            if (lobby) {
-                // check if the client is the owner of the lobby
-                Player *owner = player_get_by_sock_fd_list (lobby, packet->connection->socket->sock_fd);
-                if (owner) {
-                    lobby->game_type->start (lobby);
-                    if (!lobby_start (packet->cerver, lobby)) {
-                        #ifdef CERVER_DEBUG
-                        cerver_log (
-                            LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
-                            "Lobby %s has started in cerver %s!",
-                            lobby->id->str, packet->cerver->info->name->str
-                        );
-                        #endif
+			Lobby *lobby = lobby_search_by_id (packet->cerver, lobby_id->str);
+			if (lobby) {
+				// check if the client is the owner of the lobby
+				Player *owner = player_get_by_sock_fd_list (lobby, packet->connection->socket->sock_fd);
+				if (owner) {
+					lobby->game_type->start (lobby);
+					if (!lobby_start (packet->cerver, lobby)) {
+						#ifdef CERVER_DEBUG
+						cerver_log (
+							LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+							"Lobby %s has started in cerver %s!",
+							lobby->id->str, packet->cerver->info->name->str
+						);
+						#endif
 
-                        // send success packet back to client
-                        Packet *success_packet = packet_generate_request (PACKET_TYPE_GAME, GAME_PACKET_TYPE_GAME_START, NULL, 0);
-                        if (success_packet) {
-                            packet_set_network_values (success_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                            packet_send (success_packet, 0, NULL, false);
-                            packet_delete (success_packet);
-                        }
-                    }
+						// send success packet back to client
+						Packet *success_packet = packet_generate_request (PACKET_TYPE_GAME, GAME_PACKET_TYPE_GAME_START, NULL, 0);
+						if (success_packet) {
+							packet_set_network_values (success_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+							packet_send (success_packet, 0, NULL, false);
+							packet_delete (success_packet);
+						}
+					}
 
-                    // failed to start the lobby - cerver error
-                    else {
-                        #ifdef CERVER_DEBUG
-                        cerver_log_error ("Failed to start game in lobby!");
-                        #endif
+					// failed to start the lobby - cerver error
+					else {
+						#ifdef CERVER_DEBUG
+						cerver_log_error ("Failed to start game in lobby!");
+						#endif
 
-                        Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, 
-                            "Failed to start game in lobby!");
-                        if (error_packet) {
-                            packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                            packet_send (error_packet, 0, NULL, false);
-                            packet_delete (error_packet);
-                        }
-                    }
-                }
+						Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START,
+							"Failed to start game in lobby!");
+						if (error_packet) {
+							packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+							packet_send (error_packet, 0, NULL, false);
+							packet_delete (error_packet);
+						}
+					}
+				}
 
-                // if the player is not the owner, the lobby cannot be started!
-                else {
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_GAME,
-                        "A common player tried to start lobby %s.", 
-                        lobby->id->str
-                    );
-                    #endif
+				// if the player is not the owner, the lobby cannot be started!
+				else {
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_GAME,
+						"A common player tried to start lobby %s.",
+						lobby->id->str
+					);
+					#endif
 
-                    Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "You are not the lobby owner!");
-                    if (error_packet) {
-                        packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                        packet_send (error_packet, 0, NULL, false);
-                        packet_delete (error_packet);
-                    }
-                }
-            }
+					Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "You are not the lobby owner!");
+					if (error_packet) {
+						packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+						packet_send (error_packet, 0, NULL, false);
+						packet_delete (error_packet);
+					}
+				}
+			}
 
-            // failed to get the lobby with matching id
-            else {
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                    "Failed to get lobby with id: ""%s"" in cerver %s!", 
-                    lobby_id->str, packet->cerver->info->name->str
-                );
-                #endif
+			// failed to get the lobby with matching id
+			else {
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_GAME,
+					"Failed to get lobby with id: ""%s"" in cerver %s!",
+					lobby_id->str, packet->cerver->info->name->str
+				);
+				#endif
 
-                Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Not lobby found with id!");
-                if (error_packet) {
-                    packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                    packet_send (error_packet, 0, NULL, false);
-                    packet_delete (error_packet);
-                }
-            }
-        }
+				Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Not lobby found with id!");
+				if (error_packet) {
+					packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+					packet_send (error_packet, 0, NULL, false);
+					packet_delete (error_packet);
+				}
+			}
+		}
 
-        else {
-            cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to retreive info to start lobby!");
+		else {
+			cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to retreive info to start lobby!");
 
-            Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Failed to get lobby!");
-            if (error_packet) {
-                packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-                packet_send (error_packet, 0, NULL, false);
-                packet_delete (error_packet);
-            }
-        }
-    }
+			Packet *error_packet = error_packet_generate (CERVER_ERROR_GAME_START, "Failed to get lobby!");
+			if (error_packet) {
+				packet_set_network_values (error_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+				packet_send (error_packet, 0, NULL, false);
+				packet_delete (error_packet);
+			}
+		}
+	}
 
 }
 
 // handles a game type packet
 void game_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->header) {
-            switch (packet->header->request_type) {
-                // prepares lobby's game data structures
-                case GAME_PACKET_TYPE_GAME_INIT: game_lobby_init (packet); break;
+	if (packet) {
+		if (packet->header) {
+			switch (packet->header->request_type) {
+				// prepares lobby's game data structures
+				case GAME_PACKET_TYPE_GAME_INIT: game_lobby_init (packet); break;
 
-                // initializes the lobby's handler & update (starts the game)
-                case GAME_PACKET_TYPE_GAME_START: game_lobby_start (packet); break;
+				// initializes the lobby's handler & update (starts the game)
+				case GAME_PACKET_TYPE_GAME_START: game_lobby_start (packet); break;
 
-                case GAME_PACKET_TYPE_LOBBY_CREATE: game_lobby_create (packet); break;
-                case GAME_PACKET_TYPE_LOBBY_JOIN: game_lobby_join (packet); break;
-                case GAME_PACKET_TYPE_LOBBY_LEAVE: game_lobby_leave (packet); break;
-                case GAME_PACKET_TYPE_LOBBY_UPDATE: break;
-                case GAME_PACKET_TYPE_LOBBY_DESTROY: break;
+				case GAME_PACKET_TYPE_LOBBY_CREATE: game_lobby_create (packet); break;
+				case GAME_PACKET_TYPE_LOBBY_JOIN: game_lobby_join (packet); break;
+				case GAME_PACKET_TYPE_LOBBY_LEAVE: game_lobby_leave (packet); break;
+				case GAME_PACKET_TYPE_LOBBY_UPDATE: break;
+				case GAME_PACKET_TYPE_LOBBY_DESTROY: break;
 
-                default:
-                    cerver_log (
-                        LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                        "Got a game packet of unknown type!"
-                    );
-                    break;
-            }
-        }
-    }
+				default:
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+						"Got a game packet of unknown type!"
+					);
+					break;
+			}
+		}
+	}
 
 }
 
@@ -636,13 +636,13 @@ void game_packet_handler (Packet *packet) {
 
 static LobbyPlayer *lobby_player_new (Lobby *lobby, Player *player) {
 
-    LobbyPlayer *lp = (LobbyPlayer *) malloc (sizeof (LobbyPlayer));
-    if (lp) {
-        lp->lobby = lobby;
-        lp->player = player;
-    }
+	LobbyPlayer *lp = (LobbyPlayer *) malloc (sizeof (LobbyPlayer));
+	if (lp) {
+		lp->lobby = lobby;
+		lp->player = player;
+	}
 
-    return lp;
+	return lp;
 
 }
 

--- a/src/cerver/game/gametype.c
+++ b/src/cerver/game/gametype.c
@@ -10,16 +10,16 @@ GameType *game_type_get_by_name (DoubleList *game_types, const char *name);
 
 GameType *game_type_new (void) {
 
-    GameType *type = (GameType *) malloc (sizeof (GameType));
-    if (type) {
-        memset (type, 0, sizeof (GameType));
-        type->name = NULL;
-        type->data = NULL;
-        type->delete_data = NULL;
-        type->start = type->end = NULL;
-    }
+	GameType *type = (GameType *) malloc (sizeof (GameType));
+	if (type) {
+		memset (type, 0, sizeof (GameType));
+		type->name = NULL;
+		type->data = NULL;
+		type->delete_data = NULL;
+		type->start = type->end = NULL;
+	}
 
-    return type;
+	return type;
 
 }
 
@@ -28,55 +28,55 @@ GameType *game_type_new (void) {
 // NULL on delete_data to use free by default
 // NULL on start or end is safe
 GameType *game_type_create (const char *name, void *data, void (*delete_data)(void *),
-    void *(*start)(void *), void *(*end) (void *)) {
+	void *(*start)(void *), void *(*end) (void *)) {
 
-    GameType *type = NULL;
-    if (name) {
-        type = game_type_new ();
-        if (type) {
-            type->name = str_new (name);
-            type->data = data;
-            type->delete_data = delete_data;
-            type->start = start;
-            type->end = end;
+	GameType *type = NULL;
+	if (name) {
+		type = game_type_new ();
+		if (type) {
+			type->name = str_new (name);
+			type->data = data;
+			type->delete_data = delete_data;
+			type->start = start;
+			type->end = end;
 
-            type->use_default_handler = true;
-            type->custom_handler = NULL;
-            type->max_players = 0;
-        }
-    }
+			type->use_default_handler = true;
+			type->custom_handler = NULL;
+			type->max_players = 0;
+		}
+	}
 
-    return type;
+	return type;
 
 }
 
 void game_type_delete (void *ptr) {
 
-    if (ptr) {
-        GameType *type = (GameType *) ptr;
-        str_delete (type->name);
-        if (type->delete_data) type->delete_data (type->data);
-        else free (type->data);
+	if (ptr) {
+		GameType *type = (GameType *) ptr;
+		str_delete (type->name);
+		if (type->delete_data) type->delete_data (type->data);
+		else free (type->data);
 
-        free (type);
-    }
+		free (type);
+	}
 
 }
 
 // add the required configuration that is needed to create a new lobby for the game type when requested
 // returns 0 on success, 1 on error
 int game_type_add_lobby_config (GameType *game_type,
-    bool use_default_handler, Action custom_handler, u32 max_players) {
+	bool use_default_handler, Action custom_handler, u32 max_players) {
 
-    int retval = 0;
+	int retval = 0;
 
-    if (game_type) {
-        game_type->use_default_handler = use_default_handler;
-        game_type->custom_handler = custom_handler;
-        game_type->max_players = max_players;
-    }
+	if (game_type) {
+		game_type->use_default_handler = use_default_handler;
+		game_type->custom_handler = custom_handler;
+		game_type->max_players = max_players;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -84,64 +84,64 @@ int game_type_add_lobby_config (GameType *game_type,
 // a reference to the player and lobby is passed as an argument
 void game_type_set_on_lobby_join (GameType *game_type, Action on_lobby_join) {
 
-    if (game_type) game_type->on_lobby_join = on_lobby_join;
+	if (game_type) game_type->on_lobby_join = on_lobby_join;
 
 }
 
 // sets an action to be called when a player leaves the lobby (game)
 // a reference to the player and lobby is passed as an argument
 void game_type_set_on_lobby_leave (GameType *game_type, Action on_lobby_leave) {
-    
-    if (game_type) game_type->on_lobby_leave = on_lobby_leave;
+
+	if (game_type) game_type->on_lobby_leave = on_lobby_leave;
 
 }
 
 // registers a new game type, returns 0 on LOG_TYPE_SUCCESS, 1 on error
 int game_type_register (DoubleList *game_types, GameType *game_type) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (game_type) {
-        retval = dlist_insert_after (game_types, 
-            dlist_end (game_types), game_type);
-    }
+	if (game_type) {
+		retval = dlist_insert_after (game_types,
+			dlist_end (game_types), game_type);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // unregister a game type, returns 0 on LOG_TYPE_SUCCESS, 1 on error
 int game_type_unregister (DoubleList *game_types, const char *name) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (name) {
-        GameType *game_type = NULL;
-        for (ListElement *le = dlist_start (game_types); le; le = le->next) {
-            game_type = (GameType *) le->data;
-            if (!strcmp (name, game_type->name->str)) {
-                game_type_delete (dlist_remove_element (game_types, le));
-                retval = 0;
-            }
-        }
-    }
+	if (name) {
+		GameType *game_type = NULL;
+		for (ListElement *le = dlist_start (game_types); le; le = le->next) {
+			game_type = (GameType *) le->data;
+			if (!strcmp (name, game_type->name->str)) {
+				game_type_delete (dlist_remove_element (game_types, le));
+				retval = 0;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets a registered game type by its name
 GameType *game_type_get_by_name (DoubleList *game_types, const char *name) {
 
-    GameType *game_type = NULL;
+	GameType *game_type = NULL;
 
-    if (name) {
-        for (ListElement *le = dlist_start (game_types); le; le = le->next) {
-            game_type = (GameType *) le->data;
-            if (!strcmp (name, game_type->name->str)) break;
-        }
-    }
+	if (name) {
+		for (ListElement *le = dlist_start (game_types); le; le = le->next) {
+			game_type = (GameType *) le->data;
+			if (!strcmp (name, game_type->name->str)) break;
+		}
+	}
 
-    return game_type;
+	return game_type;
 
 }

--- a/src/cerver/game/lobby.c
+++ b/src/cerver/game/lobby.c
@@ -35,42 +35,42 @@ void lobby_poll (void *ptr);
 
 void *lobby_default_id_generator (const void *data_ptr) {
 
-    time_t rawtime = time (NULL);
-    struct tm *timeinfo = localtime (&rawtime);
-    // we generate the string timestamp in order to generate the lobby id
-    char temp[50] = { 0 };
-    size_t len = strftime (temp, 50, "%F-%r", timeinfo);
-    printf ("%s\n", temp);
+	time_t rawtime = time (NULL);
+	struct tm *timeinfo = localtime (&rawtime);
+	// we generate the string timestamp in order to generate the lobby id
+	char temp[50] = { 0 };
+	size_t len = strftime (temp, 50, "%F-%r", timeinfo);
+	printf ("%s\n", temp);
 
-    uint8_t hash[32];
-    char hash_string[65];
+	uint8_t hash[32];
+	char hash_string[65];
 
-    sha_256_calc (hash, temp, len);
-    sha_256_hash_to_string (hash_string, hash);
+	sha_256_calc (hash, temp, len);
+	sha_256_hash_to_string (hash_string, hash);
 
-    return str_new (hash_string);
+	return str_new (hash_string);
 
 }
 
 static CerverLobby *cerver_lobby_new (Cerver *cerver, Lobby *lobby) {
 
-    CerverLobby *cerver_lobby = (CerverLobby *) malloc (sizeof (CerverLobby));
-    if (cerver_lobby) {
-        cerver_lobby->cerver = cerver;
-        cerver_lobby->lobby = lobby;
-    }
+	CerverLobby *cerver_lobby = (CerverLobby *) malloc (sizeof (CerverLobby));
+	if (cerver_lobby) {
+		cerver_lobby->cerver = cerver;
+		cerver_lobby->lobby = lobby;
+	}
 
-    return cerver_lobby;
+	return cerver_lobby;
 
 }
 
 static void cerver_lobby_delete (CerverLobby *cerver_lobby) {
 
-    if (cerver_lobby) {
-        cerver_lobby->cerver = NULL;
-        cerver_lobby->lobby = NULL;
-        free (cerver_lobby);
-    }
+	if (cerver_lobby) {
+		cerver_lobby->cerver = NULL;
+		cerver_lobby->lobby = NULL;
+		free (cerver_lobby);
+	}
 
 }
 
@@ -80,194 +80,194 @@ static void cerver_lobby_delete (CerverLobby *cerver_lobby) {
 
 static LobbyStats *lobby_stats_new (void) {
 
-    LobbyStats *stats = (LobbyStats *) malloc (sizeof (LobbyStats));
-    if (stats) {
-        memset (stats, 0, sizeof (LobbyStats));
-        stats->received_packets = packets_per_type_new ();
-        stats->sent_packets = packets_per_type_new ();
-    } 
-    
-    return stats;
+	LobbyStats *stats = (LobbyStats *) malloc (sizeof (LobbyStats));
+	if (stats) {
+		memset (stats, 0, sizeof (LobbyStats));
+		stats->received_packets = packets_per_type_new ();
+		stats->sent_packets = packets_per_type_new ();
+	}
+
+	return stats;
 
 }
 
 static inline void lobby_stats_delete (LobbyStats *stats) {
 
-    if (stats) {
-        packets_per_type_delete (stats->received_packets);
-        packets_per_type_delete (stats->sent_packets);
-        free (stats);
-    }
+	if (stats) {
+		packets_per_type_delete (stats->received_packets);
+		packets_per_type_delete (stats->sent_packets);
+		free (stats);
+	}
 
 }
 
 // sets the lobby stats threshold time (how often the stats get reset)
 void lobby_stats_set_threshold_time (Lobby *lobby, time_t threshold_time) {
 
-    if (lobby) {
-        if (lobby->stats) lobby->stats->threshold_time = threshold_time;
-    }
+	if (lobby) {
+		if (lobby->stats) lobby->stats->threshold_time = threshold_time;
+	}
 
 }
 
 void lobby_stats_print (Lobby *lobby) {
 
-    if (lobby) {
-        if (lobby->stats) {
-            printf ("\nLobby's %s stats: ", lobby->id->str);
-            printf ("\nThreshold time:            %ld\n", lobby->stats->threshold_time);
+	if (lobby) {
+		if (lobby->stats) {
+			printf ("\nLobby's %s stats: ", lobby->id->str);
+			printf ("\nThreshold time:            %ld\n", lobby->stats->threshold_time);
 
-            printf ("Total packets received:        %ld\n", lobby->stats->n_packets_received);
-            printf ("Total receives done:           %ld\n", lobby->stats->n_receives_done);
-            printf ("Total bytes received:          %ld\n\n", lobby->stats->bytes_received);
+			printf ("Total packets received:        %ld\n", lobby->stats->n_packets_received);
+			printf ("Total receives done:           %ld\n", lobby->stats->n_receives_done);
+			printf ("Total bytes received:          %ld\n\n", lobby->stats->bytes_received);
 
-            printf ("N packets sent:                %ld\n", lobby->stats->n_packets_sent);
-            printf ("Total bytes sent:              %ld\n", lobby->stats->bytes_sent);
+			printf ("N packets sent:                %ld\n", lobby->stats->n_packets_sent);
+			printf ("Total bytes sent:              %ld\n", lobby->stats->bytes_sent);
 
-            printf ("\nReceived packets:\n");
-            packets_per_type_print (lobby->stats->received_packets);
+			printf ("\nReceived packets:\n");
+			packets_per_type_print (lobby->stats->received_packets);
 
-            printf ("\nSent packets:\n");
-            packets_per_type_print (lobby->stats->sent_packets);
-        }
+			printf ("\nSent packets:\n");
+			packets_per_type_print (lobby->stats->sent_packets);
+		}
 
-        else {
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Lobby %s does not have a reference to lobby stats!",
-                lobby->id->str
-            );
-        }
-    }
+		else {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Lobby %s does not have a reference to lobby stats!",
+				lobby->id->str
+			);
+		}
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_WARNING, LOG_TYPE_CERVER, 
-            "Cant print stats of a NULL lobby!"
-        );
-    }
+	else {
+		cerver_log (
+			LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+			"Cant print stats of a NULL lobby!"
+		);
+	}
 
 }
 
 // lobby constructor
 Lobby *lobby_new (void) {
 
-    Lobby *lobby = (Lobby *) malloc (sizeof (Lobby));
-    if (lobby) {
-        memset (lobby, 0, sizeof (Lobby));
+	Lobby *lobby = (Lobby *) malloc (sizeof (Lobby));
+	if (lobby) {
+		memset (lobby, 0, sizeof (Lobby));
 
-        lobby->cerver = NULL;
+		lobby->cerver = NULL;
 
-        lobby->id = NULL;
+		lobby->id = NULL;
 
-        lobby->sock_fd_player_map = NULL;
-        lobby->players_fds = NULL;
-        lobby->poll_timeout = LOBBY_DEFAULT_POLL_TIMEOUT;
+		lobby->sock_fd_player_map = NULL;
+		lobby->players_fds = NULL;
+		lobby->poll_timeout = LOBBY_DEFAULT_POLL_TIMEOUT;
 
-        lobby->running = lobby->in_game = false;
+		lobby->running = lobby->in_game = false;
 
-        lobby->owner = NULL;
+		lobby->owner = NULL;
 
-        lobby->default_handler = true;
-        lobby->handler = lobby_poll;
-        lobby->packet_handler = NULL;
+		lobby->default_handler = true;
+		lobby->handler = lobby_poll;
+		lobby->packet_handler = NULL;
 
-        lobby->game_type = NULL;
+		lobby->game_type = NULL;
 
-        lobby->game_settings = NULL;
-        lobby->game_settings_delete = NULL;
+		lobby->game_settings = NULL;
+		lobby->game_settings_delete = NULL;
 
-        lobby->game_data = NULL;
-        lobby->game_data_delete = NULL;
+		lobby->game_data = NULL;
+		lobby->game_data_delete = NULL;
 
-        lobby->update = NULL;
+		lobby->update = NULL;
 
-        lobby->stats = NULL;
-    }
+		lobby->stats = NULL;
+	}
 
-    return lobby;
+	return lobby;
 
 }
 
 void lobby_delete (void *lobby_ptr) {
 
-    if (lobby_ptr) {
-        Lobby *lobby = (Lobby *) lobby_ptr;
+	if (lobby_ptr) {
+		Lobby *lobby = (Lobby *) lobby_ptr;
 
-        str_delete (lobby->id);
+		str_delete (lobby->id);
 
-        dlist_delete (lobby->players);
-        htab_destroy (lobby->sock_fd_player_map);
+		dlist_delete (lobby->players);
+		htab_destroy (lobby->sock_fd_player_map);
 
-        if (lobby->players_fds) free (lobby->players_fds);
+		if (lobby->players_fds) free (lobby->players_fds);
 
-        lobby->owner = NULL;
+		lobby->owner = NULL;
 
-        if (lobby->game_settings) {
-            if (lobby->game_settings_delete) 
-                lobby->game_settings_delete (lobby->game_settings);
-            else free (lobby->game_settings);
-        }
+		if (lobby->game_settings) {
+			if (lobby->game_settings_delete)
+				lobby->game_settings_delete (lobby->game_settings);
+			else free (lobby->game_settings);
+		}
 
-        if (lobby->game_data) {
-            if (lobby->game_data_delete) 
-                lobby->game_data_delete (lobby->game_data);
-            else free (lobby->game_data);
-        }
+		if (lobby->game_data) {
+			if (lobby->game_data_delete)
+				lobby->game_data_delete (lobby->game_data);
+			else free (lobby->game_data);
+		}
 
-        lobby_stats_delete (lobby->stats);
+		lobby_stats_delete (lobby->stats);
 
-        free (lobby);
-    }
+		free (lobby);
+	}
 
 }
 
 // initializes a new lobby
 u8 lobby_init (GameCerver *game_cerver, Lobby *lobby) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby) {
-        lobby->creation_time_stamp = time (NULL);
-        void *id = game_cerver->lobby_id_generator (lobby);
-        if (id) {
-            lobby->id = (String *) id;
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                "Lobby id: %s", lobby->id->str
-            );
-            #endif
+	if (lobby) {
+		lobby->creation_time_stamp = time (NULL);
+		void *id = game_cerver->lobby_id_generator (lobby);
+		if (id) {
+			lobby->id = (String *) id;
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				"Lobby id: %s", lobby->id->str
+			);
+			#endif
 
-            lobby->sock_fd_player_map = htab_create (LOBBY_DEFAULT_MAX_PLAYERS, NULL, NULL);
-            lobby->players = dlist_init (player_delete, player_comparator_client_id);
-            
-            lobby->stats = lobby_stats_new ();
+			lobby->sock_fd_player_map = htab_create (LOBBY_DEFAULT_MAX_PLAYERS, NULL, NULL);
+			lobby->players = dlist_init (player_delete, player_comparator_client_id);
 
-            if (lobby->sock_fd_player_map && lobby->players && lobby->stats) retval = 0;
-        }
-    }
+			lobby->stats = lobby_stats_new ();
 
-    return retval;
+			if (lobby->sock_fd_player_map && lobby->players && lobby->stats) retval = 0;
+		}
+	}
+
+	return retval;
 
 }
 
 //compares two lobbys based on their ids
 int lobby_comparator (const void *one, const void *two) {
 
-    if (one && two) return str_compare (((Lobby *) one)->id, ((Lobby *) two)->id);
-    else if (!one && two) return -1;
-    else if (one && ! two) return 1;
-    return 0;
+	if (one && two) return str_compare (((Lobby *) one)->id, ((Lobby *) two)->id);
+	else if (!one && two) return -1;
+	else if (one && ! two) return 1;
+	return 0;
 
 }
 
 // set lobby poll function timeout in mili secs
 // how often we are checking for new packages
-void lobby_set_poll_time_out (Lobby *lobby, unsigned int timeout) { 
-    
-    if (lobby) lobby->poll_timeout = timeout; 
-    
+void lobby_set_poll_time_out (Lobby *lobby, unsigned int timeout) {
+
+	if (lobby) lobby->poll_timeout = timeout;
+
 }
 
 // set the lobby hanlder
@@ -276,27 +276,27 @@ void lobby_set_handler (Lobby *lobby, Action handler) { if (lobby) lobby->handle
 // set the lobby packet handler
 void lobby_set_packet_handler (Lobby *lobby, Action packet_handler) {
 
-    if (lobby) lobby->packet_handler = packet_handler;
+	if (lobby) lobby->packet_handler = packet_handler;
 
 }
 
 // sets the lobby settings and a function to delete it
 void lobby_set_game_settings (Lobby *lobby, void *game_settings, Action game_settings_delete) {
 
-    if (lobby) {
-        lobby->game_settings = game_settings;
-        lobby->game_settings_delete = game_settings_delete;
-    }
+	if (lobby) {
+		lobby->game_settings = game_settings;
+		lobby->game_settings_delete = game_settings_delete;
+	}
 
 }
 
 // sets the lobby game data and a function to delete it
 void lobby_set_game_data (Lobby *lobby, void *game_data, Action game_data_delete) {
 
-    if (lobby) {
-        lobby->game_data = game_data;
-        lobby->game_data_delete = game_data_delete;
-    }
+	if (lobby) {
+		lobby->game_data = game_data;
+		lobby->game_data_delete = game_data_delete;
+	}
 
 }
 
@@ -306,79 +306,79 @@ void lobby_set_update (Lobby *lobby, Action update) { if (lobby) lobby->update =
 // searches a lobby in the game cerver and returns a reference to it
 Lobby *lobby_get (GameCerver *game_cerver, Lobby *query) {
 
-    Lobby *found = NULL;
-    for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
-        found = (Lobby *) le->data;
-        if (!lobby_comparator (found, query)) return found;
-    }
+	Lobby *found = NULL;
+	for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
+		found = (Lobby *) le->data;
+		if (!lobby_comparator (found, query)) return found;
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
 // seraches for a lobby with matching id
 Lobby *lobby_search_by_id (Cerver *cerver, const char *id) {
 
-    if (cerver && id) {
-        GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+	if (cerver && id) {
+		GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
 
-        Lobby *lobby = NULL;
-        for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
-            lobby = (Lobby *) le->data;
-            if (!strcmp (lobby->id->str, id)) return lobby;
-        }
-    }
+		Lobby *lobby = NULL;
+		for (ListElement *le = dlist_start (game_cerver->current_lobbys); le; le = le->next) {
+			lobby = (Lobby *) le->data;
+			if (!strcmp (lobby->id->str, id)) return lobby;
+		}
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
 // stops the lobby, disconnects clinets (players) if any, destroys lobby game data, and deletes the lobby at the end
 int lobby_teardown (GameCerver *game_cerver, Lobby *lobby) {
 
-    int retval = 0;
+	int retval = 0;
 
-    if (lobby) {
-        #ifdef CERVER_DEBUG
-        String *name = str_new (lobby->id->str);
-        cerver_log (
-            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-            "Starting lobby %s teardown...", name->str
-        );
-        #endif
+	if (lobby) {
+		#ifdef CERVER_DEBUG
+		String *name = str_new (lobby->id->str);
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+			"Starting lobby %s teardown...", name->str
+		);
+		#endif
 
-        // stop the lobby threads
-        lobby->running = false;
-        lobby->in_game = false;
+		// stop the lobby threads
+		lobby->running = false;
+		lobby->in_game = false;
 
-        // call the game type end method
-        if (lobby->game_type->end) lobby->game_type->end (lobby);
+		// call the game type end method
+		if (lobby->game_type->end) lobby->game_type->end (lobby);
 
-        // destroy the lobby game data
-        if (lobby->game_type) {
-            if (lobby->game_data_delete) lobby->game_data_delete (lobby->game_data);
-            else free (lobby->game_data);
-        }
+		// destroy the lobby game data
+		if (lobby->game_type) {
+			if (lobby->game_data_delete) lobby->game_data_delete (lobby->game_data);
+			else free (lobby->game_data);
+		}
 
-        // unregister the lobby from the game cerver
-        game_cerver_unregister_lobby (game_cerver, lobby);
+		// unregister the lobby from the game cerver
+		game_cerver_unregister_lobby (game_cerver, lobby);
 
-        // finally delete the lobby
-        lobby_delete (lobby);
+		// finally delete the lobby
+		lobby_delete (lobby);
 
-        #ifdef CERVER_DEBUG
-        if (name) {
-            cerver_log (
-                LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
-                "Lobby %s teardown was successfull!", name->str
-            );
+		#ifdef CERVER_DEBUG
+		if (name) {
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+				"Lobby %s teardown was successfull!", name->str
+			);
 
-            str_delete (name);
-        }
-        #endif
-    }
+			str_delete (name);
+		}
+		#endif
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -392,24 +392,24 @@ int lobby_teardown (GameCerver *game_cerver, Lobby *lobby) {
 // returns 0 on success, 1 on error
 u8 lobby_poll_init (Lobby *lobby, unsigned int max_players_fds) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby) {
-        lobby->players_fds = (struct pollfd *) calloc (max_players_fds, sizeof (struct pollfd));
-        if (lobby->players_fds) {
-            lobby->max_players_fds = max_players_fds;
-            lobby->current_players_fds = 0;
+	if (lobby) {
+		lobby->players_fds = (struct pollfd *) calloc (max_players_fds, sizeof (struct pollfd));
+		if (lobby->players_fds) {
+			lobby->max_players_fds = max_players_fds;
+			lobby->current_players_fds = 0;
 
-            for (u32 i = 0; i < lobby->max_players_fds; i++) {
-                lobby->players_fds[i].fd = -1;
-                lobby->players_fds[i].events = -1;
-            }
+			for (u32 i = 0; i < lobby->max_players_fds; i++) {
+				lobby->players_fds[i].fd = -1;
+				lobby->players_fds[i].events = -1;
+			}
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -417,40 +417,40 @@ u8 lobby_poll_init (Lobby *lobby, unsigned int max_players_fds) {
 // returns 0 on success, 1 on error
 static u8 lobby_realloc_poll_fds (Lobby *lobby) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby) {
-        lobby->max_players_fds = lobby->max_players_fds * 2;
-        lobby->players_fds = (struct pollfd *) realloc (lobby->players_fds,
-            lobby->max_players_fds * sizeof (struct pollfd));
-        if (lobby->players_fds) retval = 0;
-    }
+	if (lobby) {
+		lobby->max_players_fds = lobby->max_players_fds * 2;
+		lobby->players_fds = (struct pollfd *) realloc (lobby->players_fds,
+			lobby->max_players_fds * sizeof (struct pollfd));
+		if (lobby->players_fds) retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets a free idx in the lobby poll structure
 static i32 lobby_poll_get_free_idx (const Lobby *lobby) {
 
-    if (lobby) {
-        for (i32 i = 0; i < lobby->max_players_fds; i++) 
-            if (lobby->players_fds[i].fd == -1) return i;
-    }
+	if (lobby) {
+		for (i32 i = 0; i < lobby->max_players_fds; i++)
+			if (lobby->players_fds[i].fd == -1) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
 // gets the idx of the connection fd in the poll fds
 static i32 lobby_poll_get_idx_by_sock_fd (const Lobby *lobby, const i32 sock_fd) {
 
-    if (lobby) {
-        for (u32 i = 0; i < lobby->max_players_fds; i++)
-            if (lobby->players_fds[i].fd == sock_fd) return i;
-    }
+	if (lobby) {
+		for (u32 i = 0; i < lobby->max_players_fds; i++)
+			if (lobby->players_fds[i].fd == sock_fd) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
@@ -458,52 +458,52 @@ static i32 lobby_poll_get_idx_by_sock_fd (const Lobby *lobby, const i32 sock_fd)
 // and maps the sock fd to the player
 u8 lobby_poll_register_connection (Lobby *lobby, Player *player, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player && connection) {
-        i32 idx = lobby_poll_get_free_idx (lobby);
-        if (idx >= 0) {
-            lobby->players_fds[idx].fd = connection->socket->sock_fd;
-            lobby->players_fds[idx].events = POLLIN;
-            lobby->current_players_fds++;
+	if (lobby && player && connection) {
+		i32 idx = lobby_poll_get_free_idx (lobby);
+		if (idx >= 0) {
+			lobby->players_fds[idx].fd = connection->socket->sock_fd;
+			lobby->players_fds[idx].events = POLLIN;
+			lobby->current_players_fds++;
 
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_DEBUG, LOG_TYPE_NONE,
-                "Added a new sock fd to lobby %s poll - idx %i",
-                lobby->id->str, idx
-            );
-            #endif
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+				"Added a new sock fd to lobby %s poll - idx %i",
+				lobby->id->str, idx
+			);
+			#endif
 
-            // map the socket fd with the player
-            const void *key = &connection->socket->sock_fd;
-            htab_insert (lobby->sock_fd_player_map, key, sizeof (i32), player, sizeof (Player));
+			// map the socket fd with the player
+			const void *key = &connection->socket->sock_fd;
+			htab_insert (lobby->sock_fd_player_map, key, sizeof (i32), player, sizeof (Player));
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_NONE,
-                "Lobby %s poll is full -- we need to realloc...",
-                lobby->id->str
-            );
-            #endif
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_NONE,
+				"Lobby %s poll is full -- we need to realloc...",
+				lobby->id->str
+			);
+			#endif
 
-            if (lobby_realloc_poll_fds (lobby)) {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_NONE,
-                    "Failed to realloc lobby %s poll structure!",
-                    lobby->id->str
-                );
-            }
+			if (lobby_realloc_poll_fds (lobby)) {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					"Failed to realloc lobby %s poll structure!",
+					lobby->id->str
+				);
+			}
 
-            else retval = lobby_poll_register_connection (lobby, player, connection);
-        }
-    }
+			else retval = lobby_poll_register_connection (lobby, player, connection);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -512,126 +512,126 @@ u8 lobby_poll_register_connection (Lobby *lobby, Player *player, Connection *con
 // returns 0 on success, 1 on error
 u8 lobby_poll_unregister_connection (Lobby *lobby, Player *player, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player && connection) {
-        // get the idx of the connection sock in the lobby poll fds
-        i32 idx = lobby_poll_get_idx_by_sock_fd (lobby, connection->socket->sock_fd);
-        if (idx >= 0) {
-            lobby->players_fds[idx].fd = -1;
-            lobby->players_fds[idx].events = -1;
-            lobby->current_players_fds--;
+	if (lobby && player && connection) {
+		// get the idx of the connection sock in the lobby poll fds
+		i32 idx = lobby_poll_get_idx_by_sock_fd (lobby, connection->socket->sock_fd);
+		if (idx >= 0) {
+			lobby->players_fds[idx].fd = -1;
+			lobby->players_fds[idx].events = -1;
+			lobby->current_players_fds--;
 
-            // const void *key = &connection->sock_fd;
-            // retval = htab_remove (lobby->sock_fd_player_map, key, sizeof (i32));
-            // #ifdef CERVER_DEBUG
-            // if (retval) {
-            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
-            //         c_string_create ("Failed to remove from lobby's %s sock fd player map.",
-            //         lobby->id->str));
-            // }
-            // #endif
-        }
-    }
+			// const void *key = &connection->sock_fd;
+			// retval = htab_remove (lobby->sock_fd_player_map, key, sizeof (i32));
+			// #ifdef CERVER_DEBUG
+			// if (retval) {
+			//     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+			//         c_string_create ("Failed to remove from lobby's %s sock fd player map.",
+			//         lobby->id->str));
+			// }
+			// #endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // lobby default handler
 void lobby_poll (void *ptr) {
 
-    if (ptr) {
-        CerverLobby *cerver_lobby = (CerverLobby *) ptr;
-        // Cerver *cerver = cerver_lobby->cerver;
-        Lobby *lobby = cerver_lobby->lobby;
+	if (ptr) {
+		CerverLobby *cerver_lobby = (CerverLobby *) ptr;
+		// Cerver *cerver = cerver_lobby->cerver;
+		Lobby *lobby = cerver_lobby->lobby;
 
-        cerver_log (
-            LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
-            "Lobby %s poll has started!", lobby->id->str
-        );
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+			"Lobby %s poll has started!", lobby->id->str
+		);
 
-        int poll_retval = 0;
-        while (lobby->running) {
-            poll_retval = poll (lobby->players_fds, lobby->max_players_fds, lobby->poll_timeout);
+		int poll_retval = 0;
+		while (lobby->running) {
+			poll_retval = poll (lobby->players_fds, lobby->max_players_fds, lobby->poll_timeout);
 
-            // poll failed
-            if (poll_retval < 0) {
-                cerver_log (
-                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                    "Lobby %s poll has failed!", lobby->id->str
-                );
+			// poll failed
+			if (poll_retval < 0) {
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_GAME,
+					"Lobby %s poll has failed!", lobby->id->str
+				);
 
-                perror ("Error");
-                break;
-            }
+				perror ("Error");
+				break;
+			}
 
-            // if poll has timed out, just continue to the next loop... 
-            if (poll_retval == 0) {
-                // #ifdef CERVER_DEBUG
-                // cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, 
-                //    c_string_create ("Lobby %s poll timeout.", lobby->id->str));
-                // #endif
-                continue;
-            }
+			// if poll has timed out, just continue to the next loop...
+			if (poll_retval == 0) {
+				// #ifdef CERVER_DEBUG
+				// cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+				//    c_string_create ("Lobby %s poll timeout.", lobby->id->str));
+				// #endif
+				continue;
+			}
 
-            // one or more fd(s) are readable, need to determine which ones they are
-            for (u16 i = 0; i < lobby->current_players_fds; i++) {
-                if (lobby->players_fds[i].revents == 0) continue;
-                if (lobby->players_fds[i].revents != POLLIN) continue;
+			// one or more fd(s) are readable, need to determine which ones they are
+			for (u16 i = 0; i < lobby->current_players_fds; i++) {
+				if (lobby->players_fds[i].revents == 0) continue;
+				if (lobby->players_fds[i].revents != POLLIN) continue;
 
-                if (lobby->players_fds[i].fd >= 0) {
-                    // cerver_receive (cerver_receive_new (cerver, lobby->players_fds[i].fd, false, lobby));
-                    // FIXME: 07/07/2020 -- update with new CerverReceive structure
-                    // cerver_receive (
-                    //     cerver_receive_new (
-                    //         cerver, 
-                    //         socket_get_by_fd (cerver, lobby->players_fds[i].fd, RECEIVE_TYPE_NORMAL),
-                    //         RECEIVE_TYPE_NORMAL,
-                    //         NULL
-                    //     )
-                    // );
-                    // if (thpool_add_work (cerver->thpool, lobby->handler, 
-                    //     cerver_receive_new (cerver, lobby->players_fds[i].fd, false))) {
-                    //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, 
-                    //         c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!", 
-                    //         cerver->info->name->str));
-                    // }
-                }
-            }
-        }
+				if (lobby->players_fds[i].fd >= 0) {
+					// cerver_receive (cerver_receive_new (cerver, lobby->players_fds[i].fd, false, lobby));
+					// FIXME: 07/07/2020 -- update with new CerverReceive structure
+					// cerver_receive (
+					//     cerver_receive_new (
+					//         cerver,
+					//         socket_get_by_fd (cerver, lobby->players_fds[i].fd, RECEIVE_TYPE_NORMAL),
+					//         RECEIVE_TYPE_NORMAL,
+					//         NULL
+					//     )
+					// );
+					// if (thpool_add_work (cerver->thpool, lobby->handler,
+					//     cerver_receive_new (cerver, lobby->players_fds[i].fd, false))) {
+					//     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					//         c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!",
+					//         cerver->info->name->str));
+					// }
+				}
+			}
+		}
 
-        // #ifdef CERVER_DEBUG
-        // cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-        //     c_string_create ("Lobby %s poll has stopped!", lobby->id->str));
-        // #endif
-    }
+		// #ifdef CERVER_DEBUG
+		// cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+		//     c_string_create ("Lobby %s poll has stopped!", lobby->id->str));
+		// #endif
+	}
 
-    else {
-        cerver_log (
-            LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-            "Can't handle players on a NULL cerver / lobby"
-        );
-    } 
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_GAME,
+			"Can't handle players on a NULL cerver / lobby"
+		);
+	}
 
 }
 
 // register all the players registered to the lobby to the lobby's poll structure to correctly handle packets
 static void lobby_poll_register_all_players (Cerver *cerver, Lobby *lobby) {
 
-    if (lobby) {
-        
-        // and the register them to the lobby poll
-        Player *player = NULL;
-        for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
-            player = (Player *) le->data;
-            // first remove the player's client connections from the cerver poll 
-            client_unregister_connections_from_cerver_poll (cerver, player->client);
+	if (lobby) {
 
-            // then register the player's client to the poll stuctures
-            player_register_to_lobby_poll (lobby, player);
-        }
-    }
+		// and the register them to the lobby poll
+		Player *player = NULL;
+		for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
+			player = (Player *) le->data;
+			// first remove the player's client connections from the cerver poll
+			client_unregister_connections_from_cerver_poll (cerver, player->client);
+
+			// then register the player's client to the poll stuctures
+			player_register_to_lobby_poll (lobby, player);
+		}
+	}
 
 }
 
@@ -644,94 +644,94 @@ static void lobby_poll_register_all_players (Cerver *cerver, Lobby *lobby) {
 // creates and inits a new lobby
 // creates a new user associated with the client and makes him the owner
 Lobby *lobby_create (Cerver *cerver, Client *client,
-    bool use_default_handler, Action custom_handler, u32 max_players) {
+	bool use_default_handler, Action custom_handler, u32 max_players) {
 
-    Lobby *lobby = NULL;
+	Lobby *lobby = NULL;
 
-    if (cerver && client) {
-        GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
-        lobby = lobby_new ();
-        if (lobby) {
-            lobby->cerver = cerver;
-            if (!lobby_init (game_cerver, lobby)) {
-                if (use_default_handler) {
-                    lobby->handler = lobby_poll;
-                    lobby->default_handler = true;
-                    if (lobby_poll_init (lobby, max_players)) {
-                        #ifdef CERVER_DEBUG
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                            "Failed to init lobby %s poll structures!",
-                            lobby->id->str
-                        );
-                        #endif
-                    }
-                }
+	if (cerver && client) {
+		GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+		lobby = lobby_new ();
+		if (lobby) {
+			lobby->cerver = cerver;
+			if (!lobby_init (game_cerver, lobby)) {
+				if (use_default_handler) {
+					lobby->handler = lobby_poll;
+					lobby->default_handler = true;
+					if (lobby_poll_init (lobby, max_players)) {
+						#ifdef CERVER_DEBUG
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_GAME,
+							"Failed to init lobby %s poll structures!",
+							lobby->id->str
+						);
+						#endif
+					}
+				}
 
-                // make the client that make the request, the lobby owner
-                Player *owner = player_new ();
-                if (owner) {
-                    owner->client = client;
+				// make the client that make the request, the lobby owner
+				Player *owner = player_new ();
+				if (owner) {
+					owner->client = client;
 
-                    // register the owner to the lobby
-                    if (!player_register_to_lobby (lobby, owner)) {
-                        // unregister the connections from the cerver poll
-                        // client_unregister_connections_from_cerver (cerver, client);
+					// register the owner to the lobby
+					if (!player_register_to_lobby (lobby, owner)) {
+						// unregister the connections from the cerver poll
+						// client_unregister_connections_from_cerver (cerver, client);
 
-                        // Connection *connection = NULL;
-                        // for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
-                        //     connection = (Connection *) le->data;
-                        //     connection->active = true;
-                        // }
+						// Connection *connection = NULL;
+						// for (ListElement *le = dlist_start (client->connections); le; le = le->next) {
+						//     connection = (Connection *) le->data;
+						//     connection->active = true;
+						// }
 
-                        lobby->owner = owner;
-                        #ifdef CERVER_DEBUG
-                        cerver_log (
-                            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                            "Client %ld is now the owner of lobby %s.",
-                            client->id, lobby->id->str
-                        );
-                        #endif
-                    }
+						lobby->owner = owner;
+						#ifdef CERVER_DEBUG
+						cerver_log (
+							LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+							"Client %ld is now the owner of lobby %s.",
+							client->id, lobby->id->str
+						);
+						#endif
+					}
 
-                    else {
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
-                            "Failed to register owner to the lobby %s.",
-                            lobby->id->str
-                        );
+					else {
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+							"Failed to register owner to the lobby %s.",
+							lobby->id->str
+						);
 
-                        lobby_delete (lobby);
-                        lobby = NULL;
-                    }
-                }
+						lobby_delete (lobby);
+						lobby = NULL;
+					}
+				}
 
-                else {
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
-                        "Failed to create lobby owner for lobby %s.",
-                        lobby->id->str
-                    );
-                    #endif
+				else {
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+						"Failed to create lobby owner for lobby %s.",
+						lobby->id->str
+					);
+					#endif
 
-                    lobby_delete (lobby);
-                    lobby = NULL;
-                }
-            }
+					lobby_delete (lobby);
+					lobby = NULL;
+				}
+			}
 
-            else {
-                #ifdef CERVER_DEBUG
-                cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to init the new lobby!");
-                #endif
+			else {
+				#ifdef CERVER_DEBUG
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to init the new lobby!");
+				#endif
 
-                lobby_delete (lobby);
-                lobby = NULL;
-            }
-        }
-    }
+				lobby_delete (lobby);
+				lobby = NULL;
+			}
+		}
+	}
 
-    return lobby;
+	return lobby;
 
 }
 
@@ -740,52 +740,52 @@ Lobby *lobby_create (Cerver *cerver, Client *client,
 // returns 0 on success, 1 on error
 u8 lobby_join (Cerver *cerver, Client *client, Lobby *lobby) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && client && lobby) {
-        GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
-        if (game_cerver) {
-            // check for lobby max players cap
-            // if (lobby->current_players_fds < lobby->max_players) {
-                // make the client that make the request, a lobby member
-                Player *member = player_new ();
-                if (member) {
-                    member->client = client;
+	if (cerver && client && lobby) {
+		GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+		if (game_cerver) {
+			// check for lobby max players cap
+			// if (lobby->current_players_fds < lobby->max_players) {
+				// make the client that make the request, a lobby member
+				Player *member = player_new ();
+				if (member) {
+					member->client = client;
 
-                    // register the member to the lobby
-                    if (!player_register_to_lobby (lobby, member)) retval = 0;      // success
-                    else {
-                        cerver_log (
-                            LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
-                            "Failed to register a new member to lobby %s",
-                            lobby->id->str
-                        );
-                    }
-                }
+					// register the member to the lobby
+					if (!player_register_to_lobby (lobby, member)) retval = 0;      // success
+					else {
+						cerver_log (
+							LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+							"Failed to register a new member to lobby %s",
+							lobby->id->str
+						);
+					}
+				}
 
-                else {
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
-                        "Failed to create a new lobby owner fro lobby %s",
-                        lobby->id->str
-                    );
-                    #endif
-                }
-            // }
+				else {
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+						"Failed to create a new lobby owner fro lobby %s",
+						lobby->id->str
+					);
+					#endif
+				}
+			// }
 
-            // else {
-            //     #ifdef CERVER_DEBUG
-            //     cerver_log (stderr, LOG_TYPE_WARNING, LOG_TYPE_PLAYER, 
-            //         c_string_create ("Lobby %s is already full!",
-            //         lobby->id->str));
-            //     #endif
-            // }
-            
-        }
-    }
+			// else {
+			//     #ifdef CERVER_DEBUG
+			//     cerver_log (stderr, LOG_TYPE_WARNING, LOG_TYPE_PLAYER,
+			//         c_string_create ("Lobby %s is already full!",
+			//         lobby->id->str));
+			//     #endif
+			// }
 
-    return retval;
+		}
+	}
+
+	return retval;
 
 }
 
@@ -793,162 +793,162 @@ u8 lobby_join (Cerver *cerver, Client *client, Lobby *lobby) {
 // returns 0 on success, 1 on error
 u8 lobby_leave (Cerver *cerver, Lobby *lobby, Player *player) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && lobby && player) {
-        // check that the player is in the lobby
-        Player *found = player_get_from_lobby (lobby, player);
-        if (found) {
-            // remove the player from the lobby
-            player_unregister_from_lobby (lobby, player);
+	if (cerver && lobby && player) {
+		// check that the player is in the lobby
+		Player *found = player_get_from_lobby (lobby, player);
+		if (found) {
+			// remove the player from the lobby
+			player_unregister_from_lobby (lobby, player);
 
-            // check if there are players left inside the lobby
-            if (lobby->n_current_players <= 0) {
-                // destroy the lobby
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                    "Destroying lobby %s -- it is empty.",
-                    lobby->id->str
-                );
-                #endif
-                lobby_delete (lobby);
-            }
+			// check if there are players left inside the lobby
+			if (lobby->n_current_players <= 0) {
+				// destroy the lobby
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+					"Destroying lobby %s -- it is empty.",
+					lobby->id->str
+				);
+				#endif
+				lobby_delete (lobby);
+			}
 
-            // check if the player was the owner
-            else if (!str_compare (lobby->owner->id, player->id)) {
-                // get a new owner
-                Player *new_owner = (Player *) (dlist_start (lobby->players))->data;
-                if (new_owner) {
-                    lobby->owner = new_owner;
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_DEBUG, LOG_TYPE_PLAYER,
-                        "Player %s is the new owner of lobby %s.",
-                        new_owner->id->str, lobby->id->str
-                    );
-                    #endif
-                }
-            }
+			// check if the player was the owner
+			else if (!str_compare (lobby->owner->id, player->id)) {
+				// get a new owner
+				Player *new_owner = (Player *) (dlist_start (lobby->players))->data;
+				if (new_owner) {
+					lobby->owner = new_owner;
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_DEBUG, LOG_TYPE_PLAYER,
+						"Player %s is the new owner of lobby %s.",
+						new_owner->id->str, lobby->id->str
+					);
+					#endif
+				}
+			}
 
-            player_delete (player);
+			player_delete (player);
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_PLAYER,
-                "Player %s does not seem to be in lobby %s.",
-                player->id->str, lobby->id->str
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_PLAYER,
+				"Player %s does not seem to be in lobby %s.",
+				player->id->str, lobby->id->str
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // starts the lobby's handler and/or update method in the cervers thpool
 u8 lobby_start (Cerver *cerver, Lobby *lobby) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && lobby) {
-        bool started = true;
-        CerverLobby *cerver_lobby = cerver_lobby_new (cerver, lobby);
-        lobby->running = true;
+	if (cerver && lobby) {
+		bool started = true;
+		CerverLobby *cerver_lobby = cerver_lobby_new (cerver, lobby);
+		lobby->running = true;
 
-        // check if the lobby has a handler method
-        if (lobby->handler) {
-            if (lobby->default_handler) lobby_poll_register_all_players (cerver, lobby);
+		// check if the lobby has a handler method
+		if (lobby->handler) {
+			if (lobby->default_handler) lobby_poll_register_all_players (cerver, lobby);
 
-            // if (!thpool_add_work (cerver->thpool, lobby->handler, cerver_lobby)) {
-            //     #ifdef CERVER_DEBUG
-            //     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-            //         c_string_create ("Started lobby %s handler",
-            //         lobby->id->str));
-            //     #endif
-            //     started = true;
-            // }
+			// if (!thpool_add_work (cerver->thpool, lobby->handler, cerver_lobby)) {
+			//     #ifdef CERVER_DEBUG
+			//     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+			//         c_string_create ("Started lobby %s handler",
+			//         lobby->id->str));
+			//     #endif
+			//     started = true;
+			// }
 
-            // else {
-            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
-            //         c_string_create ("Failed to add lobby %s handler to cerver's thpool!",
-            //         lobby->id->str, cerver->info->name->str));
-            // }
+			// else {
+			//     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+			//         c_string_create ("Failed to add lobby %s handler to cerver's thpool!",
+			//         lobby->id->str, cerver->info->name->str));
+			// }
 
-            if (thread_create_detachable (
-                &lobby->handler_thread_id,
-                (void *(*)(void *)) lobby->handler, 
-                cerver_lobby
-            )) {
-                cerver_log_error (
-                    "Failed to create lobby %s HANDLER thread!",
-                    lobby->id->str
-                );
-            }
-        }
+			if (thread_create_detachable (
+				&lobby->handler_thread_id,
+				(void *(*)(void *)) lobby->handler,
+				cerver_lobby
+			)) {
+				cerver_log_error (
+					"Failed to create lobby %s HANDLER thread!",
+					lobby->id->str
+				);
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_GAME,
-                "lobby_start () -- lobby %s does not have a handler.",
-                lobby->id->str
-            );
-            #endif
-        }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_GAME,
+				"lobby_start () -- lobby %s does not have a handler.",
+				lobby->id->str
+			);
+			#endif
+		}
 
-        // check if the lobby has an update method
-        if (lobby->update) {
-            // if (!thpool_add_work (cerver->thpool, lobby->update, cerver_lobby)) {
-            //     #ifdef CERVER_DEBUG
-            //     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-            //         c_string_create ("Started lobby %s update",
-            //         lobby->id->str));
-            //     #endif
-            //     started = true;
-            // }
+		// check if the lobby has an update method
+		if (lobby->update) {
+			// if (!thpool_add_work (cerver->thpool, lobby->update, cerver_lobby)) {
+			//     #ifdef CERVER_DEBUG
+			//     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+			//         c_string_create ("Started lobby %s update",
+			//         lobby->id->str));
+			//     #endif
+			//     started = true;
+			// }
 
-            // else {
-            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
-            //         c_string_create ("Failed to add lobby %s update to cerver's thpool!",
-            //         lobby->id->str, cerver->info->name->str));
-            // }
+			// else {
+			//     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+			//         c_string_create ("Failed to add lobby %s update to cerver's thpool!",
+			//         lobby->id->str, cerver->info->name->str));
+			// }
 
-            if (thread_create_detachable (
-                &lobby->update_thread_id,
-                (void *(*)(void *)) lobby->update, 
-                cerver_lobby
-            )) {
-                cerver_log_error (
-                    "Failed to create lobby %s UPDATE thread!",
-                    lobby->id->str
-                );
-            }
-        }
+			if (thread_create_detachable (
+				&lobby->update_thread_id,
+				(void *(*)(void *)) lobby->update,
+				cerver_lobby
+			)) {
+				cerver_log_error (
+					"Failed to create lobby %s UPDATE thread!",
+					lobby->id->str
+				);
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_WARNING, LOG_TYPE_GAME,
-                "lobby_start () -- lobby %s does not have an update.",
-                lobby->id->str
-            );
-            #endif
-        }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_GAME,
+				"lobby_start () -- lobby %s does not have an update.",
+				lobby->id->str
+			);
+			#endif
+		}
 
-        if (started) retval = 0;
-        else {
-            cerver_lobby_delete (cerver_lobby);
-            lobby->running = false;
-        } 
-    }
+		if (started) retval = 0;
+		else {
+			cerver_lobby_delete (cerver_lobby);
+			lobby->running = false;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -960,30 +960,30 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
 
 static SLobby *slobby_new (void) {
 
-    SLobby *slobby = (SLobby *) malloc (sizeof (SLobby));
-    if (slobby) memset (slobby, 0, sizeof (SLobby));
-    return slobby;
+	SLobby *slobby = (SLobby *) malloc (sizeof (SLobby));
+	if (slobby) memset (slobby, 0, sizeof (SLobby));
+	return slobby;
 
 }
 
 // FIXME: game settings
 SLobby *lobby_serialize (Lobby *lobby) {
 
-    SLobby *slobby = NULL;
+	SLobby *slobby = NULL;
 
-    if (lobby) {
-        slobby = slobby_new ();
-        if (slobby) {
-            strncpy (slobby->id.str, lobby->id->str, 64);
-            slobby->id.len = (lobby->id->len >= 64) ? 64 : lobby->id->len;
-            slobby->creation_timestamp = lobby->creation_time_stamp;
-            slobby->in_game = lobby->in_game;
-            slobby->running = lobby->running;
-            slobby->n_players = lobby->n_current_players;
-        }
-    }
+	if (lobby) {
+		slobby = slobby_new ();
+		if (slobby) {
+			strncpy (slobby->id.str, lobby->id->str, 64);
+			slobby->id.len = (lobby->id->len >= 64) ? 64 : lobby->id->len;
+			slobby->creation_timestamp = lobby->creation_time_stamp;
+			slobby->in_game = lobby->in_game;
+			slobby->running = lobby->running;
+			slobby->n_players = lobby->n_current_players;
+		}
+	}
 
-    return slobby;
+	return slobby;
 
 }
 
@@ -991,24 +991,24 @@ SLobby *lobby_serialize (Lobby *lobby) {
 // sends a lobby and all of its data to the client
 // created: if the lobby was just created
 void lobby_send (Lobby *lobby, bool created,
-    Cerver *cerver, Client *client, Connection *connection) {
+	Cerver *cerver, Client *client, Connection *connection) {
 
-    if (lobby) {
-        // serialize and send back the lobby
-        SLobby *slobby = lobby_serialize (lobby);
-        if (slobby) {
-            Packet *lobby_packet = packet_generate_request (PACKET_TYPE_GAME, 
-                created ? GAME_PACKET_TYPE_LOBBY_CREATE : GAME_PACKET_TYPE_LOBBY_JOIN, 
-                slobby, sizeof (SLobby));
-            if (lobby_packet) {
-                packet_set_network_values (lobby_packet, cerver, client, connection, lobby);
-                packet_send (lobby_packet, 0, NULL, false);
-                packet_delete (lobby_packet);
-            }
+	if (lobby) {
+		// serialize and send back the lobby
+		SLobby *slobby = lobby_serialize (lobby);
+		if (slobby) {
+			Packet *lobby_packet = packet_generate_request (PACKET_TYPE_GAME,
+				created ? GAME_PACKET_TYPE_LOBBY_CREATE : GAME_PACKET_TYPE_LOBBY_JOIN,
+				slobby, sizeof (SLobby));
+			if (lobby_packet) {
+				packet_set_network_values (lobby_packet, cerver, client, connection, lobby);
+				packet_send (lobby_packet, 0, NULL, false);
+				packet_delete (lobby_packet);
+			}
 
-            free (slobby);
-        }
-    }
+			free (slobby);
+		}
+	}
 
 }
 

--- a/src/cerver/game/lobby.c
+++ b/src/cerver/game/lobby.c
@@ -11,21 +11,21 @@
 #include "cerver/types/types.h"
 #include "cerver/types/string.h"
 
+#include "cerver/collections/dlist.h"
+#include "cerver/collections/htab.h"
+
 #include "cerver/socket.h"
 #include "cerver/cerver.h"
 #include "cerver/client.h"
 #include "cerver/handler.h"
 #include "cerver/packets.h"
 
-#include "cerver/game/game.h"
-#include "cerver/game/player.h"
-#include "cerver/game/lobby.h"
-
 #include "cerver/threads/thpool.h"
 #include "cerver/threads/thread.h"
 
-#include "cerver/collections/dlist.h"
-#include "cerver/collections/htab.h"
+#include "cerver/game/game.h"
+#include "cerver/game/player.h"
+#include "cerver/game/lobby.h"
 
 #include "cerver/utils/utils.h"
 #include "cerver/utils/log.h"
@@ -132,18 +132,19 @@ void lobby_stats_print (Lobby *lobby) {
         }
 
         else {
-            char *s = c_string_create ("Lobby %s does not have a reference to lobby stats!",
-                lobby->id->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Lobby %s does not have a reference to lobby stats!",
+                lobby->id->str
+            );
         }
     }
 
     else {
-        cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CERVER, 
-            "Cant print stats of a NULL lobby!");
+        cerver_log (
+            LOG_TYPE_WARNING, LOG_TYPE_CERVER, 
+            "Cant print stats of a NULL lobby!"
+        );
     }
 
 }
@@ -232,11 +233,10 @@ u8 lobby_init (GameCerver *game_cerver, Lobby *lobby) {
         if (id) {
             lobby->id = (String *) id;
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Lobby id: %s", lobby->id->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                "Lobby id: %s", lobby->id->str
+            );
             #endif
 
             lobby->sock_fd_player_map = htab_create (LOBBY_DEFAULT_MAX_PLAYERS, NULL, NULL);
@@ -341,11 +341,10 @@ int lobby_teardown (GameCerver *game_cerver, Lobby *lobby) {
     if (lobby) {
         #ifdef CERVER_DEBUG
         String *name = str_new (lobby->id->str);
-        char *s = c_string_create ("Starting lobby %s teardown...");
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-            free (s);
-        }
+        cerver_log (
+            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+            "Starting lobby %s teardown...", name->str
+        );
         #endif
 
         // stop the lobby threads
@@ -369,11 +368,10 @@ int lobby_teardown (GameCerver *game_cerver, Lobby *lobby) {
 
         #ifdef CERVER_DEBUG
         if (name) {
-            char *s = c_string_create ("Lobby %s teardown was successfull!", name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+                "Lobby %s teardown was successfull!", name->str
+            );
 
             str_delete (name);
         }
@@ -470,12 +468,11 @@ u8 lobby_poll_register_connection (Lobby *lobby, Player *player, Connection *con
             lobby->current_players_fds++;
 
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Added a new sock fd to lobby %s poll - idx %i",
-                lobby->id->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+                "Added a new sock fd to lobby %s poll - idx %i",
+                lobby->id->str, idx
+            );
             #endif
 
             // map the socket fd with the player
@@ -487,21 +484,19 @@ u8 lobby_poll_register_connection (Lobby *lobby, Player *player, Connection *con
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Lobby %s poll is full -- we need to realloc...",
-                lobby->id->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_NONE,
+                "Lobby %s poll is full -- we need to realloc...",
+                lobby->id->str
+            );
             #endif
 
             if (lobby_realloc_poll_fds (lobby)) {
-                char *s = c_string_create ("Failed to realloc lobby %s poll structure!",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_NONE,
+                    "Failed to realloc lobby %s poll structure!",
+                    lobby->id->str
+                );
             }
 
             else retval = lobby_poll_register_connection (lobby, player, connection);
@@ -531,7 +526,7 @@ u8 lobby_poll_unregister_connection (Lobby *lobby, Player *player, Connection *c
             // retval = htab_remove (lobby->sock_fd_player_map, key, sizeof (i32));
             // #ifdef CERVER_DEBUG
             // if (retval) {
-            //     cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
             //         c_string_create ("Failed to remove from lobby's %s sock fd player map.",
             //         lobby->id->str));
             // }
@@ -551,11 +546,10 @@ void lobby_poll (void *ptr) {
         // Cerver *cerver = cerver_lobby->cerver;
         Lobby *lobby = cerver_lobby->lobby;
 
-        char *s = c_string_create ("Lobby %s poll has started!", lobby->id->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_GAME, s);
-            free (s);
-        }
+        cerver_log (
+            LOG_TYPE_SUCCESS, LOG_TYPE_GAME,
+            "Lobby %s poll has started!", lobby->id->str
+        );
 
         int poll_retval = 0;
         while (lobby->running) {
@@ -563,11 +557,10 @@ void lobby_poll (void *ptr) {
 
             // poll failed
             if (poll_retval < 0) {
-                char *s = c_string_create ("Lobby %s poll has failed!", lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                    "Lobby %s poll has failed!", lobby->id->str
+                );
 
                 perror ("Error");
                 break;
@@ -576,7 +569,7 @@ void lobby_poll (void *ptr) {
             // if poll has timed out, just continue to the next loop... 
             if (poll_retval == 0) {
                 // #ifdef CERVER_DEBUG
-                // cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, 
+                // cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, 
                 //    c_string_create ("Lobby %s poll timeout.", lobby->id->str));
                 // #endif
                 continue;
@@ -600,7 +593,7 @@ void lobby_poll (void *ptr) {
                     // );
                     // if (thpool_add_work (cerver->thpool, lobby->handler, 
                     //     cerver_receive_new (cerver, lobby->players_fds[i].fd, false))) {
-                    //     cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, 
+                    //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, 
                     //         c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!", 
                     //         cerver->info->name->str));
                     // }
@@ -609,14 +602,16 @@ void lobby_poll (void *ptr) {
         }
 
         // #ifdef CERVER_DEBUG
-        // cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+        // cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
         //     c_string_create ("Lobby %s poll has stopped!", lobby->id->str));
         // #endif
     }
 
     else {
-        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-            "Can't handle players on a NULL cerver / lobby");
+        cerver_log (
+            LOG_TYPE_ERROR, LOG_TYPE_GAME, 
+            "Can't handle players on a NULL cerver / lobby"
+        );
     } 
 
 }
@@ -664,12 +659,11 @@ Lobby *lobby_create (Cerver *cerver, Client *client,
                     lobby->default_handler = true;
                     if (lobby_poll_init (lobby, max_players)) {
                         #ifdef CERVER_DEBUG
-                        char *s = c_string_create ("Failed to init lobby %s poll structures!",
-                            lobby->id->str);
-                        if (s) {
-                            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                            free (s);
-                        }
+                        cerver_log (
+                            LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                            "Failed to init lobby %s poll structures!",
+                            lobby->id->str
+                        );
                         #endif
                     }
                 }
@@ -692,22 +686,20 @@ Lobby *lobby_create (Cerver *cerver, Client *client,
 
                         lobby->owner = owner;
                         #ifdef CERVER_DEBUG
-                        char *s = c_string_create ("Client %ld is now the owner of lobby %s.",
-                            client->id, lobby->id->str);
-                        if (s) {
-                            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                            free (s);
-                        }
+                        cerver_log (
+                            LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                            "Client %ld is now the owner of lobby %s.",
+                            client->id, lobby->id->str
+                        );
                         #endif
                     }
 
                     else {
-                        char *s = c_string_create ("Failed to register owner to the lobby %s.",
-                            lobby->id->str);
-                        if (s) {
-                            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PLAYER, s);
-                            free (s);
-                        }
+                        cerver_log (
+                            LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+                            "Failed to register owner to the lobby %s.",
+                            lobby->id->str
+                        );
 
                         lobby_delete (lobby);
                         lobby = NULL;
@@ -716,12 +708,11 @@ Lobby *lobby_create (Cerver *cerver, Client *client,
 
                 else {
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Failed to create lobby owner for lobby %s.",
-                        lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PLAYER, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+                        "Failed to create lobby owner for lobby %s.",
+                        lobby->id->str
+                    );
                     #endif
 
                     lobby_delete (lobby);
@@ -731,7 +722,7 @@ Lobby *lobby_create (Cerver *cerver, Client *client,
 
             else {
                 #ifdef CERVER_DEBUG
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to init the new lobby!");
+                cerver_log (LOG_TYPE_ERROR, LOG_TYPE_GAME, "Failed to init the new lobby!");
                 #endif
 
                 lobby_delete (lobby);
@@ -764,30 +755,28 @@ u8 lobby_join (Cerver *cerver, Client *client, Lobby *lobby) {
                     // register the member to the lobby
                     if (!player_register_to_lobby (lobby, member)) retval = 0;      // success
                     else {
-                        char *s = c_string_create ("Failed to register a new member to lobby %s",
-                            lobby->id->str);
-                        if (s) {
-                            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PLAYER, s);
-                            free (s);
-                        }
+                        cerver_log (
+                            LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+                            "Failed to register a new member to lobby %s",
+                            lobby->id->str
+                        );
                     }
                 }
 
                 else {
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Failed to create a new lobby owner fro lobby %s",
-                        lobby->id->str);
-                    if (s) {
-                        free (s);
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PLAYER, s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_ERROR, LOG_TYPE_PLAYER,
+                        "Failed to create a new lobby owner fro lobby %s",
+                        lobby->id->str
+                    );
                     #endif
                 }
             // }
 
             // else {
             //     #ifdef CERVER_DEBUG
-            //     cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PLAYER, 
+            //     cerver_log (stderr, LOG_TYPE_WARNING, LOG_TYPE_PLAYER, 
             //         c_string_create ("Lobby %s is already full!",
             //         lobby->id->str));
             //     #endif
@@ -817,12 +806,11 @@ u8 lobby_leave (Cerver *cerver, Lobby *lobby, Player *player) {
             if (lobby->n_current_players <= 0) {
                 // destroy the lobby
                 #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Destroying lobby %s -- it is empty.",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                    "Destroying lobby %s -- it is empty.",
+                    lobby->id->str
+                );
                 #endif
                 lobby_delete (lobby);
             }
@@ -834,12 +822,11 @@ u8 lobby_leave (Cerver *cerver, Lobby *lobby, Player *player) {
                 if (new_owner) {
                     lobby->owner = new_owner;
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Player %s is the new owner of lobby %s.",
-                        new_owner->id->str, lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_PLAYER, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_DEBUG, LOG_TYPE_PLAYER,
+                        "Player %s is the new owner of lobby %s.",
+                        new_owner->id->str, lobby->id->str
+                    );
                     #endif
                 }
             }
@@ -851,12 +838,11 @@ u8 lobby_leave (Cerver *cerver, Lobby *lobby, Player *player) {
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Player %s does not seem to be in lobby %s.",
-                player->id->str, lobby->id->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PLAYER, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_PLAYER,
+                "Player %s does not seem to be in lobby %s.",
+                player->id->str, lobby->id->str
+            );
             #endif
         }
     }
@@ -881,7 +867,7 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
 
             // if (!thpool_add_work (cerver->thpool, lobby->handler, cerver_lobby)) {
             //     #ifdef CERVER_DEBUG
-            //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+            //     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
             //         c_string_create ("Started lobby %s handler",
             //         lobby->id->str));
             //     #endif
@@ -889,7 +875,7 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
             // }
 
             // else {
-            //     cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
             //         c_string_create ("Failed to add lobby %s handler to cerver's thpool!",
             //         lobby->id->str, cerver->info->name->str));
             // }
@@ -899,23 +885,20 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
                 (void *(*)(void *)) lobby->handler, 
                 cerver_lobby
             )) {
-                char *s = c_string_create ("Failed to create lobby %s HANDLER thread!",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_error (s);
-                    free (s);
-                }
+                cerver_log_error (
+                    "Failed to create lobby %s HANDLER thread!",
+                    lobby->id->str
+                );
             }
         }
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("lobby_start () -- lobby %s does not have a handler.",
-                lobby->id->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_GAME,
+                "lobby_start () -- lobby %s does not have a handler.",
+                lobby->id->str
+            );
             #endif
         }
 
@@ -923,7 +906,7 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
         if (lobby->update) {
             // if (!thpool_add_work (cerver->thpool, lobby->update, cerver_lobby)) {
             //     #ifdef CERVER_DEBUG
-            //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+            //     cerver_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME,
             //         c_string_create ("Started lobby %s update",
             //         lobby->id->str));
             //     #endif
@@ -931,7 +914,7 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
             // }
 
             // else {
-            //     cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
+            //     cerver_log (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME,
             //         c_string_create ("Failed to add lobby %s update to cerver's thpool!",
             //         lobby->id->str, cerver->info->name->str));
             // }
@@ -941,23 +924,20 @@ u8 lobby_start (Cerver *cerver, Lobby *lobby) {
                 (void *(*)(void *)) lobby->update, 
                 cerver_lobby
             )) {
-                char *s = c_string_create ("Failed to create lobby %s UPDATE thread!",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_error (s);
-                    free (s);
-                }
+                cerver_log_error (
+                    "Failed to create lobby %s UPDATE thread!",
+                    lobby->id->str
+                );
             }
         }
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("lobby_start () -- lobby %s does not have an update.",
-                lobby->id->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_WARNING, LOG_TYPE_GAME,
+                "lobby_start () -- lobby %s does not have an update.",
+                lobby->id->str
+            );
             #endif
         }
 
@@ -1017,8 +997,8 @@ void lobby_send (Lobby *lobby, bool created,
         // serialize and send back the lobby
         SLobby *slobby = lobby_serialize (lobby);
         if (slobby) {
-            Packet *lobby_packet = packet_generate_request (GAME_PACKET, 
-                created ? GAME_LOBBY_CREATE : GAME_LOBBY_JOIN, 
+            Packet *lobby_packet = packet_generate_request (PACKET_TYPE_GAME, 
+                created ? GAME_PACKET_TYPE_LOBBY_CREATE : GAME_PACKET_TYPE_LOBBY_JOIN, 
                 slobby, sizeof (SLobby));
             if (lobby_packet) {
                 packet_set_network_values (lobby_packet, cerver, client, connection, lobby);

--- a/src/cerver/game/player.c
+++ b/src/cerver/game/player.c
@@ -19,143 +19,143 @@ ListElement *player_get_le_from_lobby (Lobby *lobby, Player *player);
 
 Player *player_new (void) {
 
-    Player *player = (Player *) malloc (sizeof (Player));
-    if (player) {
-        player->id = NULL;
-        player->client = NULL;
-        player->data = NULL;
-        player->data_delete = NULL;
-    }
+	Player *player = (Player *) malloc (sizeof (Player));
+	if (player) {
+		player->id = NULL;
+		player->client = NULL;
+		player->data = NULL;
+		player->data_delete = NULL;
+	}
 
-    return player;
+	return player;
 
 }
 
 void player_delete (void *player_ptr) {
 
-    if (player_ptr) {
-        Player *player = (Player *) player_ptr;
+	if (player_ptr) {
+		Player *player = (Player *) player_ptr;
 
-        str_delete (player->id);
+		str_delete (player->id);
 
-        player->client = NULL;
+		player->client = NULL;
 
-        if (player->data) {
-            if (player->data_delete)
-                player->data_delete (player->data);
-            else free (player->data);
-        }
+		if (player->data) {
+			if (player->data_delete)
+				player->data_delete (player->data);
+			else free (player->data);
+		}
 
-        free (player);
-    }
+		free (player);
+	}
 
 }
 
 // sets the player id
 void player_set_id (Player *player, const char *id) {
 
-    if (player) player->id = str_new (id);
+	if (player) player->id = str_new (id);
 
 }
 
 // sets player data and a way to delete it
 void player_set_data (Player *player, void *data, Action data_delete) {
 
-    if (player) {
-        player->data = data;
-        player->data_delete = data_delete;
-    }
+	if (player) {
+		player->data = data;
+		player->data_delete = data_delete;
+	}
 
 }
 
 int player_comparator_by_id (const void *a, const void *b) {
 
-    return str_compare (((Player *) a)->id, ((Player *) b)->id);
+	return str_compare (((Player *) a)->id, ((Player *) b)->id);
 
 }
 
 int player_comparator_client_id (const void *a, const void *b) {
 
-    return client_comparator_client_id (((Player *) a)->client, ((Player *) b)->client);
+	return client_comparator_client_id (((Player *) a)->client, ((Player *) b)->client);
 
 }
 
 // registers each of the player's client connections to the lobby poll structures
 u8 player_register_to_lobby_poll (Lobby *lobby, Player *player) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player) {
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            lobby_poll_register_connection (lobby, player, connection);
-        }
-    }
+	if (lobby && player) {
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			lobby_poll_register_connection (lobby, player, connection);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // registers a player to the lobby --> add him to lobby's structures
 u8 player_register_to_lobby (Lobby *lobby, Player *player) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player) {
-        if (player->client) {
-            // bool failed = false;
+	if (lobby && player) {
+		if (player->client) {
+			// bool failed = false;
 
-            // // register all the player's client connections to the lobby poll
-            // Connection *connection = NULL;
-            // for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
-            //     connection = (Connection *) le->data;
-            //     failed = lobby_poll_register_connection (lobby, player, connection);
-            // }
+			// // register all the player's client connections to the lobby poll
+			// Connection *connection = NULL;
+			// for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
+			//     connection = (Connection *) le->data;
+			//     failed = lobby_poll_register_connection (lobby, player, connection);
+			// }
 
-            // if (!failed) {
-                dlist_insert_after (lobby->players, dlist_end (lobby->players), player);
+			// if (!failed) {
+				dlist_insert_after (lobby->players, dlist_end (lobby->players), player);
 
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
-                    "Registered a new player to lobby %s.",
-                    lobby->id->str
-                );
-                #endif
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
+					"Registered a new player to lobby %s.",
+					lobby->id->str
+				);
+				#endif
 
-                lobby->n_current_players++;
-                #ifdef CERVER_STATS
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                    "Registered players to lobby %s: %i.",
-                    lobby->id->str, lobby->n_current_players
-                );
-                #endif
+				lobby->n_current_players++;
+				#ifdef CERVER_STATS
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+					"Registered players to lobby %s: %i.",
+					lobby->id->str, lobby->n_current_players
+				);
+				#endif
 
-                retval = 0;
-            // }
-        }
-    }
+				retval = 0;
+			// }
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // unregisters each of the player's client connections from the lobby poll structures
 u8 player_unregister_from_lobby_poll (Lobby *lobby, Player *player) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player) {
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
-            connection = (Connection *) le->data;
-            lobby_poll_unregister_connection (lobby, player, connection);
-        }
-    }
+	if (lobby && player) {
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (player->client->connections); le; le = le->next) {
+			connection = (Connection *) le->data;
+			lobby_poll_unregister_connection (lobby, player, connection);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -163,115 +163,115 @@ u8 player_unregister_from_lobby_poll (Lobby *lobby, Player *player) {
 // unregisters a player from a lobby --> removes him from lobby's structures
 u8 player_unregister_from_lobby (Lobby *lobby, Player *player) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (lobby && player) {
-        if (player->client) {
-            // printf ("\nplayer_unregister_from_lobby client id: %li\n", player->client->id);
-            if (lobby->default_handler) {
-                // unregister all the player's client connections from the lobby
-                player_unregister_from_lobby_poll (lobby, player);
-            }
+	if (lobby && player) {
+		if (player->client) {
+			// printf ("\nplayer_unregister_from_lobby client id: %li\n", player->client->id);
+			if (lobby->default_handler) {
+				// unregister all the player's client connections from the lobby
+				player_unregister_from_lobby_poll (lobby, player);
+			}
 
-            if (!dlist_remove (lobby->players, player, NULL)) {
-                lobby->n_current_players--;
+			if (!dlist_remove (lobby->players, player, NULL)) {
+				lobby->n_current_players--;
 
-                #ifdef CERVER_DEBUG
-                cerver_log (
-                    LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
-                    "Unregistered a player from lobby %s.",
-                    lobby->id->str
-                );
-                #endif
+				#ifdef CERVER_DEBUG
+				cerver_log (
+					LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
+					"Unregistered a player from lobby %s.",
+					lobby->id->str
+				);
+				#endif
 
-                #ifdef CERVER_STATS
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                    "Registered players to lobby %s: %i.",
-                    lobby->id->str, lobby->n_current_players
-                );
-                #endif
+				#ifdef CERVER_STATS
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+					"Registered players to lobby %s: %i.",
+					lobby->id->str, lobby->n_current_players
+				);
+				#endif
 
-                // check if there are players left inside the lobby
-                if (lobby->n_current_players <= 0) {
-                    // destroy the lobby
-                    #ifdef CERVER_DEBUG
-                    cerver_log (
-                        LOG_TYPE_DEBUG, LOG_TYPE_GAME,
-                        "Destroying lobby %s -- it is empty.",
-                        lobby->id->str
-                    );
-                    #endif
+				// check if there are players left inside the lobby
+				if (lobby->n_current_players <= 0) {
+					// destroy the lobby
+					#ifdef CERVER_DEBUG
+					cerver_log (
+						LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+						"Destroying lobby %s -- it is empty.",
+						lobby->id->str
+					);
+					#endif
 
-                    // teardown the cerver
-                    Cerver *cerver = lobby->cerver;
-                    GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
-                    lobby_teardown (game_cerver, lobby);
-                }
+					// teardown the cerver
+					Cerver *cerver = lobby->cerver;
+					GameCerver *game_cerver = (GameCerver *) cerver->cerver_data;
+					lobby_teardown (game_cerver, lobby);
+				}
 
-                retval = 0;
-            }
-        }
-    }
+				retval = 0;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // gets a player from the lobby using the query
 Player *player_get_from_lobby (Lobby *lobby, Player *query) {
 
-    return (lobby ? (Player *) dlist_search (lobby->players, query, NULL) : NULL);
+	return (lobby ? (Player *) dlist_search (lobby->players, query, NULL) : NULL);
 
 }
 
 // get sthe list element associated with the player
 ListElement *player_get_le_from_lobby (Lobby *lobby, Player *player) {
 
-    return (lobby ? dlist_get_element (lobby->players, player, NULL) : NULL);
+	return (lobby ? dlist_get_element (lobby->players, player, NULL) : NULL);
 
 }
 
 // gets a player from the lobby player's list suing the sock fd
 Player *player_get_by_sock_fd_list (Lobby *lobby, i32 sock_fd) {
 
-    if (lobby) {
-        Player *player = NULL;
-        Connection *connection = NULL;
-        for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
-            player = (Player *) le->data;
-            for (ListElement *le_sub = dlist_start (player->client->connections); le_sub; le_sub = le_sub->next) {
-                connection = (Connection *) le_sub->data;
-                if (connection->socket->sock_fd == sock_fd) return player;
-            }
-        }
-    }
+	if (lobby) {
+		Player *player = NULL;
+		Connection *connection = NULL;
+		for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
+			player = (Player *) le->data;
+			for (ListElement *le_sub = dlist_start (player->client->connections); le_sub; le_sub = le_sub->next) {
+				connection = (Connection *) le_sub->data;
+				if (connection->socket->sock_fd == sock_fd) return player;
+			}
+		}
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
 // broadcasts a packet to all the players in the lobby
-void player_broadcast_to_all (Cerver *cerver, const Lobby *lobby, Packet *packet, 
-    Protocol protocol, int flags) {
+void player_broadcast_to_all (Cerver *cerver, const Lobby *lobby, Packet *packet,
+	Protocol protocol, int flags) {
 
-    if (lobby && packet) {
-        Player *player = NULL;
-        for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
-            player = (Player *) le->data;
+	if (lobby && packet) {
+		Player *player = NULL;
+		for (ListElement *le = dlist_start (lobby->players); le; le = le->next) {
+			player = (Player *) le->data;
 
-            Connection *connection = NULL;
-            for (ListElement *le_sub = dlist_start (player->client->connections); le_sub; le_sub = le_sub->next) {
-                connection = (Connection *) le_sub->data;
-                packet_set_network_values (packet, cerver, player->client, connection, (Lobby *) lobby);
-                packet_send (packet, flags, NULL, false);
-            }
-        }
-    }
+			Connection *connection = NULL;
+			for (ListElement *le_sub = dlist_start (player->client->connections); le_sub; le_sub = le_sub->next) {
+				connection = (Connection *) le_sub->data;
+				packet_set_network_values (packet, cerver, player->client, connection, (Lobby *) lobby);
+				packet_send (packet, flags, NULL, false);
+			}
+		}
+	}
 
 }
 
 // TODO:
 // this is used to clean disconnected players inside a lobby
-// if we haven't recieved any kind of input from a player, disconnect it 
+// if we haven't recieved any kind of input from a player, disconnect it
 void checkPlayerTimeouts (void) {}

--- a/src/cerver/game/player.c
+++ b/src/cerver/game/player.c
@@ -8,6 +8,7 @@
 
 #include "cerver/client.h"
 #include "cerver/packets.h"
+
 #include "cerver/game/game.h"
 #include "cerver/game/player.h"
 
@@ -116,22 +117,20 @@ u8 player_register_to_lobby (Lobby *lobby, Player *player) {
                 dlist_insert_after (lobby->players, dlist_end (lobby->players), player);
 
                 #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Registered a new player to lobby %s.",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
+                    "Registered a new player to lobby %s.",
+                    lobby->id->str
+                );
                 #endif
 
                 lobby->n_current_players++;
                 #ifdef CERVER_STATS
-                char *status = c_string_create ("Registered players to lobby %s: %i.",
-                    lobby->id->str, lobby->n_current_players);
-                if (status) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, status);
-                    free (status);
-                }
+                cerver_log (
+                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                    "Registered players to lobby %s: %i.",
+                    lobby->id->str, lobby->n_current_players
+                );
                 #endif
 
                 retval = 0;
@@ -178,33 +177,30 @@ u8 player_unregister_from_lobby (Lobby *lobby, Player *player) {
                 lobby->n_current_players--;
 
                 #ifdef CERVER_DEBUG
-                char *s = c_string_create ("Unregistered a player from lobby %s.",
-                    lobby->id->str);
-                if (s) {
-                    cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER, s);
-                    free (s);
-                }
+                cerver_log (
+                    LOG_TYPE_SUCCESS, LOG_TYPE_PLAYER,
+                    "Unregistered a player from lobby %s.",
+                    lobby->id->str
+                );
                 #endif
 
                 #ifdef CERVER_STATS
-                char *status = c_string_create ("Registered players to lobby %s: %i.",
-                    lobby->id->str, lobby->n_current_players);
-                if (status) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, status);
-                    free (status);
-                }
+                cerver_log (
+                    LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                    "Registered players to lobby %s: %i.",
+                    lobby->id->str, lobby->n_current_players
+                );
                 #endif
 
                 // check if there are players left inside the lobby
                 if (lobby->n_current_players <= 0) {
                     // destroy the lobby
                     #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Destroying lobby %s -- it is empty.",
-                        lobby->id->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_GAME, s);
-                        free (s);
-                    }
+                    cerver_log (
+                        LOG_TYPE_DEBUG, LOG_TYPE_GAME,
+                        "Destroying lobby %s -- it is empty.",
+                        lobby->id->str
+                    );
                     #endif
 
                     // teardown the cerver

--- a/src/cerver/game/score.c
+++ b/src/cerver/game/score.c
@@ -26,9 +26,9 @@
 // scoreboard constructor
 ScoreBoard *game_score_new (void) {
 
-    ScoreBoard *sb = (ScoreBoard *) malloc (sizeof (ScoreBoard));
-    if (sb) memset (sb, 0, sizeof (ScoreBoard));
-    return sb;
+	ScoreBoard *sb = (ScoreBoard *) malloc (sizeof (ScoreBoard));
+	if (sb) memset (sb, 0, sizeof (ScoreBoard));
+	return sb;
 
 }
 
@@ -36,46 +36,46 @@ ScoreBoard *game_score_new (void) {
 // to be added each time we add a new player!!
 ScoreBoard *game_score_create (u8 playersNum, u8 scoresNum, ...) {
 
-    ScoreBoard *sb = (ScoreBoard *) malloc (sizeof (ScoreBoard));
-    if (sb) {
-        va_list valist;
-        va_start (valist, scoresNum);
+	ScoreBoard *sb = (ScoreBoard *) malloc (sizeof (ScoreBoard));
+	if (sb) {
+		va_list valist;
+		va_start (valist, scoresNum);
 
-        sb->scoresNum = scoresNum;
-        sb->scoreTypes = (char **) calloc (scoresNum, sizeof (char *));
-        char *temp = NULL;
-        for (int i = 0; i < scoresNum; i++) {
-            temp = va_arg (valist, char *);
-            sb->scoreTypes[i] = (char *) calloc (strlen (temp) + 1, sizeof (char));
-            strcpy (sb->scoreTypes[i], temp);
-        }
+		sb->scoresNum = scoresNum;
+		sb->scoreTypes = (char **) calloc (scoresNum, sizeof (char *));
+		char *temp = NULL;
+		for (int i = 0; i < scoresNum; i++) {
+			temp = va_arg (valist, char *);
+			sb->scoreTypes[i] = (char *) calloc (strlen (temp) + 1, sizeof (char));
+			strcpy (sb->scoreTypes[i], temp);
+		}
 
-        sb->registeredPlayers = 0;
+		sb->registeredPlayers = 0;
 
-        // FIXME: pass delete data
-        sb->scores = htab_create (
-            10,
-            NULL, NULL
-        );
+		// FIXME: pass delete data
+		sb->scores = htab_create (
+			10,
+			NULL, NULL
+		);
 
-        va_end (valist);
-    }
+		va_end (valist);
+	}
 
-    return sb;
+	return sb;
 
 }
 
 // destroy the scoreboard
 void game_score_delete (ScoreBoard *sb) {
 
-    if (sb) {
-        if (sb->scores) htab_destroy (sb->scores);
-        if (sb->scoreTypes) {
-            for (int i = 0; i < sb->scoresNum; i++) 
-                if (sb->scoreTypes[i]) free (sb->scoreTypes[i]);
-            
-        }
-    }
+	if (sb) {
+		if (sb->scores) htab_destroy (sb->scores);
+		if (sb->scoreTypes) {
+			for (int i = 0; i < sb->scoresNum; i++)
+				if (sb->scoreTypes[i]) free (sb->scoreTypes[i]);
+
+		}
+	}
 
 }
 
@@ -83,38 +83,38 @@ void game_score_delete (ScoreBoard *sb) {
 // add a new score type to all current players
 void game_score_add_scoreType (ScoreBoard *sb, char *newScore) {
 
-    if (sb && newScore) {
-        // first check if we have that score type
-        bool found = false;
-        for (int i = 0; i < sb->scoresNum; i++) {
-            if (!strcmp (sb->scoreTypes[i], newScore)) {
-                found = true;
-                break;
-            }
-        }
+	if (sb && newScore) {
+		// first check if we have that score type
+		bool found = false;
+		for (int i = 0; i < sb->scoresNum; i++) {
+			if (!strcmp (sb->scoreTypes[i], newScore)) {
+				found = true;
+				break;
+			}
+		}
 
-        if (found) {
-            // add the new score to all the players
-            // FIXME:
+		if (found) {
+			// add the new score to all the players
+			// FIXME:
 
-            // add the score to the scoretypes
-            sb->scoreTypes = (char **) realloc (sb->scores, sb->scoresNum);
-            if (sb->scoreTypes) {
-                sb->scoreTypes[sb->scoresNum] = (char *) calloc (strlen (newScore) + 1, sizeof (char));
-                strcpy (sb->scoreTypes[sb->scoresNum], newScore);
-                sb->scoresNum++;
-            } 
-        }
+			// add the score to the scoretypes
+			sb->scoreTypes = (char **) realloc (sb->scores, sb->scoresNum);
+			if (sb->scoreTypes) {
+				sb->scoreTypes[sb->scoresNum] = (char *) calloc (strlen (newScore) + 1, sizeof (char));
+				strcpy (sb->scoreTypes[sb->scoresNum], newScore);
+				sb->scoresNum++;
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Can't add score type! It already exists in the scoreboard."
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Can't add score type! It already exists in the scoreboard."
+			);
+			#endif
+		}
+	}
 
 }
 
@@ -122,262 +122,262 @@ void game_score_add_scoreType (ScoreBoard *sb, char *newScore) {
 // remove a score type from all current players
 u8 game_score_remove_scoreType (ScoreBoard *sb, char *oldScore) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (sb && oldScore) {
-        // first check if we have that score type
-        int found = -1;
-        for (int i = 0; i < sb->scoresNum; i++) {
-            if (!strcmp (sb->scoreTypes[i], oldScore)) {
-                found = i;
-                break;
-            }
-        }
+	if (sb && oldScore) {
+		// first check if we have that score type
+		int found = -1;
+		for (int i = 0; i < sb->scoresNum; i++) {
+			if (!strcmp (sb->scoreTypes[i], oldScore)) {
+				found = i;
+				break;
+			}
+		}
 
-        if (found > 0) {
-            // remove the score from all the players
-            // FIXME:
+		if (found > 0) {
+			// remove the score from all the players
+			// FIXME:
 
-            // manually copy old scores array and delete it
-            // this is done because we allocate exat space for each score type!
-            char **new_scoreTypes = (char **) calloc (sb->scoresNum - 1, sizeof (char *));
-            int i = 0;
-            while (i < found) {
-                new_scoreTypes[i] = (char *) calloc (strlen (sb->scoreTypes[i]) + 1, sizeof (char));
-                strcpy (new_scoreTypes[i], sb->scoreTypes[i]);
-                i++;
-            }
+			// manually copy old scores array and delete it
+			// this is done because we allocate exat space for each score type!
+			char **new_scoreTypes = (char **) calloc (sb->scoresNum - 1, sizeof (char *));
+			int i = 0;
+			while (i < found) {
+				new_scoreTypes[i] = (char *) calloc (strlen (sb->scoreTypes[i]) + 1, sizeof (char));
+				strcpy (new_scoreTypes[i], sb->scoreTypes[i]);
+				i++;
+			}
 
-            for (i = found + 1; i < sb->scoresNum; i++) {
-                new_scoreTypes[i - 1] = (char *) calloc (strlen (sb->scoreTypes[i]) + 1, sizeof (char));
-                strcpy (new_scoreTypes[i - 1], sb->scoreTypes[i]);
-            }
+			for (i = found + 1; i < sb->scoresNum; i++) {
+				new_scoreTypes[i - 1] = (char *) calloc (strlen (sb->scoreTypes[i]) + 1, sizeof (char));
+				strcpy (new_scoreTypes[i - 1], sb->scoreTypes[i]);
+			}
 
-            sb->scoresNum--;
+			sb->scoresNum--;
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Can't remove %s scoretype, doesn't exist in the scoreboard!"
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Can't remove %s scoretype, doesn't exist in the scoreboard!"
+			);
+			#endif
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // adds a new player to the score table
 u8 game_score_add_player (ScoreBoard *sb, char *playerName) {
 
-    if (sb && playerName) {
-        if (htab_contains_key (sb->scores, playerName, sizeof (playerName))) {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Scores table already contains player: %s", playerName
-            );
-            #endif
-            return 1;
-        }
+	if (sb && playerName) {
+		if (htab_contains_key (sb->scores, playerName, sizeof (playerName))) {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Scores table already contains player: %s", playerName
+			);
+			#endif
+			return 1;
+		}
 
-        // associate the player with his own scores dictionary
-        else {
-            // FIXME: correctly destroy this
-            Htab *newHt = htab_create (sb->scoresNum, NULL, NULL);
-            if (newHt) {
-                if (!htab_insert (sb->scores, playerName, sizeof (playerName), newHt, sizeof (Htab))) {
-                    // insert each score type in the player's dictionary
-                    u32 zero = 0;
-                    for (int i = 0; i < sb->scoresNum; i++) 
-                        htab_insert (newHt, sb->scoreTypes[i], 
-                            sizeof (sb->scoreTypes[i]), &zero, sizeof (int));
+		// associate the player with his own scores dictionary
+		else {
+			// FIXME: correctly destroy this
+			Htab *newHt = htab_create (sb->scoresNum, NULL, NULL);
+			if (newHt) {
+				if (!htab_insert (sb->scores, playerName, sizeof (playerName), newHt, sizeof (Htab))) {
+					// insert each score type in the player's dictionary
+					u32 zero = 0;
+					for (int i = 0; i < sb->scoresNum; i++)
+						htab_insert (newHt, sb->scoreTypes[i],
+							sizeof (sb->scoreTypes[i]), &zero, sizeof (int));
 
-                    sb->registeredPlayers++;
+					sb->registeredPlayers++;
 
-                    return 0;   // LOG_TYPE_SUCCESS adding new player and its scores
-                }
-            }
-        }
-    }
+					return 0;   // LOG_TYPE_SUCCESS adding new player and its scores
+				}
+			}
+		}
+	}
 
-    return 1;
+	return 1;
 
 }
 
 // FIXME: how do we get the player name?? the server is not interested in knowing a playe's name
-// inside his player structure, it is the admin reponsability to determine how to get 
+// inside his player structure, it is the admin reponsability to determine how to get
 // the player's name
 void game_score_add_lobby_players (ScoreBoard *sb, AVLNode *playerNode) {
 
-    if (sb && playerNode) {
-        game_score_add_lobby_players (sb, playerNode->right);
+	if (sb && playerNode) {
+		game_score_add_lobby_players (sb, playerNode->right);
 
-        // if (playerNode->id) game_score_add_player (sb, ((Player *) playerNode->id));
+		// if (playerNode->id) game_score_add_player (sb, ((Player *) playerNode->id));
 
-        game_score_add_lobby_players (sb, playerNode->left);
-    }
+		game_score_add_lobby_players (sb, playerNode->left);
+	}
 
 }
 
 // removes a player from the score table
 u8 game_score_remove_player (ScoreBoard *sb, char *playerName) {
 
-    if (sb && playerName) {
-        if (htab_contains_key (sb->scores, playerName, sizeof (playerName))) {
-            // size_t htab_size = sizeof (Htab);
-            void *htab = htab_get (sb->scores, playerName, sizeof (playerName));
-            
-            // destroy player's scores htab
-            if (htab) htab_destroy ((Htab *) htab);
+	if (sb && playerName) {
+		if (htab_contains_key (sb->scores, playerName, sizeof (playerName))) {
+			// size_t htab_size = sizeof (Htab);
+			void *htab = htab_get (sb->scores, playerName, sizeof (playerName));
 
-            // remove th player from the scoreboard
-            htab_remove (sb->scores, playerName, sizeof (playerName));
+			// destroy player's scores htab
+			if (htab) htab_destroy ((Htab *) htab);
 
-            sb->registeredPlayers--;
-        }
+			// remove th player from the scoreboard
+			htab_remove (sb->scores, playerName, sizeof (playerName));
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Scores table doesn't contains player: %s", playerName
-            );
-            #endif
-        }
-    }
+			sb->registeredPlayers--;
+		}
 
-    return 1;   // error
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Scores table doesn't contains player: %s", playerName
+			);
+			#endif
+		}
+	}
+
+	return 1;   // error
 
 }
 
 // sets the score's value, negative values not allowed
 void game_score_set (ScoreBoard *sb, char *playerName, char *scoreType, i32 value) {
 
-    if (sb && playerName && scoreType) {
-        // size_t htab_size = sizeof (Htab);
-        void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
-        if (playerScores) {
-            // size_t int_size = sizeof (unsigned int);
-            void *currValue = htab_get ((Htab *) playerScores, 
-                scoreType, sizeof (scoreType));
+	if (sb && playerName && scoreType) {
+		// size_t htab_size = sizeof (Htab);
+		void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
+		if (playerScores) {
+			// size_t int_size = sizeof (unsigned int);
+			void *currValue = htab_get ((Htab *) playerScores,
+				scoreType, sizeof (scoreType));
 
-            // replace the old value with the new one
-            if (currValue) {
-                u32 *current = (u32 *) currValue;
-                if (value > 0) *current = value;
-                else *current = 0;
-            }
-        }
+			// replace the old value with the new one
+			if (currValue) {
+				u32 *current = (u32 *) currValue;
+				if (value > 0) *current = value;
+				else *current = 0;
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Player: %s has not scores in the table!", playerName
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Player: %s has not scores in the table!", playerName
+			);
+			#endif
+		}
+	}
 
 }
 
 // gets the value of the player's score type
 i32 game_score_get (ScoreBoard *sb, char *playerName, char *scoreType) {
 
-    if (sb && playerName && scoreType) {
-        // size_t htab_size = sizeof (Htab);
-        void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
-        if (playerScores) {
-            // size_t int_size = sizeof (unsigned int);
-            void *value = htab_get ((Htab *) playerScores, 
-                scoreType, sizeof (scoreType));
+	if (sb && playerName && scoreType) {
+		// size_t htab_size = sizeof (Htab);
+		void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
+		if (playerScores) {
+			// size_t int_size = sizeof (unsigned int);
+			void *value = htab_get ((Htab *) playerScores,
+				scoreType, sizeof (scoreType));
 
-            if (value) {
-                u32 *retval = (u32 *) value;
-                return *retval;
-            }
-        }
+			if (value) {
+				u32 *retval = (u32 *) value;
+				return *retval;
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Player: %s has not scores in the table!", playerName
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Player: %s has not scores in the table!", playerName
+			);
+			#endif
+		}
+	}
 
-    return -1;  // error
+	return -1;  // error
 
 }
 
 // updates the value of the player's score type, clamped to 0
 void game_score_update (ScoreBoard *sb, char *playerName, char *scoreType, i32 value) {
 
-    if (sb && playerName && scoreType) {
-        // size_t htab_size = sizeof (Htab);
-        void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
-        if (playerScores) {
-            // size_t int_size = sizeof (unsigned int);
-            void *currValue = htab_get ((Htab *) playerScores, 
-                scoreType, sizeof (scoreType));
-            
-            // directly update the score value adding the new value
-            if (value) {
-                u32 *current = (u32 *) currValue;
-                if ((*current += value) < 0) *current = 0;
-                else *current += value;
-            }
-        }
+	if (sb && playerName && scoreType) {
+		// size_t htab_size = sizeof (Htab);
+		void *playerScores = htab_get (sb->scores, playerName, sizeof (playerName));
+		if (playerScores) {
+			// size_t int_size = sizeof (unsigned int);
+			void *currValue = htab_get ((Htab *) playerScores,
+				scoreType, sizeof (scoreType));
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Player: %s has not scores in the table!", playerName
-            );
-            #endif
-        }
-    }
+			// directly update the score value adding the new value
+			if (value) {
+				u32 *current = (u32 *) currValue;
+				if ((*current += value) < 0) *current = 0;
+				else *current += value;
+			}
+		}
+
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Player: %s has not scores in the table!", playerName
+			);
+			#endif
+		}
+	}
 
 }
 
 // reset all the player's scores
 void game_score_reset (ScoreBoard *sb, char *playerName) {
 
-    if (sb && playerName) {
-        // size_t htab_size = sizeof (Htab);
-        void *data = htab_get (sb->scores, playerName, sizeof (playerName));
-        if (data) {
-            Htab *playerScores = (Htab *) data;
-            void *scoreData = NULL;
-            // size_t score_size = sizeof (u32);
-            for (int i = 0; i < sb->scoresNum; i++) {
-                scoreData = htab_get (playerScores, 
-                    sb->scoreTypes[i], sizeof (sb->scoreTypes[i]));
+	if (sb && playerName) {
+		// size_t htab_size = sizeof (Htab);
+		void *data = htab_get (sb->scores, playerName, sizeof (playerName));
+		if (data) {
+			Htab *playerScores = (Htab *) data;
+			void *scoreData = NULL;
+			// size_t score_size = sizeof (u32);
+			for (int i = 0; i < sb->scoresNum; i++) {
+				scoreData = htab_get (playerScores,
+					sb->scoreTypes[i], sizeof (sb->scoreTypes[i]));
 
-                if (scoreData) {
-                    u32 *current = (u32 *) scoreData;
-                    *current = 0;
-                }
-            }
-        }
+				if (scoreData) {
+					u32 *current = (u32 *) scoreData;
+					*current = 0;
+				}
+			}
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            cerver_log (
-                LOG_TYPE_ERROR, LOG_TYPE_GAME,
-                "Scores table already contains player: %s", playerName
-            );
-            #endif
-        }
-    }
+		else {
+			#ifdef CERVER_DEBUG
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_GAME,
+				"Scores table already contains player: %s", playerName
+			);
+			#endif
+		}
+	}
 
 }

--- a/src/cerver/game/score.c
+++ b/src/cerver/game/score.c
@@ -108,8 +108,10 @@ void game_score_add_scoreType (ScoreBoard *sb, char *newScore) {
 
         else {
             #ifdef CERVER_DEBUG
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, 
-                "Can't add score type! It already exists in the scoreboard.");
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME, 
+                "Can't add score type! It already exists in the scoreboard."
+            );
             #endif
         }
     }
@@ -158,11 +160,10 @@ u8 game_score_remove_scoreType (ScoreBoard *sb, char *oldScore) {
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Can't remove %s scoretype, doesn't exist in the scoreboard!");
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Can't remove %s scoretype, doesn't exist in the scoreboard!"
+            );
             #endif
         }
     }
@@ -177,11 +178,10 @@ u8 game_score_add_player (ScoreBoard *sb, char *playerName) {
     if (sb && playerName) {
         if (htab_contains_key (sb->scores, playerName, sizeof (playerName))) {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Scores table already contains player: %s", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Scores table already contains player: %s", playerName
+            );
             #endif
             return 1;
         }
@@ -244,11 +244,10 @@ u8 game_score_remove_player (ScoreBoard *sb, char *playerName) {
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Scores table doesn't contains player: %s", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Scores table doesn't contains player: %s", playerName
+            );
             #endif
         }
     }
@@ -278,11 +277,10 @@ void game_score_set (ScoreBoard *sb, char *playerName, char *scoreType, i32 valu
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Player: %s has not scores in the table!", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Player: %s has not scores in the table!", playerName
+            );
             #endif
         }
     }
@@ -308,11 +306,10 @@ i32 game_score_get (ScoreBoard *sb, char *playerName, char *scoreType) {
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Player: %s has not scores in the table!", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Player: %s has not scores in the table!", playerName
+            );
             #endif
         }
     }
@@ -342,11 +339,10 @@ void game_score_update (ScoreBoard *sb, char *playerName, char *scoreType, i32 v
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Player: %s has not scores in the table!", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Player: %s has not scores in the table!", playerName
+            );
             #endif
         }
     }
@@ -376,11 +372,10 @@ void game_score_reset (ScoreBoard *sb, char *playerName) {
 
         else {
             #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Scores table already contains player: %s", playerName);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_GAME, s);
-                free (s);
-            }
+            cerver_log (
+                LOG_TYPE_ERROR, LOG_TYPE_GAME,
+                "Scores table already contains player: %s", playerName
+            );
             #endif
         }
     }

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -762,178 +762,154 @@ static void cerver_request_packet_handler (Packet *packet) {
 // sends back a test packet to the client!
 void cerver_test_packet_handler (Packet *packet) {
 
-	if (packet) {
-		#ifdef CERVER_DEBUG
-		char *s = c_string_create ("Got a test packet in cerver %s.", packet->cerver->info->name->str);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_PACKET, s);
-			free (s);
-		}
-		#endif
+	#ifdef HANDLER_DEBUG
+	cerver_log (
+		LOG_TYPE_DEBUG, LOG_TYPE_PACKET,
+		"Got a test packet in cerver %s.", packet->cerver->info->name->str
+	);
+	#endif
 
-		Packet *test_packet = packet_new ();
-		if (test_packet) {
-			packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-			test_packet->packet_type = TEST_PACKET;
-			packet_generate (test_packet);
-			if (packet_send (test_packet, 0, NULL, false)) {
-				char *s = c_string_create ("Failed to send error packet from cerver %s.",
-					packet->cerver->info->name->str);
-				if (s) {
-					cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PACKET, s);
-					free (s);
-				}
-			}
-
-			packet_delete (test_packet);
+	Packet *test_packet = packet_new ();
+	if (test_packet) {
+		packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+		test_packet->packet_type = PACKET_TYPE_TEST;
+		packet_generate (test_packet);
+		if (packet_send (test_packet, 0, NULL, false)) {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_PACKET,
+				"Failed to send error packet from cerver %s.",
+				packet->cerver->info->name->str
+			);
 		}
+
+		packet_delete (test_packet);
 	}
 
 }
 
 // 27/01/2020
-// handles an APP_PACKET packet type
+// handles an PACKET_TYPE_APP packet type
 static void cerver_app_packet_handler (Packet *packet) {
 
-	if (packet) {
-		// 11/05/2020
-		if (packet->cerver->multiple_handlers) {
-			// select which handler to use
-			if (packet->header->handler_id < packet->cerver->n_handlers) {
-				if (packet->cerver->handlers[packet->header->handler_id]) {
-					// add the packet to the handler's job queueu to be handled
-					// as soon as the handler is available
-					if (job_queue_push (
-						packet->cerver->handlers[packet->header->handler_id]->job_queue,
-						job_create (NULL, packet)
-					)) {
-						char *s = c_string_create ("Failed to push a new job to cerver's %s <%d> handler!",
-							packet->cerver->info->name->str, packet->header->handler_id);
-						if (s) {
-							cerver_log_error (s);
-							free (s);
-						}
-					}
+	// 11/05/2020
+	if (packet->cerver->multiple_handlers) {
+		// select which handler to use
+		if (packet->header->handler_id < packet->cerver->n_handlers) {
+			if (packet->cerver->handlers[packet->header->handler_id]) {
+				// add the packet to the handler's job queueu to be handled
+				// as soon as the handler is available
+				if (job_queue_push (
+					packet->cerver->handlers[packet->header->handler_id]->job_queue,
+					job_create (NULL, packet)
+				)) {
+					cerver_log_error (
+						"Failed to push a new job to cerver's %s <%d> handler!",
+						packet->cerver->info->name->str, packet->header->handler_id
+					);
+				}
+			}
+		}
+	}
+
+	else {
+		if (packet->cerver->app_packet_handler) {
+			if (packet->cerver->app_packet_handler->direct_handle) {
+				// printf ("app_packet_handler - direct handle!\n");
+				packet->cerver->app_packet_handler->handler (packet);
+				if (packet->cerver->app_packet_handler_delete_packet) packet_delete (packet);
+			}
+
+			else {
+				// add the packet to the handler's job queueu to be handled
+				// as soon as the handler is available
+				if (job_queue_push (
+					packet->cerver->app_packet_handler->job_queue,
+					job_create (NULL, packet)
+				)) {
+					cerver_log_error (
+						"Failed to push a new job to cerver's %s app_packet_handler!",
+						packet->cerver->info->name->str
+					);
 				}
 			}
 		}
 
 		else {
-			if (packet->cerver->app_packet_handler) {
-				if (packet->cerver->app_packet_handler->direct_handle) {
-					// printf ("app_packet_handler - direct handle!\n");
-					packet->cerver->app_packet_handler->handler (packet);
-					if (packet->cerver->app_packet_handler_delete_packet) packet_delete (packet);
-				}
-
-				else {
-					// add the packet to the handler's job queueu to be handled
-					// as soon as the handler is available
-					if (job_queue_push (
-						packet->cerver->app_packet_handler->job_queue,
-						job_create (NULL, packet)
-					)) {
-						char *s = c_string_create ("Failed to push a new job to cerver's %s app_packet_handler!",
-							packet->cerver->info->name->str);
-						if (s) {
-							cerver_log_error (s);
-							free (s);
-						}
-					}
-				}
-			}
-
-			else {
-				char *s = c_string_create ("Cerver %s does not have an app_packet_handler!",
-					packet->cerver->info->name->str);
-				if (s) {
-					cerver_log_warning (s);
-					free (s);
-				}
-			}
+			cerver_log_warning (
+				"Cerver %s does not have an app_packet_handler!",
+				packet->cerver->info->name->str
+			);
 		}
 	}
 
 }
 
 // 27/05/2020
-// handles an APP_ERROR_PACKET packet type
+// handles an PACKET_TYPE_APP_ERROR packet type
 static void cerver_app_error_packet_handler (Packet *packet) {
 
-	if (packet) {
-		if (packet->cerver->app_error_packet_handler) {
-			if (packet->cerver->app_error_packet_handler->direct_handle) {
-				// printf ("app_error_packet_handler - direct handle!\n");
-				packet->cerver->app_error_packet_handler->handler (packet);
-				if (packet->cerver->app_error_packet_handler_delete_packet) packet_delete (packet);
-			}
-
-			else {
-				// add the packet to the handler's job queueu to be handled
-				// as soon as the handler is available
-				if (job_queue_push (
-					packet->cerver->app_error_packet_handler->job_queue,
-					job_create (NULL, packet)
-				)) {
-					char *s = c_string_create ("Failed to push a new job to cerver's %s app_error_packet_handler!",
-						packet->cerver->info->name->str);
-					if (s) {
-						cerver_log_error (s);
-						free (s);
-					}
-				}
-			}
+	if (packet->cerver->app_error_packet_handler) {
+		if (packet->cerver->app_error_packet_handler->direct_handle) {
+			// printf ("app_error_packet_handler - direct handle!\n");
+			packet->cerver->app_error_packet_handler->handler (packet);
+			if (packet->cerver->app_error_packet_handler_delete_packet) packet_delete (packet);
 		}
 
 		else {
-			char *s = c_string_create ("Cerver %s does not have an app_error_packet_handler!",
-				packet->cerver->info->name->str);
-			if (s) {
-				cerver_log_warning (s);
-				free (s);
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->cerver->app_error_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to cerver's %s app_error_packet_handler!",
+					packet->cerver->info->name->str
+				);
 			}
 		}
+	}
+
+	else {
+		cerver_log_warning (
+			"Cerver %s does not have an app_error_packet_handler!",
+			packet->cerver->info->name->str
+		);
 	}
 
 }
 
 // 27/05/2020
-// handles a CUSTOM_PACKET packet type
+// handles a PACKET_TYPE_CUSTOM packet type
 static void cerver_custom_packet_handler (Packet *packet) {
 
-	if (packet) {
-		if (packet->cerver->custom_packet_handler) {
-			if (packet->cerver->custom_packet_handler->direct_handle) {
-				// printf ("custom_packet_handler - direct handle!\n");
-				packet->cerver->custom_packet_handler->handler (packet);
-				if (packet->cerver->custom_packet_handler_delete_packet) packet_delete (packet);
-			}
-
-			else {
-				// add the packet to the handler's job queueu to be handled
-				// as soon as the handler is available
-				if (job_queue_push (
-					packet->cerver->custom_packet_handler->job_queue,
-					job_create (NULL, packet)
-				)) {
-					char *s = c_string_create ("Failed to push a new job to cerver's %s custom_packet_handler!",
-						packet->cerver->info->name->str);
-					if (s) {
-						cerver_log_error (s);
-						free (s);
-					}
-				}
-			}
+	if (packet->cerver->custom_packet_handler) {
+		if (packet->cerver->custom_packet_handler->direct_handle) {
+			// printf ("custom_packet_handler - direct handle!\n");
+			packet->cerver->custom_packet_handler->handler (packet);
+			if (packet->cerver->custom_packet_handler_delete_packet) packet_delete (packet);
 		}
 
 		else {
-			char *s = c_string_create ("Cerver %s does not have a custom_packet_handler!",
-				packet->cerver->info->name->str);
-			if (s) {
-				cerver_log_warning (s);
-				free (s);
+			// add the packet to the handler's job queueu to be handled
+			// as soon as the handler is available
+			if (job_queue_push (
+				packet->cerver->custom_packet_handler->job_queue,
+				job_create (NULL, packet)
+			)) {
+				cerver_log_error (
+					"Failed to push a new job to cerver's %s custom_packet_handler!",
+					packet->cerver->info->name->str
+				);
 			}
 		}
+	}
+
+	else {
+		cerver_log_warning (
+			"Cerver %s does not have a custom_packet_handler!",
+			packet->cerver->info->name->str
+		);
 	}
 
 }

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -38,61 +38,61 @@ static int unique_handler_id = 0;
 
 static HandlerData *handler_data_new (void) {
 
-    HandlerData *handler_data = (HandlerData *) malloc (sizeof (HandlerData));
-    if (handler_data) {
-        handler_data->handler_id = 0;
+	HandlerData *handler_data = (HandlerData *) malloc (sizeof (HandlerData));
+	if (handler_data) {
+		handler_data->handler_id = 0;
 
-        handler_data->data = NULL;
-        handler_data->packet = NULL;
-    }
+		handler_data->data = NULL;
+		handler_data->packet = NULL;
+	}
 
-    return handler_data;
+	return handler_data;
 
 }
 
 static void handler_data_delete (HandlerData *handler_data) {
 
-    if (handler_data) free (handler_data);
+	if (handler_data) free (handler_data);
 
 }
 
 static Handler *handler_new (void) {
 
-    Handler *handler = (Handler *) malloc (sizeof (Handler));
-    if (handler) {
-        handler->type = HANDLER_TYPE_NONE;
-        handler->unique_id = -1;
+	Handler *handler = (Handler *) malloc (sizeof (Handler));
+	if (handler) {
+		handler->type = HANDLER_TYPE_NONE;
+		handler->unique_id = -1;
 
-        handler->id = -1;
-        handler->thread_id = 0;
+		handler->id = -1;
+		handler->thread_id = 0;
 
-        handler->data = NULL;
-        handler->data_create = NULL;
-        handler->data_create_args = NULL;
-        handler->data_delete = NULL;
+		handler->data = NULL;
+		handler->data_create = NULL;
+		handler->data_create_args = NULL;
+		handler->data_delete = NULL;
 
-        handler->handler = NULL;
-        handler->direct_handle = false;
+		handler->handler = NULL;
+		handler->direct_handle = false;
 
-        handler->job_queue = NULL;
+		handler->job_queue = NULL;
 
-        handler->cerver = NULL;
-        handler->client = NULL;
-    }
+		handler->cerver = NULL;
+		handler->client = NULL;
+	}
 
-    return handler;
+	return handler;
 
 }
 
 void handler_delete (void *handler_ptr) {
 
-    if (handler_ptr) {
-        Handler *handler = (Handler *) handler_ptr;
+	if (handler_ptr) {
+		Handler *handler = (Handler *) handler_ptr;
 
-        job_queue_delete (handler->job_queue);
+		job_queue_delete (handler->job_queue);
 
-        free (handler_ptr);
-    }
+		free (handler_ptr);
+	}
 
 }
 
@@ -100,17 +100,17 @@ void handler_delete (void *handler_ptr) {
 // handler method is your actual app packet handler
 Handler *handler_create (Action handler_method) {
 
-    Handler *handler = handler_new ();
-    if (handler) {
-        handler->unique_id = unique_handler_id;
-        unique_handler_id += 1;
+	Handler *handler = handler_new ();
+	if (handler) {
+		handler->unique_id = unique_handler_id;
+		unique_handler_id += 1;
 
-        handler->handler = handler_method;
+		handler->handler = handler_method;
 
-        handler->job_queue = job_queue_create ();
-    }
+		handler->job_queue = job_queue_create ();
+	}
 
-    return handler;
+	return handler;
 
 }
 
@@ -121,12 +121,12 @@ Handler *handler_create (Action handler_method) {
 // handler method is your actual app packet handler
 Handler *handler_create_with_id (int id, Action handler_method) {
 
-    Handler *handler = handler_create (handler_method);
-    if (handler) {
-        handler->id = id;
-    }
+	Handler *handler = handler_create (handler_method);
+	if (handler) {
+		handler->id = id;
+	}
 
-    return handler;
+	return handler;
 
 }
 
@@ -134,26 +134,26 @@ Handler *handler_create_with_id (int id, Action handler_method) {
 // this data will be passed to the handler method using a HandlerData structure
 void handler_set_data (Handler *handler, void *data) {
 
-    if (handler) handler->data = data;
+	if (handler) handler->data = data;
 
 }
 
 // set a method to create the handler's data before it starts handling any packet
 // this data will be passed to the handler method using a HandlerData structure
 void handler_set_data_create (Handler *handler,
-    void *(*data_create) (void *args), void *data_create_args) {
+	void *(*data_create) (void *args), void *data_create_args) {
 
-    if (handler) {
-        handler->data_create = data_create;
-        handler->data_create_args = data_create_args;
-    }
+	if (handler) {
+		handler->data_create = data_create;
+		handler->data_create_args = data_create_args;
+	}
 
 }
 
 // set the method to be used to delete the handler's data
 void handler_set_data_delete (Handler *handler, Action data_delete) {
 
-    if (handler) handler->data_delete = data_delete;
+	if (handler) handler->data_delete = data_delete;
 
 }
 
@@ -161,216 +161,216 @@ void handler_set_data_delete (Handler *handler, Action data_delete) {
 // the packet directly in the same thread
 void handler_set_direct_handle (Handler *handler, bool direct_handle) {
 
-    if (handler) handler->direct_handle = direct_handle;
+	if (handler) handler->direct_handle = direct_handle;
 
 }
 
 // while cerver is running, check for new jobs and handle them
 static void handler_do_while_cerver (Handler *handler) {
 
-    if (handler) {
-        Job *job = NULL;
-        Packet *packet = NULL;
-        PacketType packet_type = PACKET_TYPE_NONE;
-        HandlerData *handler_data = handler_data_new ();
-        while (handler->cerver->isRunning) {
-            bsem_wait (handler->job_queue->has_jobs);
+	if (handler) {
+		Job *job = NULL;
+		Packet *packet = NULL;
+		PacketType packet_type = PACKET_TYPE_NONE;
+		HandlerData *handler_data = handler_data_new ();
+		while (handler->cerver->isRunning) {
+			bsem_wait (handler->job_queue->has_jobs);
 
-            if (handler->cerver->isRunning) {
-                pthread_mutex_lock (handler->cerver->handlers_lock);
-                handler->cerver->num_handlers_working += 1;
-                pthread_mutex_unlock (handler->cerver->handlers_lock);
+			if (handler->cerver->isRunning) {
+				pthread_mutex_lock (handler->cerver->handlers_lock);
+				handler->cerver->num_handlers_working += 1;
+				pthread_mutex_unlock (handler->cerver->handlers_lock);
 
-                // read job from queue
-                job = job_queue_pull (handler->job_queue);
-                if (job) {
-                    packet = (Packet *) job->args;
-                    packet_type = packet->header->packet_type;
+				// read job from queue
+				job = job_queue_pull (handler->job_queue);
+				if (job) {
+					packet = (Packet *) job->args;
+					packet_type = packet->header->packet_type;
 
-                    handler_data->handler_id = handler->id;
-                    handler_data->data = handler->data;
-                    handler_data->packet = packet;
+					handler_data->handler_id = handler->id;
+					handler_data->data = handler->data;
+					handler_data->packet = packet;
 
-                    handler->handler (handler_data);
+					handler->handler (handler_data);
 
-                    job_delete (job);
+					job_delete (job);
 
-                    switch (packet_type) {
-                        case PACKET_TYPE_APP: if (handler->cerver->app_packet_handler_delete_packet) packet_delete (packet); break;
-                        case PACKET_TYPE_APP_ERROR: if (handler->cerver->app_error_packet_handler_delete_packet) packet_delete (packet); break;
-                        case PACKET_TYPE_CUSTOM: if (handler->cerver->custom_packet_handler_delete_packet) packet_delete (packet); break;
+					switch (packet_type) {
+						case PACKET_TYPE_APP: if (handler->cerver->app_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_APP_ERROR: if (handler->cerver->app_error_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_CUSTOM: if (handler->cerver->custom_packet_handler_delete_packet) packet_delete (packet); break;
 
-                        default: packet_delete (packet); break;
-                    }
-                }
+						default: packet_delete (packet); break;
+					}
+				}
 
-                pthread_mutex_lock (handler->cerver->handlers_lock);
-                handler->cerver->num_handlers_working -= 1;
-                pthread_mutex_unlock (handler->cerver->handlers_lock);
-            }
-        }
+				pthread_mutex_lock (handler->cerver->handlers_lock);
+				handler->cerver->num_handlers_working -= 1;
+				pthread_mutex_unlock (handler->cerver->handlers_lock);
+			}
+		}
 
-        handler_data_delete (handler_data);
-    }
+		handler_data_delete (handler_data);
+	}
 
 }
 
 // while client is running, check for new jobs and handle them
 static void handler_do_while_client (Handler *handler) {
 
-    if (handler) {
-        Job *job = NULL;
-        Packet *packet = NULL;
-        HandlerData *handler_data = handler_data_new ();
-        while (handler->client->running) {
-            bsem_wait (handler->job_queue->has_jobs);
+	if (handler) {
+		Job *job = NULL;
+		Packet *packet = NULL;
+		HandlerData *handler_data = handler_data_new ();
+		while (handler->client->running) {
+			bsem_wait (handler->job_queue->has_jobs);
 
-            if (handler->client->running) {
-                pthread_mutex_lock (handler->client->handlers_lock);
-                handler->client->num_handlers_working += 1;
-                pthread_mutex_unlock (handler->client->handlers_lock);
+			if (handler->client->running) {
+				pthread_mutex_lock (handler->client->handlers_lock);
+				handler->client->num_handlers_working += 1;
+				pthread_mutex_unlock (handler->client->handlers_lock);
 
-                // read job from queue
-                job = job_queue_pull (handler->job_queue);
-                if (job) {
-                    packet = (Packet *) job->args;
+				// read job from queue
+				job = job_queue_pull (handler->job_queue);
+				if (job) {
+					packet = (Packet *) job->args;
 
-                    handler_data->handler_id = handler->id;
-                    handler_data->data = handler->data;
-                    handler_data->packet = packet;
+					handler_data->handler_id = handler->id;
+					handler_data->data = handler->data;
+					handler_data->packet = packet;
 
-                    handler->handler (handler_data);
+					handler->handler (handler_data);
 
-                    job_delete (job);
-                    packet_delete (packet);
-                }
+					job_delete (job);
+					packet_delete (packet);
+				}
 
-                pthread_mutex_lock (handler->client->handlers_lock);
-                handler->client->num_handlers_working -= 1;
-                pthread_mutex_unlock (handler->client->handlers_lock);
-            }
-        }
+				pthread_mutex_lock (handler->client->handlers_lock);
+				handler->client->num_handlers_working -= 1;
+				pthread_mutex_unlock (handler->client->handlers_lock);
+			}
+		}
 
-        handler_data_delete (handler_data);
-    }
+		handler_data_delete (handler_data);
+	}
 
 }
 
 // while cerver is running, check for new jobs and handle them
 static void handler_do_while_admin (Handler *handler) {
 
-    if (handler) {
-        Job *job = NULL;
-        Packet *packet = NULL;
-        PacketType packet_type = PACKET_TYPE_NONE;
-        HandlerData *handler_data = handler_data_new ();
-        while (handler->cerver->isRunning) {
-            bsem_wait (handler->job_queue->has_jobs);
+	if (handler) {
+		Job *job = NULL;
+		Packet *packet = NULL;
+		PacketType packet_type = PACKET_TYPE_NONE;
+		HandlerData *handler_data = handler_data_new ();
+		while (handler->cerver->isRunning) {
+			bsem_wait (handler->job_queue->has_jobs);
 
-            if (handler->cerver->isRunning) {
-                pthread_mutex_lock (handler->cerver->admin->handlers_lock);
-                handler->cerver->admin->num_handlers_working += 1;
-                pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
+			if (handler->cerver->isRunning) {
+				pthread_mutex_lock (handler->cerver->admin->handlers_lock);
+				handler->cerver->admin->num_handlers_working += 1;
+				pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
 
-                // read job from queue
-                job = job_queue_pull (handler->job_queue);
-                if (job) {
-                    packet = (Packet *) job->args;
-                    packet_type = packet->header->packet_type;
+				// read job from queue
+				job = job_queue_pull (handler->job_queue);
+				if (job) {
+					packet = (Packet *) job->args;
+					packet_type = packet->header->packet_type;
 
-                    handler_data->handler_id = handler->id;
-                    handler_data->data = handler->data;
-                    handler_data->packet = packet;
+					handler_data->handler_id = handler->id;
+					handler_data->data = handler->data;
+					handler_data->packet = packet;
 
-                    handler->handler (handler_data);
+					handler->handler (handler_data);
 
-                    job_delete (job);
+					job_delete (job);
 
-                    switch (packet_type) {
-                        case PACKET_TYPE_APP: if (handler->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet); break;
-                        case PACKET_TYPE_APP_ERROR: if (handler->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet); break;
-                        case PACKET_TYPE_CUSTOM: if (handler->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet); break;
+					switch (packet_type) {
+						case PACKET_TYPE_APP: if (handler->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_APP_ERROR: if (handler->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_CUSTOM: if (handler->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet); break;
 
-                        default: packet_delete (packet); break;
-                    }
-                }
+						default: packet_delete (packet); break;
+					}
+				}
 
-                pthread_mutex_lock (handler->cerver->admin->handlers_lock);
-                handler->cerver->admin->num_handlers_working -= 1;
-                pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
-            }
-        }
+				pthread_mutex_lock (handler->cerver->admin->handlers_lock);
+				handler->cerver->admin->num_handlers_working -= 1;
+				pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
+			}
+		}
 
-        handler_data_delete (handler_data);
-    }
+		handler_data_delete (handler_data);
+	}
 
 }
 
 static void *handler_do (void *handler_ptr) {
 
-    if (handler_ptr) {
-        Handler *handler = (Handler *) handler_ptr;
+	if (handler_ptr) {
+		Handler *handler = (Handler *) handler_ptr;
 
-        pthread_mutex_t *handlers_lock = NULL;
-        switch (handler->type) {
-            case HANDLER_TYPE_CERVER: handlers_lock = handler->cerver->handlers_lock; break;
-            case HANDLER_TYPE_CLIENT: handlers_lock = handler->client->handlers_lock; break;
-            case HANDLER_TYPE_ADMIN: handlers_lock = handler->cerver->admin->handlers_lock; break;
-            default: break;
-        }
+		pthread_mutex_t *handlers_lock = NULL;
+		switch (handler->type) {
+			case HANDLER_TYPE_CERVER: handlers_lock = handler->cerver->handlers_lock; break;
+			case HANDLER_TYPE_CLIENT: handlers_lock = handler->client->handlers_lock; break;
+			case HANDLER_TYPE_ADMIN: handlers_lock = handler->cerver->admin->handlers_lock; break;
+			default: break;
+		}
 
-        // set the thread name
-        if (handler->id >= 0) {
-            char thread_name[128] = { 0 };
+		// set the thread name
+		if (handler->id >= 0) {
+			char thread_name[128] = { 0 };
 
-            switch (handler->type) {
-                case HANDLER_TYPE_CERVER: snprintf (thread_name, 128, "cerver-handler-%d", handler->unique_id); break;
-                case HANDLER_TYPE_CLIENT: snprintf (thread_name, 128, "client-handler-%d", handler->unique_id); break;
-                case HANDLER_TYPE_ADMIN: snprintf (thread_name, 128, "admin-handler-%d", handler->unique_id); break;
-                default: break;
-            }
+			switch (handler->type) {
+				case HANDLER_TYPE_CERVER: snprintf (thread_name, 128, "cerver-handler-%d", handler->unique_id); break;
+				case HANDLER_TYPE_CLIENT: snprintf (thread_name, 128, "client-handler-%d", handler->unique_id); break;
+				case HANDLER_TYPE_ADMIN: snprintf (thread_name, 128, "admin-handler-%d", handler->unique_id); break;
+				default: break;
+			}
 
-            // printf ("%s\n", thread_name);
-            prctl (PR_SET_NAME, thread_name);
-        }
+			// printf ("%s\n", thread_name);
+			prctl (PR_SET_NAME, thread_name);
+		}
 
-        // TODO: register to signals to handle multiple actions
+		// TODO: register to signals to handle multiple actions
 
-        if (handler->data_create)
-            handler->data = handler->data_create (handler->data_create_args);
+		if (handler->data_create)
+			handler->data = handler->data_create (handler->data_create_args);
 
-        // mark the handler as alive and ready
-        pthread_mutex_lock (handlers_lock);
-        switch (handler->type) {
-            case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive += 1; break;
-            case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive += 1; break;
-            case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive += 1; break;
-            default: break;
-        }
-        pthread_mutex_unlock (handlers_lock);
+		// mark the handler as alive and ready
+		pthread_mutex_lock (handlers_lock);
+		switch (handler->type) {
+			case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive += 1; break;
+			case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive += 1; break;
+			case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive += 1; break;
+			default: break;
+		}
+		pthread_mutex_unlock (handlers_lock);
 
-        // while cerver / client is running, check for new jobs and handle them
-        switch (handler->type) {
-            case HANDLER_TYPE_CERVER: handler_do_while_cerver (handler); break;
-            case HANDLER_TYPE_CLIENT: handler_do_while_client (handler); break;
-            case HANDLER_TYPE_ADMIN: handler_do_while_admin (handler); break;
-            default: break;
-        }
+		// while cerver / client is running, check for new jobs and handle them
+		switch (handler->type) {
+			case HANDLER_TYPE_CERVER: handler_do_while_cerver (handler); break;
+			case HANDLER_TYPE_CLIENT: handler_do_while_client (handler); break;
+			case HANDLER_TYPE_ADMIN: handler_do_while_admin (handler); break;
+			default: break;
+		}
 
-        if (handler->data_delete)
-            handler->data_delete (handler->data);
+		if (handler->data_delete)
+			handler->data_delete (handler->data);
 
-        pthread_mutex_lock (handlers_lock);
-        switch (handler->type) {
-            case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive -= 1; break;
-            case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive -= 1; break;
-            case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive -= 1; break;
-            default: break;
-        }
-        pthread_mutex_unlock (handlers_lock);
-    }
+		pthread_mutex_lock (handlers_lock);
+		switch (handler->type) {
+			case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive -= 1; break;
+			case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive -= 1; break;
+			case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive -= 1; break;
+			default: break;
+		}
+		pthread_mutex_unlock (handlers_lock);
+	}
 
-    return NULL;
+	return NULL;
 
 }
 
@@ -378,47 +378,47 @@ static void *handler_do (void *handler_ptr) {
 // called by internal cerver methods
 int handler_start (Handler *handler) {
 
-    int retval = 1;
+	int retval = 1;
 
-    if (handler) {
-        if (handler->type != HANDLER_TYPE_NONE) {
-            // retval = pthread_create (
-            //     &handler->thread_id,
-            //     NULL,
-            //     (void *(*)(void *)) handler_do,
-            //     (void *) handler
-            // );
+	if (handler) {
+		if (handler->type != HANDLER_TYPE_NONE) {
+			// retval = pthread_create (
+			//     &handler->thread_id,
+			//     NULL,
+			//     (void *(*)(void *)) handler_do,
+			//     (void *) handler
+			// );
 
 
-            // 26/05/2020 -- 12:54
-            // handler's threads are not explicitly joined by pthread_join ()
-            // on cerver teardown
-            if (!thread_create_detachable (
-                &handler->thread_id,
-                (void *(*)(void *)) handler_do,
-                (void *) handler
-            )) {
-                #ifdef HANDLER_DEBUG
-                cerver_log (
-                    LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
-                    "Created handler %d thread!",
-                    handler->unique_id
-                );
-                #endif
+			// 26/05/2020 -- 12:54
+			// handler's threads are not explicitly joined by pthread_join ()
+			// on cerver teardown
+			if (!thread_create_detachable (
+				&handler->thread_id,
+				(void *(*)(void *)) handler_do,
+				(void *) handler
+			)) {
+				#ifdef HANDLER_DEBUG
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
+					"Created handler %d thread!",
+					handler->unique_id
+				);
+				#endif
 
-                retval = 0;
-            }
-        }
+				retval = 0;
+			}
+		}
 
-        else {
-            cerver_log_error (
-                "handler_start () - Handler %d is of invalid type!",
-                handler->unique_id
-            );
-        }
-    }
+		else {
+			cerver_log_error (
+				"handler_start () - Handler %d is of invalid type!",
+				handler->unique_id
+			);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -428,32 +428,32 @@ int handler_start (Handler *handler) {
 
 SockReceive *sock_receive_new (void) {
 
-    SockReceive *sr = (SockReceive *) malloc (sizeof (SockReceive));
-    if (sr) {
-        sr->spare_packet = NULL;
-        sr->missing_packet = 0;
+	SockReceive *sr = (SockReceive *) malloc (sizeof (SockReceive));
+	if (sr) {
+		sr->spare_packet = NULL;
+		sr->missing_packet = 0;
 
-        sr->header = NULL;
-        sr->header_end = NULL;
-        // sr->curr_header_pos = 0;
-        sr->remaining_header = 0;
-        sr->complete_header = false;
-    }
+		sr->header = NULL;
+		sr->header_end = NULL;
+		// sr->curr_header_pos = 0;
+		sr->remaining_header = 0;
+		sr->complete_header = false;
+	}
 
-    return sr;
+	return sr;
 
 }
 
 void sock_receive_delete (void *sock_receive_ptr) {
 
-    if (sock_receive_ptr) {
-        SockReceive *sock_receive = (SockReceive *) sock_receive_ptr;
+	if (sock_receive_ptr) {
+		SockReceive *sock_receive = (SockReceive *) sock_receive_ptr;
 
-        packet_delete (sock_receive->spare_packet);
-        if (sock_receive->header) free (sock_receive->header);
+		packet_delete (sock_receive->spare_packet);
+		if (sock_receive->header) free (sock_receive->header);
 
-        free (sock_receive_ptr);
-    }
+		free (sock_receive_ptr);
+	}
 
 }
 
@@ -685,7 +685,7 @@ static inline void cerver_request_send_file_actual (Packet *packet) {
 					saved_filename
 				);
 			}
-			
+
 			if (saved_filename) free (saved_filename);
 		}
 
@@ -730,7 +730,7 @@ static void cerver_request_send_file (Packet *packet) {
 				packet->cerver, packet->client, packet->connection
 			);
 		} break;
-	}	
+	}
 
 }
 
@@ -762,32 +762,32 @@ static void cerver_request_packet_handler (Packet *packet) {
 // sends back a test packet to the client!
 void cerver_test_packet_handler (Packet *packet) {
 
-    if (packet) {
-        #ifdef CERVER_DEBUG
-        char *s = c_string_create ("Got a test packet in cerver %s.", packet->cerver->info->name->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_PACKET, s);
-            free (s);
-        }
-        #endif
+	if (packet) {
+		#ifdef CERVER_DEBUG
+		char *s = c_string_create ("Got a test packet in cerver %s.", packet->cerver->info->name->str);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_PACKET, s);
+			free (s);
+		}
+		#endif
 
-        Packet *test_packet = packet_new ();
-        if (test_packet) {
-            packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
-            test_packet->packet_type = TEST_PACKET;
-            packet_generate (test_packet);
-            if (packet_send (test_packet, 0, NULL, false)) {
-                char *s = c_string_create ("Failed to send error packet from cerver %s.", 
-                    packet->cerver->info->name->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PACKET, s);
-                    free (s);
-                }
-            }
+		Packet *test_packet = packet_new ();
+		if (test_packet) {
+			packet_set_network_values (test_packet, packet->cerver, packet->client, packet->connection, packet->lobby);
+			test_packet->packet_type = TEST_PACKET;
+			packet_generate (test_packet);
+			if (packet_send (test_packet, 0, NULL, false)) {
+				char *s = c_string_create ("Failed to send error packet from cerver %s.",
+					packet->cerver->info->name->str);
+				if (s) {
+					cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PACKET, s);
+					free (s);
+				}
+			}
 
-            packet_delete (test_packet);
-        }
-    }
+			packet_delete (test_packet);
+		}
+	}
 
 }
 
@@ -795,64 +795,64 @@ void cerver_test_packet_handler (Packet *packet) {
 // handles an APP_PACKET packet type
 static void cerver_app_packet_handler (Packet *packet) {
 
-    if (packet) {
-        // 11/05/2020
-        if (packet->cerver->multiple_handlers) {
-            // select which handler to use
-            if (packet->header->handler_id < packet->cerver->n_handlers) {
-                if (packet->cerver->handlers[packet->header->handler_id]) {
-                    // add the packet to the handler's job queueu to be handled
-                    // as soon as the handler is available
-                    if (job_queue_push (
-                        packet->cerver->handlers[packet->header->handler_id]->job_queue,
-                        job_create (NULL, packet)
-                    )) {
-                        char *s = c_string_create ("Failed to push a new job to cerver's %s <%d> handler!",
-                            packet->cerver->info->name->str, packet->header->handler_id);
-                        if (s) {
-                            cerver_log_error (s);
-                            free (s);
-                        }
-                    }
-                }
-            }
-        }
+	if (packet) {
+		// 11/05/2020
+		if (packet->cerver->multiple_handlers) {
+			// select which handler to use
+			if (packet->header->handler_id < packet->cerver->n_handlers) {
+				if (packet->cerver->handlers[packet->header->handler_id]) {
+					// add the packet to the handler's job queueu to be handled
+					// as soon as the handler is available
+					if (job_queue_push (
+						packet->cerver->handlers[packet->header->handler_id]->job_queue,
+						job_create (NULL, packet)
+					)) {
+						char *s = c_string_create ("Failed to push a new job to cerver's %s <%d> handler!",
+							packet->cerver->info->name->str, packet->header->handler_id);
+						if (s) {
+							cerver_log_error (s);
+							free (s);
+						}
+					}
+				}
+			}
+		}
 
-        else {
-            if (packet->cerver->app_packet_handler) {
-                if (packet->cerver->app_packet_handler->direct_handle) {
-                    // printf ("app_packet_handler - direct handle!\n");
-                    packet->cerver->app_packet_handler->handler (packet);
-                    if (packet->cerver->app_packet_handler_delete_packet) packet_delete (packet);
-                }
+		else {
+			if (packet->cerver->app_packet_handler) {
+				if (packet->cerver->app_packet_handler->direct_handle) {
+					// printf ("app_packet_handler - direct handle!\n");
+					packet->cerver->app_packet_handler->handler (packet);
+					if (packet->cerver->app_packet_handler_delete_packet) packet_delete (packet);
+				}
 
-                else {
-                    // add the packet to the handler's job queueu to be handled
-                    // as soon as the handler is available
-                    if (job_queue_push (
-                        packet->cerver->app_packet_handler->job_queue,
-                        job_create (NULL, packet)
-                    )) {
-                        char *s = c_string_create ("Failed to push a new job to cerver's %s app_packet_handler!",
-                            packet->cerver->info->name->str);
-                        if (s) {
-                            cerver_log_error (s);
-                            free (s);
-                        }
-                    }
-                }
-            }
+				else {
+					// add the packet to the handler's job queueu to be handled
+					// as soon as the handler is available
+					if (job_queue_push (
+						packet->cerver->app_packet_handler->job_queue,
+						job_create (NULL, packet)
+					)) {
+						char *s = c_string_create ("Failed to push a new job to cerver's %s app_packet_handler!",
+							packet->cerver->info->name->str);
+						if (s) {
+							cerver_log_error (s);
+							free (s);
+						}
+					}
+				}
+			}
 
-            else {
-                char *s = c_string_create ("Cerver %s does not have an app_packet_handler!",
-                    packet->cerver->info->name->str);
-                if (s) {
-                    cerver_log_warning (s);
-                    free (s);
-                }
-            }
-        }
-    }
+			else {
+				char *s = c_string_create ("Cerver %s does not have an app_packet_handler!",
+					packet->cerver->info->name->str);
+				if (s) {
+					cerver_log_warning (s);
+					free (s);
+				}
+			}
+		}
+	}
 
 }
 
@@ -860,40 +860,40 @@ static void cerver_app_packet_handler (Packet *packet) {
 // handles an APP_ERROR_PACKET packet type
 static void cerver_app_error_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->app_error_packet_handler) {
-            if (packet->cerver->app_error_packet_handler->direct_handle) {
-                // printf ("app_error_packet_handler - direct handle!\n");
-                packet->cerver->app_error_packet_handler->handler (packet);
-                if (packet->cerver->app_error_packet_handler_delete_packet) packet_delete (packet);
-            }
+	if (packet) {
+		if (packet->cerver->app_error_packet_handler) {
+			if (packet->cerver->app_error_packet_handler->direct_handle) {
+				// printf ("app_error_packet_handler - direct handle!\n");
+				packet->cerver->app_error_packet_handler->handler (packet);
+				if (packet->cerver->app_error_packet_handler_delete_packet) packet_delete (packet);
+			}
 
-            else {
-                // add the packet to the handler's job queueu to be handled
-                // as soon as the handler is available
-                if (job_queue_push (
-                    packet->cerver->app_error_packet_handler->job_queue,
-                    job_create (NULL, packet)
-                )) {
-                    char *s = c_string_create ("Failed to push a new job to cerver's %s app_error_packet_handler!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
-                }
-            }
-        }
+			else {
+				// add the packet to the handler's job queueu to be handled
+				// as soon as the handler is available
+				if (job_queue_push (
+					packet->cerver->app_error_packet_handler->job_queue,
+					job_create (NULL, packet)
+				)) {
+					char *s = c_string_create ("Failed to push a new job to cerver's %s app_error_packet_handler!",
+						packet->cerver->info->name->str);
+					if (s) {
+						cerver_log_error (s);
+						free (s);
+					}
+				}
+			}
+		}
 
-        else {
-            char *s = c_string_create ("Cerver %s does not have an app_error_packet_handler!",
-                packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_warning (s);
-                free (s);
-            }
-        }
-    }
+		else {
+			char *s = c_string_create ("Cerver %s does not have an app_error_packet_handler!",
+				packet->cerver->info->name->str);
+			if (s) {
+				cerver_log_warning (s);
+				free (s);
+			}
+		}
+	}
 
 }
 
@@ -901,210 +901,210 @@ static void cerver_app_error_packet_handler (Packet *packet) {
 // handles a CUSTOM_PACKET packet type
 static void cerver_custom_packet_handler (Packet *packet) {
 
-    if (packet) {
-        if (packet->cerver->custom_packet_handler) {
-            if (packet->cerver->custom_packet_handler->direct_handle) {
-                // printf ("custom_packet_handler - direct handle!\n");
-                packet->cerver->custom_packet_handler->handler (packet);
-                if (packet->cerver->custom_packet_handler_delete_packet) packet_delete (packet);
-            }
+	if (packet) {
+		if (packet->cerver->custom_packet_handler) {
+			if (packet->cerver->custom_packet_handler->direct_handle) {
+				// printf ("custom_packet_handler - direct handle!\n");
+				packet->cerver->custom_packet_handler->handler (packet);
+				if (packet->cerver->custom_packet_handler_delete_packet) packet_delete (packet);
+			}
 
-            else {
-                // add the packet to the handler's job queueu to be handled
-                // as soon as the handler is available
-                if (job_queue_push (
-                    packet->cerver->custom_packet_handler->job_queue,
-                    job_create (NULL, packet)
-                )) {
-                    char *s = c_string_create ("Failed to push a new job to cerver's %s custom_packet_handler!",
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_error (s);
-                        free (s);
-                    }
-                }
-            }
-        }
+			else {
+				// add the packet to the handler's job queueu to be handled
+				// as soon as the handler is available
+				if (job_queue_push (
+					packet->cerver->custom_packet_handler->job_queue,
+					job_create (NULL, packet)
+				)) {
+					char *s = c_string_create ("Failed to push a new job to cerver's %s custom_packet_handler!",
+						packet->cerver->info->name->str);
+					if (s) {
+						cerver_log_error (s);
+						free (s);
+					}
+				}
+			}
+		}
 
-        else {
-            char *s = c_string_create ("Cerver %s does not have a custom_packet_handler!",
-                packet->cerver->info->name->str);
-            if (s) {
-                cerver_log_warning (s);
-                free (s);
-            }
-        }
-    }
+		else {
+			char *s = c_string_create ("Cerver %s does not have a custom_packet_handler!",
+				packet->cerver->info->name->str);
+			if (s) {
+				cerver_log_warning (s);
+				free (s);
+			}
+		}
+	}
 
 }
 
 // handle packet based on type
 static void cerver_packet_handler (void *ptr) {
 
-    if (ptr) {
-        Packet *packet = (Packet *) ptr;
+	if (ptr) {
+		Packet *packet = (Packet *) ptr;
 
-        packet->cerver->stats->client_n_packets_received += 1;
-        packet->cerver->stats->total_n_packets_received += 1;
-        if (packet->lobby) packet->lobby->stats->n_packets_received += 1;
+		packet->cerver->stats->client_n_packets_received += 1;
+		packet->cerver->stats->total_n_packets_received += 1;
+		if (packet->lobby) packet->lobby->stats->n_packets_received += 1;
 
-        bool good = true;
-        if (packet->cerver->check_packets) {
-            // we expect the packet version in the packet's data
-            if (packet->data) {
-                packet->version = (PacketVersion *) packet->data_ptr;
-                packet->data_ptr += sizeof (PacketVersion);
-                good = packet_check (packet);
-            }
+		bool good = true;
+		if (packet->cerver->check_packets) {
+			// we expect the packet version in the packet's data
+			if (packet->data) {
+				packet->version = (PacketVersion *) packet->data_ptr;
+				packet->data_ptr += sizeof (PacketVersion);
+				good = packet_check (packet);
+			}
 
-            else {
-                cerver_log_error ("cerver_packet_handler () - No packet version to check!");
-                good = false;
-            }
-        }
+			else {
+				cerver_log_error ("cerver_packet_handler () - No packet version to check!");
+				good = false;
+			}
+		}
 
-        if (good) {
-            switch (packet->header->packet_type) {
-                // handles an error from the client
-                case ERROR_PACKET: 
-                    packet->cerver->stats->received_packets->n_error_packets += 1;
-                    packet->client->stats->received_packets->n_error_packets += 1;
-                    packet->connection->stats->received_packets->n_error_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_error_packets += 1;
-                    /* TODO: */ 
-                    packet_delete (packet);
-                    break;
+		if (good) {
+			switch (packet->header->packet_type) {
+				// handles an error from the client
+				case ERROR_PACKET:
+					packet->cerver->stats->received_packets->n_error_packets += 1;
+					packet->client->stats->received_packets->n_error_packets += 1;
+					packet->connection->stats->received_packets->n_error_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_error_packets += 1;
+					/* TODO: */
+					packet_delete (packet);
+					break;
 
-                // handles authentication packets
-                case AUTH_PACKET: 
-                    packet->cerver->stats->received_packets->n_auth_packets += 1;
-                    packet->client->stats->received_packets->n_auth_packets += 1;
-                    packet->connection->stats->received_packets->n_auth_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_auth_packets += 1;
-                    /* TODO: */ 
-                    packet_delete (packet);
-                    break;
+				// handles authentication packets
+				case AUTH_PACKET:
+					packet->cerver->stats->received_packets->n_auth_packets += 1;
+					packet->client->stats->received_packets->n_auth_packets += 1;
+					packet->connection->stats->received_packets->n_auth_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_auth_packets += 1;
+					/* TODO: */
+					packet_delete (packet);
+					break;
 
-                // handles a request made from the client
-                case REQUEST_PACKET: 
-                    packet->cerver->stats->received_packets->n_request_packets += 1;
-                    packet->client->stats->received_packets->n_request_packets += 1;
-                    packet->connection->stats->received_packets->n_request_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_request_packets += 1;
-                    cerver_request_packet_handler (packet); 
-                    packet_delete (packet);
-                    break;
+				// handles a request made from the client
+				case REQUEST_PACKET:
+					packet->cerver->stats->received_packets->n_request_packets += 1;
+					packet->client->stats->received_packets->n_request_packets += 1;
+					packet->connection->stats->received_packets->n_request_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_request_packets += 1;
+					cerver_request_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                // handles a game packet sent from the client
-                case GAME_PACKET: 
-                    packet->cerver->stats->received_packets->n_game_packets += 1;
-                    packet->client->stats->received_packets->n_game_packets += 1;
-                    packet->connection->stats->received_packets->n_game_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_game_packets += 1;
-                    game_packet_handler (packet); 
-                    break;
+				// handles a game packet sent from the client
+				case GAME_PACKET:
+					packet->cerver->stats->received_packets->n_game_packets += 1;
+					packet->client->stats->received_packets->n_game_packets += 1;
+					packet->connection->stats->received_packets->n_game_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_game_packets += 1;
+					game_packet_handler (packet);
+					break;
 
-                // user set handler to handle app specific packets
-                case APP_PACKET:
-                    packet->cerver->stats->received_packets->n_app_packets += 1;
-                    packet->client->stats->received_packets->n_app_packets += 1;
-                    packet->connection->stats->received_packets->n_app_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_app_packets += 1;
-                    cerver_app_packet_handler (packet);
-                    break;
+				// user set handler to handle app specific packets
+				case APP_PACKET:
+					packet->cerver->stats->received_packets->n_app_packets += 1;
+					packet->client->stats->received_packets->n_app_packets += 1;
+					packet->connection->stats->received_packets->n_app_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_app_packets += 1;
+					cerver_app_packet_handler (packet);
+					break;
 
-                // user set handler to handle app specific errors
-                case APP_ERROR_PACKET: 
-                    packet->cerver->stats->received_packets->n_app_error_packets += 1;
-                    packet->client->stats->received_packets->n_app_error_packets += 1;
-                    packet->connection->stats->received_packets->n_app_error_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_app_error_packets += 1;
-                    cerver_app_error_packet_handler (packet);
-                    break;
+				// user set handler to handle app specific errors
+				case APP_ERROR_PACKET:
+					packet->cerver->stats->received_packets->n_app_error_packets += 1;
+					packet->client->stats->received_packets->n_app_error_packets += 1;
+					packet->connection->stats->received_packets->n_app_error_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_app_error_packets += 1;
+					cerver_app_error_packet_handler (packet);
+					break;
 
-                // custom packet hanlder
-                case CUSTOM_PACKET: 
-                    packet->cerver->stats->received_packets->n_custom_packets += 1;
-                    packet->client->stats->received_packets->n_custom_packets += 1;
-                    packet->connection->stats->received_packets->n_custom_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_custom_packets += 1;
-                    cerver_custom_packet_handler (packet);
-                    break;
+				// custom packet hanlder
+				case CUSTOM_PACKET:
+					packet->cerver->stats->received_packets->n_custom_packets += 1;
+					packet->client->stats->received_packets->n_custom_packets += 1;
+					packet->connection->stats->received_packets->n_custom_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_custom_packets += 1;
+					cerver_custom_packet_handler (packet);
+					break;
 
-                // acknowledge the client we have received his test packet
-                case TEST_PACKET: 
-                    packet->cerver->stats->received_packets->n_test_packets += 1;
-                    packet->client->stats->received_packets->n_test_packets += 1;
-                    packet->connection->stats->received_packets->n_test_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_test_packets += 1;
-                    cerver_test_packet_handler (packet); 
-                    packet_delete (packet);
-                    break;
+				// acknowledge the client we have received his test packet
+				case TEST_PACKET:
+					packet->cerver->stats->received_packets->n_test_packets += 1;
+					packet->client->stats->received_packets->n_test_packets += 1;
+					packet->connection->stats->received_packets->n_test_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_test_packets += 1;
+					cerver_test_packet_handler (packet);
+					packet_delete (packet);
+					break;
 
-                default: {
-                    packet->cerver->stats->received_packets->n_bad_packets += 1;
-                    packet->client->stats->received_packets->n_bad_packets += 1;
-                    packet->connection->stats->received_packets->n_bad_packets += 1;
-                    if (packet->lobby) packet->lobby->stats->received_packets->n_bad_packets += 1;
-                    #ifdef CERVER_DEBUG
-                    char *s = c_string_create ("Got a packet of unknown type in cerver %s.", 
-                        packet->cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, s);
-                        free (s);
-                    }
-                    #endif
-                    packet_delete (packet);
-                } break;
-            }
-        }
-    }
+				default: {
+					packet->cerver->stats->received_packets->n_bad_packets += 1;
+					packet->client->stats->received_packets->n_bad_packets += 1;
+					packet->connection->stats->received_packets->n_bad_packets += 1;
+					if (packet->lobby) packet->lobby->stats->received_packets->n_bad_packets += 1;
+					#ifdef CERVER_DEBUG
+					char *s = c_string_create ("Got a packet of unknown type in cerver %s.",
+						packet->cerver->info->name->str);
+					if (s) {
+						cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, s);
+						free (s);
+					}
+					#endif
+					packet_delete (packet);
+				} break;
+			}
+		}
+	}
 
 }
 
 static void cerver_packet_select_handler (ReceiveHandle *receive_handle, Packet *packet) {
 
-    switch (receive_handle->type) {
-        case RECEIVE_TYPE_NONE: break;
+	switch (receive_handle->type) {
+		case RECEIVE_TYPE_NONE: break;
 
-        case RECEIVE_TYPE_NORMAL: {
-            packet->cerver = receive_handle->cerver;
-            packet->client = receive_handle->client;
-            packet->connection = receive_handle->connection;
+		case RECEIVE_TYPE_NORMAL: {
+			packet->cerver = receive_handle->cerver;
+			packet->client = receive_handle->client;
+			packet->connection = receive_handle->connection;
 
-            packet->cerver->stats->client_n_packets_received += 1;
-            packet->client->stats->n_packets_received += 1;
-            packet->connection->stats->n_packets_received += 1;
+			packet->cerver->stats->client_n_packets_received += 1;
+			packet->client->stats->n_packets_received += 1;
+			packet->connection->stats->n_packets_received += 1;
 
-            cerver_packet_handler (packet);
-        } break;
+			cerver_packet_handler (packet);
+		} break;
 
-        case RECEIVE_TYPE_ON_HOLD: {
-            packet->cerver = receive_handle->cerver;
-            packet->connection = receive_handle->connection;
+		case RECEIVE_TYPE_ON_HOLD: {
+			packet->cerver = receive_handle->cerver;
+			packet->connection = receive_handle->connection;
 
-            packet->cerver->stats->on_hold_n_packets_received += 1;
-            packet->connection->stats->n_packets_received += 1;
+			packet->cerver->stats->on_hold_n_packets_received += 1;
+			packet->connection->stats->n_packets_received += 1;
 
-            on_hold_packet_handler (packet);
-        } break;
+			on_hold_packet_handler (packet);
+		} break;
 
-        case RECEIVE_TYPE_ADMIN: {
-            packet->cerver = receive_handle->cerver;
-            packet->connection = receive_handle->connection;
-            packet->client = receive_handle->admin->client;
+		case RECEIVE_TYPE_ADMIN: {
+			packet->cerver = receive_handle->cerver;
+			packet->connection = receive_handle->connection;
+			packet->client = receive_handle->admin->client;
 
-            packet->cerver->admin->stats->total_n_packets_received += 1;
+			packet->cerver->admin->stats->total_n_packets_received += 1;
 
-            receive_handle->admin->client->stats->n_packets_received += 1;
+			receive_handle->admin->client->stats->n_packets_received += 1;
 
-            packet->connection->stats->n_packets_received += 1;
+			packet->connection->stats->n_packets_received += 1;
 
-            admin_packet_handler (packet);
-        } break;
+			admin_packet_handler (packet);
+		} break;
 
-        default: break;
-    }
+		default: break;
+	}
 
 }
 
@@ -1116,24 +1116,24 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd);
 
 static ReceiveHandle *receive_handle_new (void) {
 
-    ReceiveHandle *receive_handle = (ReceiveHandle *) malloc (sizeof (ReceiveHandle));
-    if (receive_handle) {
-        receive_handle->type = RECEIVE_TYPE_NONE;
+	ReceiveHandle *receive_handle = (ReceiveHandle *) malloc (sizeof (ReceiveHandle));
+	if (receive_handle) {
+		receive_handle->type = RECEIVE_TYPE_NONE;
 
-        receive_handle->cerver = NULL;
+		receive_handle->cerver = NULL;
 
-        receive_handle->socket = NULL;
-        receive_handle->connection = NULL;
-        receive_handle->client = NULL;
-        receive_handle->admin = NULL;
+		receive_handle->socket = NULL;
+		receive_handle->connection = NULL;
+		receive_handle->client = NULL;
+		receive_handle->admin = NULL;
 
-        receive_handle->lobby = NULL;
+		receive_handle->lobby = NULL;
 
-        receive_handle->buffer = NULL;
-        receive_handle->buffer_size = 0;
-    }
+		receive_handle->buffer = NULL;
+		receive_handle->buffer_size = 0;
+	}
 
-    return receive_handle;
+	return receive_handle;
 
 }
 
@@ -1141,21 +1141,21 @@ void receive_handle_delete (void *receive_ptr) { if (receive_ptr) free (receive_
 
 CerverReceive *cerver_receive_new (void) {
 
-    CerverReceive *cr = (CerverReceive *) malloc (sizeof (CerverReceive));
-    if (cr) {
-        cr->type = RECEIVE_TYPE_NONE;
+	CerverReceive *cr = (CerverReceive *) malloc (sizeof (CerverReceive));
+	if (cr) {
+		cr->type = RECEIVE_TYPE_NONE;
 
-        cr->cerver = NULL;
+		cr->cerver = NULL;
 
-        cr->socket = NULL;
-        cr->connection = NULL;
-        cr->client = NULL;
-        cr->admin = NULL;
+		cr->socket = NULL;
+		cr->connection = NULL;
+		cr->client = NULL;
+		cr->admin = NULL;
 
-        cr->lobby = NULL;
-    }
+		cr->lobby = NULL;
+	}
 
-    return cr;
+	return cr;
 
 }
 
@@ -1163,397 +1163,397 @@ void cerver_receive_delete (void *ptr) { if (ptr) free (ptr); }
 
 static inline void cerver_receive_create_normal (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
 
-    if (cr) {
-        cr->client = client_get_by_sock_fd (cerver, sock_fd);
-        if (cr->client) {
-            cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
-            if (cr->connection) {
-                cr->socket = cr->connection->socket;
-            }
-        }
+	if (cr) {
+		cr->client = client_get_by_sock_fd (cerver, sock_fd);
+		if (cr->client) {
+			cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
+			if (cr->connection) {
+				cr->socket = cr->connection->socket;
+			}
+		}
 
-        // for what ever reason we have a rogue connection
-        else {
-            // #ifdef CERVER_DEBUG
-            char *s = c_string_create (
-                "cerver_receive_create () - RECEIVE_TYPE_NORMAL - no client with sock fd <%d>",
-                sock_fd
-            );
-            if (s) {
-                cerver_log_error (s);
-                free (s);
-            }
-            // #endif
+		// for what ever reason we have a rogue connection
+		else {
+			// #ifdef CERVER_DEBUG
+			char *s = c_string_create (
+				"cerver_receive_create () - RECEIVE_TYPE_NORMAL - no client with sock fd <%d>",
+				sock_fd
+			);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+			// #endif
 
-            // remove the sock fd from the cerver's main poll array
-            cerver_poll_unregister_sock_fd (cerver, sock_fd);
+			// remove the sock fd from the cerver's main poll array
+			cerver_poll_unregister_sock_fd (cerver, sock_fd);
 
-            // try to remove the sock fd from the cerver's map
-            const void *key = &sock_fd;
-            htab_remove (cerver->client_sock_fd_map, key, sizeof (i32));
+			// try to remove the sock fd from the cerver's map
+			const void *key = &sock_fd;
+			htab_remove (cerver->client_sock_fd_map, key, sizeof (i32));
 
-            close (sock_fd);        // just close the socket
-        }
-    }
+			close (sock_fd);        // just close the socket
+		}
+	}
 
 }
 
 static inline void cerver_receive_create_on_hold (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
 
-    if (cr) {
-        cr->connection = connection_get_by_sock_fd_from_on_hold (cerver, sock_fd);
-        if (cr->connection) {
-            cr->socket = cr->connection->socket;
-        }
+	if (cr) {
+		cr->connection = connection_get_by_sock_fd_from_on_hold (cerver, sock_fd);
+		if (cr->connection) {
+			cr->socket = cr->connection->socket;
+		}
 
-        // for what ever reason we have a rogue connection
-        else {
-            // #ifdef CERVER_DEBUG
-            char *s = c_string_create (
-                "cerver_receive_create () - RECEIVE_TYPE_ON_HOLD - no connection with sock fd <%d>",
-                sock_fd
-            );
-            if (s) {
-                cerver_log_error (s);
-                free (s);
-            }
-            // #endif
+		// for what ever reason we have a rogue connection
+		else {
+			// #ifdef CERVER_DEBUG
+			char *s = c_string_create (
+				"cerver_receive_create () - RECEIVE_TYPE_ON_HOLD - no connection with sock fd <%d>",
+				sock_fd
+			);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+			// #endif
 
-            // remove the sock fd from the cerver's on hold poll array
-            on_hold_poll_unregister_sock_fd (cerver, sock_fd);
+			// remove the sock fd from the cerver's on hold poll array
+			on_hold_poll_unregister_sock_fd (cerver, sock_fd);
 
-            close (sock_fd);        // just close the socket
-        }
-    }
+			close (sock_fd);        // just close the socket
+		}
+	}
 
 }
 
 static inline void cerver_receive_create_admin (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
 
-    if (cr) {
-        cr->admin = admin_get_by_sock_fd (cerver->admin, sock_fd);
-        if (cr->admin) {
-            cr->client = cr->admin->client;
-            cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
-            if (cr->connection) {
-                cr->socket = cr->connection->socket;
-            }
-        }
+	if (cr) {
+		cr->admin = admin_get_by_sock_fd (cerver->admin, sock_fd);
+		if (cr->admin) {
+			cr->client = cr->admin->client;
+			cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
+			if (cr->connection) {
+				cr->socket = cr->connection->socket;
+			}
+		}
 
-        // for what ever reason we have a rogue connection
-        else {
-            // #ifdef ADMIN_DEBUG
-            char *s = c_string_create (
-                "cerver_receive_create () - RECEIVE_TYPE_ADMIN - no admin with sock fd <%d>",
-                sock_fd
-            );
-            if (s) {
-                cerver_log_error (s);
-                free (s);
-            }
-            // #endif
+		// for what ever reason we have a rogue connection
+		else {
+			// #ifdef ADMIN_DEBUG
+			char *s = c_string_create (
+				"cerver_receive_create () - RECEIVE_TYPE_ADMIN - no admin with sock fd <%d>",
+				sock_fd
+			);
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+			// #endif
 
-            // remove the sock fd from the cerver's admin poll array
-            admin_cerver_poll_unregister_sock_fd (cerver->admin, sock_fd);
+			// remove the sock fd from the cerver's admin poll array
+			admin_cerver_poll_unregister_sock_fd (cerver->admin, sock_fd);
 
-            close (sock_fd);        // just close the socket
-        }
-    }
+			close (sock_fd);        // just close the socket
+		}
+	}
 
 }
 
 CerverReceive *cerver_receive_create (ReceiveType receive_type, Cerver *cerver, const i32 sock_fd) {
 
-    CerverReceive *cr = cerver_receive_new ();
-    if (cr) {
-        cr->type = receive_type;
+	CerverReceive *cr = cerver_receive_new ();
+	if (cr) {
+		cr->type = receive_type;
 
-        cr->cerver = cerver;
+		cr->cerver = cerver;
 
-        switch (cr->type) {
-            case RECEIVE_TYPE_NONE: break;
+		switch (cr->type) {
+			case RECEIVE_TYPE_NONE: break;
 
-            case RECEIVE_TYPE_NORMAL: cerver_receive_create_normal (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_NORMAL: cerver_receive_create_normal (cr, cerver, sock_fd); break;
 
-            case RECEIVE_TYPE_ON_HOLD: cerver_receive_create_on_hold (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_ON_HOLD: cerver_receive_create_on_hold (cr, cerver, sock_fd); break;
 
-            case RECEIVE_TYPE_ADMIN: cerver_receive_create_admin (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_ADMIN: cerver_receive_create_admin (cr, cerver, sock_fd); break;
 
-            default: break;
-        }
-    }
+			default: break;
+		}
+	}
 
-    return cr;
+	return cr;
 
 }
 
-CerverReceive *cerver_receive_create_full (ReceiveType receive_type, 
-    Cerver *cerver, 
-    Client *client, Connection *connection
+CerverReceive *cerver_receive_create_full (ReceiveType receive_type,
+	Cerver *cerver,
+	Client *client, Connection *connection
 ) {
 
-    CerverReceive *cr = cerver_receive_new ();
-    if (cr) {
-        cr->type = receive_type;
+	CerverReceive *cr = cerver_receive_new ();
+	if (cr) {
+		cr->type = receive_type;
 
-        cr->cerver = cerver;
+		cr->cerver = cerver;
 
-        cr->socket = connection ? connection->socket : NULL;
-        cr->connection = connection;
-        cr->client = client;
-    }
+		cr->socket = connection ? connection->socket : NULL;
+		cr->connection = connection;
+		cr->client = client;
+	}
 
-    return cr;
+	return cr;
 
 }
 
 static void cerver_receive_handle_spare_packet (ReceiveHandle *receive_handle,
-    SockReceive *sock_receive,
-    size_t buffer_size, char **end, size_t *buffer_pos) {
+	SockReceive *sock_receive,
+	size_t buffer_size, char **end, size_t *buffer_pos) {
 
-    if (sock_receive) {
-        if (sock_receive->header) {
-            // copy the remaining header size
-            memcpy (sock_receive->header_end, (void *) *end, sock_receive->remaining_header);
-            // *end += sock_receive->remaining_header;
-            // *buffer_pos += sock_receive->remaining_header;
-            
-            // printf ("size in new header: %ld\n", ((PacketHeader *) sock_receive->header)->packet_size);
-            // packet_header_print (((PacketHeader *) sock_receive->header));
+	if (sock_receive) {
+		if (sock_receive->header) {
+			// copy the remaining header size
+			memcpy (sock_receive->header_end, (void *) *end, sock_receive->remaining_header);
+			// *end += sock_receive->remaining_header;
+			// *buffer_pos += sock_receive->remaining_header;
 
-            sock_receive->complete_header = true;
-        }
+			// printf ("size in new header: %ld\n", ((PacketHeader *) sock_receive->header)->packet_size);
+			// packet_header_print (((PacketHeader *) sock_receive->header));
 
-        else if (sock_receive->spare_packet) {
-            size_t copy_to_spare = 0;
-            if (sock_receive->missing_packet < buffer_size) 
-                copy_to_spare = sock_receive->missing_packet;
+			sock_receive->complete_header = true;
+		}
 
-            else copy_to_spare = buffer_size;
+		else if (sock_receive->spare_packet) {
+			size_t copy_to_spare = 0;
+			if (sock_receive->missing_packet < buffer_size)
+				copy_to_spare = sock_receive->missing_packet;
 
-            // printf ("copy to spare: %ld\n", copy_to_spare);
+			else copy_to_spare = buffer_size;
 
-            // append new data from buffer to the spare packet
-            if (copy_to_spare > 0) {
-                packet_append_data (sock_receive->spare_packet, (void *) *end, copy_to_spare);
+			// printf ("copy to spare: %ld\n", copy_to_spare);
 
-                // check if we can handle the packet 
-                size_t curr_packet_size = sock_receive->spare_packet->data_size + sizeof (PacketHeader);
-                if (sock_receive->spare_packet->header->packet_size == curr_packet_size) {
-                    cerver_packet_select_handler (receive_handle, sock_receive->spare_packet);
-                    sock_receive->spare_packet = NULL;
-                    sock_receive->missing_packet = 0;
-                }
+			// append new data from buffer to the spare packet
+			if (copy_to_spare > 0) {
+				packet_append_data (sock_receive->spare_packet, (void *) *end, copy_to_spare);
 
-                else sock_receive->missing_packet -= copy_to_spare;
+				// check if we can handle the packet
+				size_t curr_packet_size = sock_receive->spare_packet->data_size + sizeof (PacketHeader);
+				if (sock_receive->spare_packet->header->packet_size == curr_packet_size) {
+					cerver_packet_select_handler (receive_handle, sock_receive->spare_packet);
+					sock_receive->spare_packet = NULL;
+					sock_receive->missing_packet = 0;
+				}
 
-                // offset for the buffer
-                if (copy_to_spare < buffer_size) *end += copy_to_spare;
-                *buffer_pos += copy_to_spare;
-                // printf ("buffer pos after copy to spare: %ld\n", *buffer_pos);
-            }
-        }
-    }
+				else sock_receive->missing_packet -= copy_to_spare;
+
+				// offset for the buffer
+				if (copy_to_spare < buffer_size) *end += copy_to_spare;
+				*buffer_pos += copy_to_spare;
+				// printf ("buffer pos after copy to spare: %ld\n", *buffer_pos);
+			}
+		}
+	}
 
 }
 
 // default cerver receive handler
 void cerver_receive_handle_buffer (void *receive_handle_ptr) {
 
-    if (receive_handle_ptr) {
-        // printf ("cerver_receive_handle_buffer ()\n");
-        ReceiveHandle *receive_handle = (ReceiveHandle *) receive_handle_ptr;
+	if (receive_handle_ptr) {
+		// printf ("cerver_receive_handle_buffer ()\n");
+		ReceiveHandle *receive_handle = (ReceiveHandle *) receive_handle_ptr;
 
-        Cerver *cerver = receive_handle->cerver;
-        // i32 sock_fd = receive_handle->sock_fd;
-        char *buffer = receive_handle->buffer;
-        size_t buffer_size = receive_handle->buffer_size;
-        // i32 sock_fd = receive_handle->socket->sock_fd;
-        // char *buffer = receive_handle->socket->packet_buffer;
-        // size_t buffer_size = receive_handle->socket->packet_buffer_size;
-        Lobby *lobby = receive_handle->lobby;
+		Cerver *cerver = receive_handle->cerver;
+		// i32 sock_fd = receive_handle->sock_fd;
+		char *buffer = receive_handle->buffer;
+		size_t buffer_size = receive_handle->buffer_size;
+		// i32 sock_fd = receive_handle->socket->sock_fd;
+		// char *buffer = receive_handle->socket->packet_buffer;
+		// size_t buffer_size = receive_handle->socket->packet_buffer_size;
+		Lobby *lobby = receive_handle->lobby;
 
-        pthread_mutex_lock (receive_handle->socket->read_mutex);
+		pthread_mutex_lock (receive_handle->socket->read_mutex);
 
-        SockReceive *sock_receive = receive_handle->connection ? receive_handle->connection->sock_receive : NULL;
-        if (sock_receive) {
-            if (buffer && (buffer_size > 0)) {
-                char *end = buffer;
-                size_t buffer_pos = 0;
+		SockReceive *sock_receive = receive_handle->connection ? receive_handle->connection->sock_receive : NULL;
+		if (sock_receive) {
+			if (buffer && (buffer_size > 0)) {
+				char *end = buffer;
+				size_t buffer_pos = 0;
 
-                cerver_receive_handle_spare_packet (
-                    receive_handle,
-                    sock_receive,
-                    buffer_size, &end, &buffer_pos
-                );
+				cerver_receive_handle_spare_packet (
+					receive_handle,
+					sock_receive,
+					buffer_size, &end, &buffer_pos
+				);
 
-                PacketHeader *header = NULL;
-                size_t packet_size = 0;
-                // char *packet_data = NULL;
+				PacketHeader *header = NULL;
+				size_t packet_size = 0;
+				// char *packet_data = NULL;
 
-                size_t remaining_buffer_size = 0;
-                size_t packet_real_size = 0;
-                size_t to_copy_size = 0;
+				size_t remaining_buffer_size = 0;
+				size_t packet_real_size = 0;
+				size_t to_copy_size = 0;
 
-                bool spare_header = false;
+				bool spare_header = false;
 
-                while (buffer_pos < buffer_size) {
-                    remaining_buffer_size = buffer_size - buffer_pos;
+				while (buffer_pos < buffer_size) {
+					remaining_buffer_size = buffer_size - buffer_pos;
 
-                    if (sock_receive->complete_header) {
-                        packet_header_copy (&header, (PacketHeader *) sock_receive->header);
-                        // header = ((PacketHeader *) sock_receive->header);
-                        // packet_header_print (header);
+					if (sock_receive->complete_header) {
+						packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+						// header = ((PacketHeader *) sock_receive->header);
+						// packet_header_print (header);
 
-                        end += sock_receive->remaining_header;
-                        buffer_pos += sock_receive->remaining_header;
-                        // printf ("buffer pos after copy to header: %ld\n", buffer_pos);
+						end += sock_receive->remaining_header;
+						buffer_pos += sock_receive->remaining_header;
+						// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
 
-                        // reset sock header values
-                        free (sock_receive->header);
-                        sock_receive->header = NULL;
-                        sock_receive->header_end = NULL;
-                        // sock_receive->curr_header_pos = 0;
-                        // sock_receive->remaining_header = 0;
-                        sock_receive->complete_header = false;
+						// reset sock header values
+						free (sock_receive->header);
+						sock_receive->header = NULL;
+						sock_receive->header_end = NULL;
+						// sock_receive->curr_header_pos = 0;
+						// sock_receive->remaining_header = 0;
+						sock_receive->complete_header = false;
 
-                        spare_header = true;
-                    }
+						spare_header = true;
+					}
 
-                    else if (remaining_buffer_size >= sizeof (PacketHeader)) {
-                        header = (PacketHeader *) end;
-                        end += sizeof (PacketHeader);
-                        buffer_pos += sizeof (PacketHeader);
+					else if (remaining_buffer_size >= sizeof (PacketHeader)) {
+						header = (PacketHeader *) end;
+						end += sizeof (PacketHeader);
+						buffer_pos += sizeof (PacketHeader);
 
-                        // packet_header_print (header);
+						// packet_header_print (header);
 
-                        spare_header = false;
-                    }
+						spare_header = false;
+					}
 
-                    if (header) {
-                        // check the packet size
-                        packet_size = header->packet_size;
-                        if ((packet_size > 0) /* && (packet_size < 65536) */) {
-                            // printf ("packet_size: %ld\n", packet_size);
-                            // end += sizeof (PacketHeader);
-                            // buffer_pos += sizeof (PacketHeader);
-                            // printf ("first buffer pos: %ld\n", buffer_pos);
+					if (header) {
+						// check the packet size
+						packet_size = header->packet_size;
+						if ((packet_size > 0) /* && (packet_size < 65536) */) {
+							// printf ("packet_size: %ld\n", packet_size);
+							// end += sizeof (PacketHeader);
+							// buffer_pos += sizeof (PacketHeader);
+							// printf ("first buffer pos: %ld\n", buffer_pos);
 
-                            Packet *packet = packet_new ();
-                            if (packet) {
-                                packet_header_copy (&packet->header, header);
-                                packet->packet_size = header->packet_size;
-                                packet->cerver = cerver;
-                                packet->lobby = lobby;
+							Packet *packet = packet_new ();
+							if (packet) {
+								packet_header_copy (&packet->header, header);
+								packet->packet_size = header->packet_size;
+								packet->cerver = cerver;
+								packet->lobby = lobby;
 
-                                if (spare_header) {
-                                    free (header);
-                                    header = NULL;
-                                }
+								if (spare_header) {
+									free (header);
+									header = NULL;
+								}
 
-                                // check for packet size and only copy what is in the current buffer
-                                packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
-                                to_copy_size = 0;
-                                if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
-                                    sock_receive->spare_packet = packet;
+								// check for packet size and only copy what is in the current buffer
+								packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
+								to_copy_size = 0;
+								if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
+									sock_receive->spare_packet = packet;
 
-                                    if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
-                                    else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-                                    
-                                    sock_receive->missing_packet = packet_real_size - to_copy_size;
-                                }
+									if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
+									else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 
-                                else {
-                                    to_copy_size = packet_real_size;
-                                    packet_delete (sock_receive->spare_packet);
-                                    sock_receive->spare_packet = NULL;
-                                } 
+									sock_receive->missing_packet = packet_real_size - to_copy_size;
+								}
 
-                                // printf ("to copy size: %ld\n", to_copy_size);
-                                packet_set_data (packet, (void *) end, to_copy_size);
+								else {
+									to_copy_size = packet_real_size;
+									packet_delete (sock_receive->spare_packet);
+									sock_receive->spare_packet = NULL;
+								}
 
-                                end += to_copy_size;
-                                buffer_pos += to_copy_size;
-                                // printf ("second buffer pos: %ld\n", buffer_pos);
+								// printf ("to copy size: %ld\n", to_copy_size);
+								packet_set_data (packet, (void *) end, to_copy_size);
 
-                                if (!sock_receive->spare_packet) {
-                                    cerver_packet_select_handler (receive_handle, packet);
-                                }
-                                    
-                            }
+								end += to_copy_size;
+								buffer_pos += to_copy_size;
+								// printf ("second buffer pos: %ld\n", buffer_pos);
 
-                            else {
-                                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PACKET, 
-                                    "Failed to create a new packet in cerver_handle_receive_buffer ()");
-                            }
-                        }
+								if (!sock_receive->spare_packet) {
+									cerver_packet_select_handler (receive_handle, packet);
+								}
 
-                        else {
-                            char *status = c_string_create ("Got a packet of invalid size: %ld", packet_size);
-                            if (status) {
-                                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, status); 
-                                free (status);
-                            }
+							}
 
-                            // FIXME: what to do next?
-                            
-                            break;
-                        }
-                    }
+							else {
+								cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_PACKET,
+									"Failed to create a new packet in cerver_handle_receive_buffer ()");
+							}
+						}
 
-                    else {
-                        if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+						else {
+							char *status = c_string_create ("Got a packet of invalid size: %ld", packet_size);
+							if (status) {
+								cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_PACKET, status);
+								free (status);
+							}
 
-                        else {
-                            // handle part of a new header
-                            // #ifdef CERVER_DEBUG
-                            // cerver_log_debug ("Handle part of a new header...");
-                            // #endif
+							// FIXME: what to do next?
 
-                            // copy the piece of possible header that was cut of between recv ()
-                            sock_receive->header = malloc (sizeof (PacketHeader));
-                            memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+							break;
+						}
+					}
 
-                            sock_receive->header_end = (char *) sock_receive->header;
-                            sock_receive->header_end += remaining_buffer_size;
+					else {
+						if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
 
-                            // sock_receive->curr_header_pos = remaining_buffer_size;
-                            sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
+						else {
+							// handle part of a new header
+							// #ifdef CERVER_DEBUG
+							// cerver_log_debug ("Handle part of a new header...");
+							// #endif
 
-                            // printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
-                            // printf ("remaining header: %d\n", sock_receive->remaining_header);
+							// copy the piece of possible header that was cut of between recv ()
+							sock_receive->header = malloc (sizeof (PacketHeader));
+							memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
 
-                            buffer_pos += remaining_buffer_size;
-                        }
-                    }
+							sock_receive->header_end = (char *) sock_receive->header;
+							sock_receive->header_end += remaining_buffer_size;
 
-                    header = NULL;
-                }
-            }
-        }
+							// sock_receive->curr_header_pos = remaining_buffer_size;
+							sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
 
-        else {
-            #ifdef CERVER_DEBUG
-            char *status = c_string_create ("Sock fd: %d does not have an associated sock_receive in cerver %s.",
-                receive_handle->socket->sock_fd, cerver->info->name->str);
-            if (status) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-                free (status);
-            }
-            #endif
-        }
+							// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
+							// printf ("remaining header: %d\n", sock_receive->remaining_header);
 
-        // 28/05/2020 -- deleting the created buffer from cerver_receive ()
-        // to correct handle both cases: using thpool and single threaded
-        if (buffer) free (receive_handle->buffer);
+							buffer_pos += remaining_buffer_size;
+						}
+					}
 
-        // free (receive->socket->packet_buffer);
-        // receive->socket->packet_buffer = NULL;
+					header = NULL;
+				}
+			}
+		}
 
-        pthread_mutex_unlock (receive_handle->socket->read_mutex);
+		else {
+			#ifdef CERVER_DEBUG
+			char *status = c_string_create ("Sock fd: %d does not have an associated sock_receive in cerver %s.",
+				receive_handle->socket->sock_fd, cerver->info->name->str);
+			if (status) {
+				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
+				free (status);
+			}
+			#endif
+		}
 
-        receive_handle_delete (receive_handle);
-    }
+		// 28/05/2020 -- deleting the created buffer from cerver_receive ()
+		// to correct handle both cases: using thpool and single threaded
+		if (buffer) free (receive_handle->buffer);
+
+		// free (receive->socket->packet_buffer);
+		// receive->socket->packet_buffer = NULL;
+
+		pthread_mutex_unlock (receive_handle->socket->read_mutex);
+
+		receive_handle_delete (receive_handle);
+	}
 
 }
 
@@ -1561,521 +1561,521 @@ void cerver_receive_handle_buffer (void *receive_handle_ptr) {
 // end sthe connection to prevent seg faults or signals for bad sock fd
 static void cerver_receive_handle_failed (void *cr_ptr) {
 
-    if (cr_ptr) {
-        CerverReceive *cr = (CerverReceive *) cr_ptr;
+	if (cr_ptr) {
+		CerverReceive *cr = (CerverReceive *) cr_ptr;
 
-        if (cr->socket) {
-            pthread_mutex_lock (cr->socket->read_mutex);
+		if (cr->socket) {
+			pthread_mutex_lock (cr->socket->read_mutex);
 
-            if (cr->socket->sock_fd > 0) {
-                switch (cr->type) {
-                    case RECEIVE_TYPE_NORMAL: {
-                        // check if the socket belongs to a player inside a lobby
-                        if (cr->lobby) {
-                            if (cr->lobby->players->size > 0) {
-                                Player *player = player_get_by_sock_fd_list (cr->lobby, cr->socket->sock_fd);
-                                if (player) player_unregister_from_lobby (cr->lobby, player);
-                            }
-                        }
+			if (cr->socket->sock_fd > 0) {
+				switch (cr->type) {
+					case RECEIVE_TYPE_NORMAL: {
+						// check if the socket belongs to a player inside a lobby
+						if (cr->lobby) {
+							if (cr->lobby->players->size > 0) {
+								Player *player = player_get_by_sock_fd_list (cr->lobby, cr->socket->sock_fd);
+								if (player) player_unregister_from_lobby (cr->lobby, player);
+							}
+						}
 
-                        client_remove_connection_by_sock_fd (cr->cerver, cr->client, cr->socket->sock_fd);
-                    } break;
+						client_remove_connection_by_sock_fd (cr->cerver, cr->client, cr->socket->sock_fd);
+					} break;
 
-                    case RECEIVE_TYPE_ON_HOLD: {
-                        on_hold_connection_drop (cr->cerver, cr->connection);
-                    } break;
+					case RECEIVE_TYPE_ON_HOLD: {
+						on_hold_connection_drop (cr->cerver, cr->connection);
+					} break;
 
-                    case RECEIVE_TYPE_ADMIN: {
-                        admin_remove_connection_by_sock_fd (cr->cerver->admin, cr->admin, cr->socket->sock_fd);
-                    } break;
+					case RECEIVE_TYPE_ADMIN: {
+						admin_remove_connection_by_sock_fd (cr->cerver->admin, cr->admin, cr->socket->sock_fd);
+					} break;
 
-                    default: break;
-                }
-            }
+					default: break;
+				}
+			}
 
-            pthread_mutex_unlock (cr->socket->read_mutex);
-        }
+			pthread_mutex_unlock (cr->socket->read_mutex);
+		}
 
-        cerver_receive_delete (cr);
-    }
+		cerver_receive_delete (cr);
+	}
 
 }
 
 // 28/05/2020 -- correctly call cerver_receive_handle_failed ()
 void cerver_switch_receive_handle_failed (CerverReceive *cr) {
 
-    if (cr) {
-        if (cr->cerver->thpool) {
-            if (thpool_add_work (cr->cerver->thpool, cerver_receive_handle_failed, cr)) {
-                char *s = c_string_create (
-                    "Failed to add cerver_receive_handle_failed () to cerver's %s thpool!", 
-                    cr->cerver->info->name->str
-                );
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                    free (s);
-                }
-            }
-        }
+	if (cr) {
+		if (cr->cerver->thpool) {
+			if (thpool_add_work (cr->cerver->thpool, cerver_receive_handle_failed, cr)) {
+				char *s = c_string_create (
+					"Failed to add cerver_receive_handle_failed () to cerver's %s thpool!",
+					cr->cerver->info->name->str
+				);
+				if (s) {
+					cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
+					free (s);
+				}
+			}
+		}
 
-        else {
-            cerver_receive_handle_failed (cr);
-        }
-    }
+		else {
+			cerver_receive_handle_failed (cr);
+		}
+	}
 
 }
 
 static inline void cerver_receive_success_receive_handle (CerverReceive *cr, ssize_t rc, char *packet_buffer) {
 
-    ReceiveHandle *receive_handle = receive_handle_new ();
-    if (receive_handle) {
-        receive_handle->type = cr->type;
+	ReceiveHandle *receive_handle = receive_handle_new ();
+	if (receive_handle) {
+		receive_handle->type = cr->type;
 
-        receive_handle->cerver = cr->cerver;
+		receive_handle->cerver = cr->cerver;
 
-        receive_handle->socket = cr->socket;
-        receive_handle->connection = cr->connection;
-        receive_handle->client = cr->client;
-        receive_handle->admin = cr->admin;
+		receive_handle->socket = cr->socket;
+		receive_handle->connection = cr->connection;
+		receive_handle->client = cr->client;
+		receive_handle->admin = cr->admin;
 
-        receive_handle->lobby = cr->lobby;
+		receive_handle->lobby = cr->lobby;
 
-        receive_handle->buffer = packet_buffer;
-        receive_handle->buffer_size = rc;
+		receive_handle->buffer = packet_buffer;
+		receive_handle->buffer_size = rc;
 
-        switch (receive_handle->cerver->handler_type) {
-            case CERVER_HANDLER_TYPE_NONE: break;
+		switch (receive_handle->cerver->handler_type) {
+			case CERVER_HANDLER_TYPE_NONE: break;
 
-            case CERVER_HANDLER_TYPE_POLL: {
-                if (cr->cerver->thpool) {
-                    // 28/05/2020 -- 02:37 -- added thpool here instead of cerver_poll ()
-                    // and it seems to be working as expected
-                    if (!thpool_add_work (cr->cerver->thpool, cr->cerver->handle_received_buffer, receive_handle)) {
-                        // char *s = c_string_create ("Added %s cr->cerver->handle_received_buffer () to thpool!",
-                        //     cr->cerver->info->name->str);
-                        // if (s) {
-                        //     cerver_log_debug (s);
-                        //     free (s);
-                        // }
-                    }
+			case CERVER_HANDLER_TYPE_POLL: {
+				if (cr->cerver->thpool) {
+					// 28/05/2020 -- 02:37 -- added thpool here instead of cerver_poll ()
+					// and it seems to be working as expected
+					if (!thpool_add_work (cr->cerver->thpool, cr->cerver->handle_received_buffer, receive_handle)) {
+						// char *s = c_string_create ("Added %s cr->cerver->handle_received_buffer () to thpool!",
+						//     cr->cerver->info->name->str);
+						// if (s) {
+						//     cerver_log_debug (s);
+						//     free (s);
+						// }
+					}
 
-                    else {
-                        char *s = c_string_create (
-                            "Failed to add %s cr->cerver->handle_received_buffer () to thpool!",
-                            cr->cerver->info->name->str
-                        );
-                        if (s) {
-                            cerver_log_error (s);
-                            free (s);
-                        }
-                    }
+					else {
+						char *s = c_string_create (
+							"Failed to add %s cr->cerver->handle_received_buffer () to thpool!",
+							cr->cerver->info->name->str
+						);
+						if (s) {
+							cerver_log_error (s);
+							free (s);
+						}
+					}
 
-                    // char *status = c_string_create ("Cerver %s active thpool threads: %d", 
-                    //     cr->cerver->info->name->str,
-                    //     thpool_get_num_threads_working (cr->cerver->thpool)
-                    // );
-                    // if (status) {
-                    //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-                    //     free (status);
-                    // }
-                }
+					// char *status = c_string_create ("Cerver %s active thpool threads: %d",
+					//     cr->cerver->info->name->str,
+					//     thpool_get_num_threads_working (cr->cerver->thpool)
+					// );
+					// if (status) {
+					//     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
+					//     free (status);
+					// }
+				}
 
-                else {
-                    cr->cerver->handle_received_buffer (receive_handle);
+				else {
+					cr->cerver->handle_received_buffer (receive_handle);
 
-                    // 28/05/2020 -- called from inside cerver_receive_handle_buffer ()
-                    // receive_handle_delete (receive);
-                }
+					// 28/05/2020 -- called from inside cerver_receive_handle_buffer ()
+					// receive_handle_delete (receive);
+				}
 
-                cerver_receive_delete (cr);
-            } break;
+				cerver_receive_delete (cr);
+			} break;
 
-            case CERVER_HANDLER_TYPE_THREADS: 
-                cr->cerver->handle_received_buffer (receive_handle);
-                break;
+			case CERVER_HANDLER_TYPE_THREADS:
+				cr->cerver->handle_received_buffer (receive_handle);
+				break;
 
-            default: break;
-        }
-    }
+			default: break;
+		}
+	}
 
 }
 
 static void cerver_receive_success (CerverReceive *cr, ssize_t rc, char *packet_buffer) {
 
-    // char *status = c_string_create ("Cerver %s rc: %ld for sock fd: %d",
-    //     cr->cerver->info->name->str, rc, cr->sock_fd);
-    // if (status) {
-    //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-    //     free (status);
-    // }
+	// char *status = c_string_create ("Cerver %s rc: %ld for sock fd: %d",
+	//     cr->cerver->info->name->str, rc, cr->sock_fd);
+	// if (status) {
+	//     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
+	//     free (status);
+	// }
 
-    cr->socket->packet_buffer_size = rc;
+	cr->socket->packet_buffer_size = rc;
 
-    cr->cerver->stats->total_n_receives_done += 1;
-    cr->cerver->stats->total_bytes_received += rc;
+	cr->cerver->stats->total_n_receives_done += 1;
+	cr->cerver->stats->total_bytes_received += rc;
 
-    if (cr->lobby) {
-        cr->lobby->stats->n_receives_done += 1;
-        cr->lobby->stats->bytes_received += rc;
-    }
+	if (cr->lobby) {
+		cr->lobby->stats->n_receives_done += 1;
+		cr->lobby->stats->bytes_received += rc;
+	}
 
-    switch (cr->type) {
-        case RECEIVE_TYPE_NORMAL: {
-            cr->cerver->stats->client_receives_done += 1;
-            cr->cerver->stats->client_bytes_received += rc;
+	switch (cr->type) {
+		case RECEIVE_TYPE_NORMAL: {
+			cr->cerver->stats->client_receives_done += 1;
+			cr->cerver->stats->client_bytes_received += rc;
 
-            cr->client->stats->n_receives_done += 1;
-            cr->client->stats->total_bytes_received += rc;
+			cr->client->stats->n_receives_done += 1;
+			cr->client->stats->total_bytes_received += rc;
 
-            cr->connection->stats->n_receives_done += 1;
-            cr->connection->stats->total_bytes_received += rc;
-        } break;
+			cr->connection->stats->n_receives_done += 1;
+			cr->connection->stats->total_bytes_received += rc;
+		} break;
 
-        case RECEIVE_TYPE_ON_HOLD: {
-            cr->cerver->stats->on_hold_receives_done += 1;
-            cr->cerver->stats->on_hold_bytes_received += rc;
+		case RECEIVE_TYPE_ON_HOLD: {
+			cr->cerver->stats->on_hold_receives_done += 1;
+			cr->cerver->stats->on_hold_bytes_received += rc;
 
-            cr->connection->stats->n_receives_done += 1;
-            cr->connection->stats->total_bytes_received += rc;
-        } break;
+			cr->connection->stats->n_receives_done += 1;
+			cr->connection->stats->total_bytes_received += rc;
+		} break;
 
-        case RECEIVE_TYPE_ADMIN: {
-            cr->cerver->admin->stats->total_n_receives_done += 1;
-            cr->cerver->admin->stats->total_bytes_received += rc;
+		case RECEIVE_TYPE_ADMIN: {
+			cr->cerver->admin->stats->total_n_receives_done += 1;
+			cr->cerver->admin->stats->total_bytes_received += rc;
 
-            cr->client->stats->n_receives_done += 1;
-            cr->client->stats->total_bytes_received += rc;
+			cr->client->stats->n_receives_done += 1;
+			cr->client->stats->total_bytes_received += rc;
 
-            cr->connection->stats->n_receives_done += 1;
-            cr->connection->stats->total_bytes_received += rc;
-        } break;
+			cr->connection->stats->n_receives_done += 1;
+			cr->connection->stats->total_bytes_received += rc;
+		} break;
 
-        default: break;
-    }
+		default: break;
+	}
 
-    cerver_receive_success_receive_handle (cr, rc, packet_buffer);
+	cerver_receive_success_receive_handle (cr, rc, packet_buffer);
 
 }
 
 // receive all incoming data from the socket
 void cerver_receive (void *cerver_receive_ptr) {
 
-    if (cerver_receive_ptr) {
-        CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
+	if (cerver_receive_ptr) {
+		CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
-        if (cr->cerver && cr->socket) {
-            if (cr->socket > 0) {
-                char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
-                // cr->socket->packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
-                if (packet_buffer) {
-                    // ssize_t rc = read (cr->sock_fd, packet_buffer, cr->cerver->receive_buffer_size);
-                    ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
+		if (cr->cerver && cr->socket) {
+			if (cr->socket > 0) {
+				char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
+				// cr->socket->packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
+				if (packet_buffer) {
+					// ssize_t rc = read (cr->sock_fd, packet_buffer, cr->cerver->receive_buffer_size);
+					ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
 
-                    switch (rc) {
-                        case -1: {
-                            // no more data to read 
-                            if (errno != EWOULDBLOCK) {
-                                #ifdef CERVER_DEBUG 
-                                char *s = c_string_create (
-                                    "cerver_receive () - rc < 0 - sock fd: %d", 
-                                    cr->socket->sock_fd
-                                );
+					switch (rc) {
+						case -1: {
+							// no more data to read
+							if (errno != EWOULDBLOCK) {
+								#ifdef CERVER_DEBUG
+								char *s = c_string_create (
+									"cerver_receive () - rc < 0 - sock fd: %d",
+									cr->socket->sock_fd
+								);
 
-                                if (s) {
-                                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
-                                    free (s);
-                                }
+								if (s) {
+									cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
+									free (s);
+								}
 
-                                perror ("Error ");
-                                #endif
+								perror ("Error ");
+								#endif
 
-                                cerver_switch_receive_handle_failed (cr);
-                            }
+								cerver_switch_receive_handle_failed (cr);
+							}
 
-                            free (packet_buffer);
-                        } break;
+							free (packet_buffer);
+						} break;
 
-                        case 0: {
-                            // man recv -> steam socket perfomed an orderly shutdown
-                            // but in dgram it might mean something?
-                            #ifdef CERVER_DEBUG
-                            char *s = c_string_create (
-                                "cerver_recieve () - rc == 0 - sock fd: %d",
-                                cr->socket->sock_fd
-                            );
+						case 0: {
+							// man recv -> steam socket perfomed an orderly shutdown
+							// but in dgram it might mean something?
+							#ifdef CERVER_DEBUG
+							char *s = c_string_create (
+								"cerver_recieve () - rc == 0 - sock fd: %d",
+								cr->socket->sock_fd
+							);
 
-                            if (s) {
-                                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                                free (s);
-                            }
+							if (s) {
+								cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
+								free (s);
+							}
 
-                            // perror ("Error ");
-                            #endif
+							// perror ("Error ");
+							#endif
 
-                            cerver_switch_receive_handle_failed (cr);
+							cerver_switch_receive_handle_failed (cr);
 
-                            free (packet_buffer);
-                        } break;
+							free (packet_buffer);
+						} break;
 
-                        default: {
-                            cerver_receive_success (cr, rc, packet_buffer);
-                        } break;
-                    }
+						default: {
+							cerver_receive_success (cr, rc, packet_buffer);
+						} break;
+					}
 
-                    // 28/05/2020 -- 02:40
-                    // packet_buffer is not free from inside cr->cerver->handle_received_buffer ()
-                    // free (packet_buffer);
-                }
+					// 28/05/2020 -- 02:40
+					// packet_buffer is not free from inside cr->cerver->handle_received_buffer ()
+					// free (packet_buffer);
+				}
 
-                else {
-                    char *status = c_string_create (
-                        "cerver_receive () - Failed to allocate packet buffer for connection with sock fd <%d>!",
-                        cr->connection->socket->sock_fd
-                    );
+				else {
+					char *status = c_string_create (
+						"cerver_receive () - Failed to allocate packet buffer for connection with sock fd <%d>!",
+						cr->connection->socket->sock_fd
+					);
 
-                    if (status) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
-                        free (status);
-                    }
-                }
-            }
+					if (status) {
+						cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
+						free (status);
+					}
+				}
+			}
 
-            else {
-                cerver_log_warning ("cerver_receive () - cr->socket <= 0");
-                cerver_receive_delete (cr);
-            }
-        }
+			else {
+				cerver_log_warning ("cerver_receive () - cr->socket <= 0");
+				cerver_receive_delete (cr);
+			}
+		}
 
-        else {
-            cerver_receive_delete (cr);
-        }
-    }
+		else {
+			cerver_receive_delete (cr);
+		}
+	}
 
 }
 
 // packet buffer only gets deleted if cerver_receive_handle_buffer () is used
 static inline u8 cerver_receive_threads_actual (CerverReceive *cr) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    #ifdef HANDLER_DEBUG
-    char *s = NULL;
-    #endif
+	#ifdef HANDLER_DEBUG
+	char *s = NULL;
+	#endif
 
-    char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
-    if (packet_buffer) {
-        ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
+	char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
+	if (packet_buffer) {
+		ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
 
-        switch (rc) {
-            case -1: {
-                if (cr->socket->sock_fd > -1) {
-                    switch (errno) {
-                        case EAGAIN: {
-                            #ifdef HANDLER_DEBUG
-                            s = c_string_create (
-                                "cerver_receive_threads () - sock fd: %d timed out", 
-                                cr->socket->sock_fd
-                            );
+		switch (rc) {
+			case -1: {
+				if (cr->socket->sock_fd > -1) {
+					switch (errno) {
+						case EAGAIN: {
+							#ifdef HANDLER_DEBUG
+							s = c_string_create (
+								"cerver_receive_threads () - sock fd: %d timed out",
+								cr->socket->sock_fd
+							);
 
-                            if (s) {
-                                cerver_log_debug (s);
-                                free (s);
-                            }
-                            #endif
+							if (s) {
+								cerver_log_debug (s);
+								free (s);
+							}
+							#endif
 
-                            retval = 0;
-                        } break;
+							retval = 0;
+						} break;
 
-                        default: {
-                            #ifdef HANDLER_DEBUG 
-                            s = c_string_create (
-                                "cerver_receive_threads () - rc < 0 - sock fd: %d", 
-                                cr->socket->sock_fd
-                            );
-                            
-                            if (s) {
-                                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
-                                free (s);
-                            }
+						default: {
+							#ifdef HANDLER_DEBUG
+							s = c_string_create (
+								"cerver_receive_threads () - rc < 0 - sock fd: %d",
+								cr->socket->sock_fd
+							);
 
-                            perror ("Error ");
-                            #endif
-                        } break;
-                    }
-                }
+							if (s) {
+								cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
+								free (s);
+							}
 
-                free (packet_buffer);
-            } break;
+							perror ("Error ");
+							#endif
+						} break;
+					}
+				}
 
-            case 0: {
-                #ifdef HANDLER_DEBUG
-                s = c_string_create (
-                    "cerver_receive_threads () - rc == 0 - sock fd: %d",
-                    cr->socket->sock_fd
-                );
+				free (packet_buffer);
+			} break;
 
-                if (s) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                    free (s);
-                }
+			case 0: {
+				#ifdef HANDLER_DEBUG
+				s = c_string_create (
+					"cerver_receive_threads () - rc == 0 - sock fd: %d",
+					cr->socket->sock_fd
+				);
 
-                // perror ("Error ");
-                #endif
+				if (s) {
+					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
+					free (s);
+				}
 
-                free (packet_buffer);
-            } break;
+				// perror ("Error ");
+				#endif
 
-            default: {
-                cerver_receive_success (cr, rc, packet_buffer);
+				free (packet_buffer);
+			} break;
 
-                retval = 0;
-            } break;
-        }
-    }
+			default: {
+				cerver_receive_success (cr, rc, packet_buffer);
 
-    else {
-        char *status = c_string_create (
-            "cerver_receive_threads () - Failed to allocate packet buffer for sock fd <%d> connection!",
-            cr->connection->socket->sock_fd
-        );
+				retval = 0;
+			} break;
+		}
+	}
 
-        if (status) {
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
-            free (status);
-        }
-    }
+	else {
+		char *status = c_string_create (
+			"cerver_receive_threads () - Failed to allocate packet buffer for sock fd <%d> connection!",
+			cr->connection->socket->sock_fd
+		);
 
-    return retval;
+		if (status) {
+			cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
+			free (status);
+		}
+	}
+
+	return retval;
 
 }
 
 static void *cerver_receive_threads (void *cerver_receive_ptr) {
 
-    CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
+	CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
-    // set the socket's timeout to prevent thread from getting stuck if no more data to read
-    (void) sock_set_timeout (cr->connection->socket->sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
+	// set the socket's timeout to prevent thread from getting stuck if no more data to read
+	(void) sock_set_timeout (cr->connection->socket->sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
 
-    while (!cerver_receive_threads_actual (cr) && (cr->socket->sock_fd > 0) && cr->cerver->isRunning);
+	while (!cerver_receive_threads_actual (cr) && (cr->socket->sock_fd > 0) && cr->cerver->isRunning);
 
-    // check if the connection has already ended
-    if (cr->socket->sock_fd > 0) {
-        client_remove_connection_by_sock_fd (cr->cerver, cr->client, cr->socket->sock_fd);
-    }
+	// check if the connection has already ended
+	if (cr->socket->sock_fd > 0) {
+		client_remove_connection_by_sock_fd (cr->cerver, cr->client, cr->socket->sock_fd);
+	}
 
-    cerver_receive_delete (cr);
+	cerver_receive_delete (cr);
 
-    #ifdef HANDLER_DEBUG
-    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, "cerver_receive_threads () - loop has ended");
-    #endif
+	#ifdef HANDLER_DEBUG
+	cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, "cerver_receive_threads () - loop has ended");
+	#endif
 
-    return NULL;
+	return NULL;
 
 }
 
 static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *http_receive) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    #ifdef HANDLER_DEBUG
-    char *s = NULL;
-    #endif
+	#ifdef HANDLER_DEBUG
+	char *s = NULL;
+	#endif
 
-    char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
-    if (packet_buffer) {
-        ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
+	char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
+	if (packet_buffer) {
+		ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
 
-        switch (rc) {
-            case -1: {
-                if (cr->socket->sock_fd > -1) {
-                    switch (errno) {
-                        case EAGAIN: {
-                            #ifdef HANDLER_DEBUG
-                            s = c_string_create (
-                                "cerver_receive_http () - sock fd: %d timed out", 
-                                cr->socket->sock_fd
-                            );
+		switch (rc) {
+			case -1: {
+				if (cr->socket->sock_fd > -1) {
+					switch (errno) {
+						case EAGAIN: {
+							#ifdef HANDLER_DEBUG
+							s = c_string_create (
+								"cerver_receive_http () - sock fd: %d timed out",
+								cr->socket->sock_fd
+							);
 
-                            if (s) {
-                                cerver_log_debug (s);
-                                free (s);
-                            }
-                            #endif
+							if (s) {
+								cerver_log_debug (s);
+								free (s);
+							}
+							#endif
 
-                            if (http_receive->keep_alive) retval = 0;
-                        } break;
+							if (http_receive->keep_alive) retval = 0;
+						} break;
 
-                        default: {
-                            #ifdef HANDLER_DEBUG 
-                            s = c_string_create (
-                                "cerver_receive_http () - rc < 0 - sock fd: %d", 
-                                cr->socket->sock_fd
-                            );
-                            
-                            if (s) {
-                                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
-                                free (s);
-                            }
+						default: {
+							#ifdef HANDLER_DEBUG
+							s = c_string_create (
+								"cerver_receive_http () - rc < 0 - sock fd: %d",
+								cr->socket->sock_fd
+							);
 
-                            perror ("Error ");
-                            #endif
-                        } break;
-                    }
-                }
-            } break;
+							if (s) {
+								cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
+								free (s);
+							}
 
-            case 0: {
-                #ifdef HANDLER_DEBUG
-                s = c_string_create (
-                    "cerver_receive_http () - rc == 0 - sock fd: %d",
-                    cr->socket->sock_fd
-                );
+							perror ("Error ");
+							#endif
+						} break;
+					}
+				}
+			} break;
 
-                if (s) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                    free (s);
-                }
+			case 0: {
+				#ifdef HANDLER_DEBUG
+				s = c_string_create (
+					"cerver_receive_http () - rc == 0 - sock fd: %d",
+					cr->socket->sock_fd
+				);
 
-                // perror ("Error ");
-                #endif
-            } break;
+				if (s) {
+					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
+					free (s);
+				}
 
-            default: {
-                // char *status = c_string_create ("Cerver %s rc: %ld for sock fd: %d",
-                //     cr->cerver->info->name->str, rc, cr->sock_fd);
-                // if (status) {
-                //     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-                //     free (status);
-                // }
+				// perror ("Error ");
+				#endif
+			} break;
 
-                // update cerver stats
-                cr->socket->packet_buffer_size = rc;
+			default: {
+				// char *status = c_string_create ("Cerver %s rc: %ld for sock fd: %d",
+				//     cr->cerver->info->name->str, rc, cr->sock_fd);
+				// if (status) {
+				//     cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
+				//     free (status);
+				// }
 
-                cr->cerver->stats->total_n_receives_done += 1;
-                cr->cerver->stats->total_bytes_received += rc;
+				// update cerver stats
+				cr->socket->packet_buffer_size = rc;
 
-                http_receive->handler (http_receive, rc, packet_buffer);
+				cr->cerver->stats->total_n_receives_done += 1;
+				cr->cerver->stats->total_bytes_received += rc;
 
-                retval = 0;
-            } break;
-        }
+				http_receive->handler (http_receive, rc, packet_buffer);
 
-        free (packet_buffer);
-    }
+				retval = 0;
+			} break;
+		}
 
-    else {
-        char *status = c_string_create (
-            "cerver_receive_http () - Failed to allocate packet buffer for connection with sock fd <%d>!",
-            cr->connection->socket->sock_fd
-        );
+		free (packet_buffer);
+	}
 
-        if (status) {
-            cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
-            free (status);
-        }
-    }
+	else {
+		char *status = c_string_create (
+			"cerver_receive_http () - Failed to allocate packet buffer for connection with sock fd <%d>!",
+			cr->connection->socket->sock_fd
+		);
 
-    return retval;
+		if (status) {
+			cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_HANDLER, status);
+			free (status);
+		}
+	}
+
+	return retval;
 
 }
 
@@ -2083,39 +2083,39 @@ static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *htt
 // and then handle the complete buffer
 static void *cerver_receive_http (void *cerver_receive_ptr) {
 
-    CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
+	CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
-    HttpReceive *http_receive = http_receive_new ();
-    http_receive->cr = cr;
-    http_receive->http_cerver = (HttpCerver *) cr->cerver->cerver_data;
+	HttpReceive *http_receive = http_receive_new ();
+	http_receive->cr = cr;
+	http_receive->http_cerver = (HttpCerver *) cr->cerver->cerver_data;
 
-    i32 sock_fd = cr->socket->sock_fd;
+	i32 sock_fd = cr->socket->sock_fd;
 
-    // set the socket's timeout to prevent thread from getting stuck if no more data to read
-    (void) sock_set_timeout (cr->connection->socket->sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
+	// set the socket's timeout to prevent thread from getting stuck if no more data to read
+	(void) sock_set_timeout (cr->connection->socket->sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
 
-    while (!cerver_receive_http_actual (cr, http_receive) && cr->cerver->isRunning);
+	while (!cerver_receive_http_actual (cr, http_receive) && cr->cerver->isRunning);
 
-    http_receive_delete (http_receive);
+	http_receive_delete (http_receive);
 
-    #ifdef HANDLER_DEBUG
-    char *status = c_string_create (
-        "cerver_receive_http () - loop has ended - dropping sock fd <%d> connection...",
-        sock_fd
-    );
+	#ifdef HANDLER_DEBUG
+	char *status = c_string_create (
+		"cerver_receive_http () - loop has ended - dropping sock fd <%d> connection...",
+		sock_fd
+	);
 
-    if (status) {
-        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-        free (status);
-    }
-    #endif
+	if (status) {
+		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
+		free (status);
+	}
+	#endif
 
-    // the connection has ended
-    connection_drop (cr->cerver, cr->connection);
+	// the connection has ended
+	connection_drop (cr->cerver, cr->connection);
 
-    cerver_receive_delete (cr);
+	cerver_receive_delete (cr);
 
-    return NULL;
+	return NULL;
 
 }
 
@@ -2124,440 +2124,440 @@ static void *cerver_receive_http (void *cerver_receive_ptr) {
 #pragma region accept
 
 // 07/06/2020 - create a new connection but check if we can use the cerver's socket pool first
-static Connection *cerver_connection_create (Cerver *cerver, 
-    const i32 new_fd, const struct sockaddr_storage client_address) {
+static Connection *cerver_connection_create (Cerver *cerver,
+	const i32 new_fd, const struct sockaddr_storage client_address) {
 
-    Connection *retval = NULL;
+	Connection *retval = NULL;
 
-    if (cerver) {
-        if (cerver->sockets_pool) {
-            // use a socket from the pool to create a new connection
-            Socket *socket = cerver_sockets_pool_pop (cerver);
-            if (socket) {
-                // manually create the connection
-                retval = connection_new ();
-                if (retval) {
-                    // from connection_create_empty ()
-                    // retval->socket = (Socket *) socket_create_empty ();
-                    retval->socket = socket;
-                    retval->sock_receive = sock_receive_new ();
-                    retval->stats = connection_stats_new ();
+	if (cerver) {
+		if (cerver->sockets_pool) {
+			// use a socket from the pool to create a new connection
+			Socket *socket = cerver_sockets_pool_pop (cerver);
+			if (socket) {
+				// manually create the connection
+				retval = connection_new ();
+				if (retval) {
+					// from connection_create_empty ()
+					// retval->socket = (Socket *) socket_create_empty ();
+					retval->socket = socket;
+					retval->sock_receive = sock_receive_new ();
+					retval->stats = connection_stats_new ();
 
-                    // from connection_create ()
-                    retval->socket->sock_fd = new_fd;
-                    memcpy (&retval->address, &client_address, sizeof (struct sockaddr_storage));
-                    retval->protocol = cerver->protocol;
+					// from connection_create ()
+					retval->socket->sock_fd = new_fd;
+					memcpy (&retval->address, &client_address, sizeof (struct sockaddr_storage));
+					retval->protocol = cerver->protocol;
 
-                    connection_get_values (retval);
-                }
-            }
+					connection_get_values (retval);
+				}
+			}
 
-            else {
-                retval = connection_create (new_fd, client_address, cerver->protocol);
-            }
-        }
+			else {
+				retval = connection_create (new_fd, client_address, cerver->protocol);
+			}
+		}
 
-        else {
-            retval = connection_create (new_fd, client_address, cerver->protocol);
-        }
-    }
+		else {
+			retval = connection_create (new_fd, client_address, cerver->protocol);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // if the cerver requires auth, we put the connection on hold
 static u8 cerver_register_new_connection_auth_required (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (!on_hold_connection (cerver, connection)) {
-        #ifdef CERVER_DEBUG
-        char *status = c_string_create ("Connection is on hold on cerver %s!", cerver->info->name->str);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-            free (status);
-        }
-        #endif
+	if (!on_hold_connection (cerver, connection)) {
+		#ifdef CERVER_DEBUG
+		char *status = c_string_create ("Connection is on hold on cerver %s!", cerver->info->name->str);
+		if (status) {
+			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
+			free (status);
+		}
+		#endif
 
-        cerver->stats->total_on_hold_connections += 1;
+		cerver->stats->total_on_hold_connections += 1;
 
-        connection->active = true;
+		connection->active = true;
 
-        cerver_info_send_info_packet (cerver, NULL, connection);
+		cerver_info_send_info_packet (cerver, NULL, connection);
 
-        cerver_event_trigger (
-            CERVER_EVENT_ON_HOLD_CONNECTED,
-            cerver,
-            NULL, connection
-        );
+		cerver_event_trigger (
+			CERVER_EVENT_ON_HOLD_CONNECTED,
+			cerver,
+			NULL, connection
+		);
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        char *status = c_string_create ("Failed to put connection on hold in cerver %s",
-            cerver->info->name->str);
-        if (status) {
-            cerver_log_error (status);
-            free (status);
-        }
-    }
+	else {
+		char *status = c_string_create ("Failed to put connection on hold in cerver %s",
+			cerver->info->name->str);
+		if (status) {
+			cerver_log_error (status);
+			free (status);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    CerverReceive *cr = cerver_receive_create_full (
-        RECEIVE_TYPE_NORMAL,
-        cerver,
-        NULL, connection
-    );
+	CerverReceive *cr = cerver_receive_create_full (
+		RECEIVE_TYPE_NORMAL,
+		cerver,
+		NULL, connection
+	);
 
-    if (cr) {
-        if (thpool_is_full (cerver->thpool)) {
-            #ifdef HANDLER_DEBUG
-            char *status = c_string_create (
-                "Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
-                cerver->info->name->str, connection->socket->sock_fd
-            );
+	if (cr) {
+		if (thpool_is_full (cerver->thpool)) {
+			#ifdef HANDLER_DEBUG
+			char *status = c_string_create (
+				"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
+				cerver->info->name->str, connection->socket->sock_fd
+			);
 
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                free (status);
-            }
-            #endif
+			if (status) {
+				cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+				free (status);
+			}
+			#endif
 
-            pthread_t thread_id = 0;
-            if (!thread_create_detachable (
-                &thread_id,
-                cerver_receive_http,
-                cr
-            )) {
-                retval = 0;     // success
-            }
+			pthread_t thread_id = 0;
+			if (!thread_create_detachable (
+				&thread_id,
+				cerver_receive_http,
+				cr
+			)) {
+				retval = 0;     // success
+			}
 
-            else {
-                cerver_log_error ("cerver_register_new_connection_normal_web () - failed to create detachable thread!");
-                cerver_receive_delete (cr);
-            }
-        }
+			else {
+				cerver_log_error ("cerver_register_new_connection_normal_web () - failed to create detachable thread!");
+				cerver_receive_delete (cr);
+			}
+		}
 
-        else {
-            if (!thpool_add_work (
-                cerver->thpool, 
-                (void (*) (void *)) cerver_receive_http, 
-                cr
-            )) {
-                #ifdef HANDLER_DEBUG
-                char *status = c_string_create (
-                    "Added work for sock fd <%d> connection to the thpool!",
-                    connection->socket->sock_fd
-                );
+		else {
+			if (!thpool_add_work (
+				cerver->thpool,
+				(void (*) (void *)) cerver_receive_http,
+				cr
+			)) {
+				#ifdef HANDLER_DEBUG
+				char *status = c_string_create (
+					"Added work for sock fd <%d> connection to the thpool!",
+					connection->socket->sock_fd
+				);
 
-                if (status) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                    free (status);
-                }
+				if (status) {
+					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+					free (status);
+				}
 
-                status = c_string_create (
-                    "Cerver %s thpool - %d / %d threads working",
-                    cerver->info->name->str,
-                    thpool_get_num_threads_working (cerver->thpool),
-                    cerver->thpool->num_threads_alive
-                );
+				status = c_string_create (
+					"Cerver %s thpool - %d / %d threads working",
+					cerver->info->name->str,
+					thpool_get_num_threads_working (cerver->thpool),
+					cerver->thpool->num_threads_alive
+				);
 
-                if (status) {
-                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                    free (status);
-                }
-                #endif
+				if (status) {
+					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+					free (status);
+				}
+				#endif
 
-                retval = 0;     // success
-            }
+				retval = 0;     // success
+			}
 
-            else {
-                cerver_receive_delete (cr);
-            }
-        }
-    }
+			else {
+				cerver_receive_delete (cr);
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_register_new_connection_normal_default_create_detachable (CerverReceive *cr) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    pthread_t thread_id = 0;
-    if (!thread_create_detachable (
-        &thread_id,
-        cerver_receive_threads,
-        cr
-    )) {
-        #ifdef HANDLER_DEBUG
-        char *status = c_string_create (
-            "Created detachable thread for sock fd <%d> connection",
-            cr->connection->socket->sock_fd
-        );
+	pthread_t thread_id = 0;
+	if (!thread_create_detachable (
+		&thread_id,
+		cerver_receive_threads,
+		cr
+	)) {
+		#ifdef HANDLER_DEBUG
+		char *status = c_string_create (
+			"Created detachable thread for sock fd <%d> connection",
+			cr->connection->socket->sock_fd
+		);
 
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-            free (status);
-        }
-        #endif
+		if (status) {
+			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+			free (status);
+		}
+		#endif
 
-        retval = 0;     // success
-    }
+		retval = 0;     // success
+	}
 
-    else {
-        char *status = c_string_create (
-            "cerver_register_new_connection_normal_default () - Failed to create detachable thread for sock fd <%d> connection!",
-            cr->connection->socket->sock_fd
-        );
+	else {
+		char *status = c_string_create (
+			"cerver_register_new_connection_normal_default () - Failed to create detachable thread for sock fd <%d> connection!",
+			cr->connection->socket->sock_fd
+		);
 
-        if (status) {
-            cerver_log_error (status);
-            free (status);
-        }
+		if (status) {
+			cerver_log_error (status);
+			free (status);
+		}
 
-        cerver_receive_delete (cr);
-    }
+		cerver_receive_delete (cr);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    Client *client = client_create ();
-    if (client) {
-        (void) connection_register_to_client (client, connection);
+	Client *client = client_create ();
+	if (client) {
+		(void) connection_register_to_client (client, connection);
 
-        if (!client_register_to_cerver (cerver, client)) {
-            connection->active = true;
+		if (!client_register_to_cerver (cerver, client)) {
+			connection->active = true;
 
-            cerver_info_send_info_packet (cerver, client, connection);
+			cerver_info_send_info_packet (cerver, client, connection);
 
-            cerver_event_trigger (
-                CERVER_EVENT_CLIENT_CONNECTED,
-                cerver,
-                client, connection
-            );
+			cerver_event_trigger (
+				CERVER_EVENT_CLIENT_CONNECTED,
+				cerver,
+				client, connection
+			);
 
-            switch (cerver->handler_type) {
-                case CERVER_HANDLER_TYPE_NONE: break;
+			switch (cerver->handler_type) {
+				case CERVER_HANDLER_TYPE_NONE: break;
 
-                case CERVER_HANDLER_TYPE_POLL: 
-                    // nothing to be done, as connection will be handled by poll ()
-                    // after being registered to the cerver
-                    retval = 0;     // success
-                    break;
+				case CERVER_HANDLER_TYPE_POLL:
+					// nothing to be done, as connection will be handled by poll ()
+					// after being registered to the cerver
+					retval = 0;     // success
+					break;
 
-                // handle connection in dedicated thread
-                case CERVER_HANDLER_TYPE_THREADS: {
-                    CerverReceive *cr = cerver_receive_create_full (
-                        RECEIVE_TYPE_NORMAL,
-                        cerver,
-                        client, connection
-                    );
-                    
-                    if (cr) {
-                        // create a new detachable thread directly
-                        if (cerver->handle_detachable_threads) {
-                            retval = cerver_register_new_connection_normal_default_create_detachable (cr);
-                        }
+				// handle connection in dedicated thread
+				case CERVER_HANDLER_TYPE_THREADS: {
+					CerverReceive *cr = cerver_receive_create_full (
+						RECEIVE_TYPE_NORMAL,
+						cerver,
+						client, connection
+					);
 
-                        else {
-                            if (thpool_is_full (cerver->thpool)) {
-                                #ifdef HANDLER_DEBUG
-                                char *status = c_string_create (
-                                    "Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
-                                    cerver->info->name->str, connection->socket->sock_fd
-                                );
+					if (cr) {
+						// create a new detachable thread directly
+						if (cerver->handle_detachable_threads) {
+							retval = cerver_register_new_connection_normal_default_create_detachable (cr);
+						}
 
-                                if (status) {
-                                    cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                                    free (status);
-                                }
-                                #endif
+						else {
+							if (thpool_is_full (cerver->thpool)) {
+								#ifdef HANDLER_DEBUG
+								char *status = c_string_create (
+									"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
+									cerver->info->name->str, connection->socket->sock_fd
+								);
 
-                                retval = cerver_register_new_connection_normal_default_create_detachable (cr);
-                            }
+								if (status) {
+									cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+									free (status);
+								}
+								#endif
 
-                            else {
-                                if (!thpool_add_work (
-                                    cerver->thpool, 
-                                    (void (*) (void *)) cerver_receive_threads, 
-                                    cr
-                                )) {
-                                    #ifdef HANDLER_DEBUG
-                                    char *status = c_string_create (
-                                        "Added work for sock fd <%d> connection to the thpool!",
-                                        connection->socket->sock_fd
-                                    );
+								retval = cerver_register_new_connection_normal_default_create_detachable (cr);
+							}
 
-                                    if (status) {
-                                        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                                        free (status);
-                                    }
+							else {
+								if (!thpool_add_work (
+									cerver->thpool,
+									(void (*) (void *)) cerver_receive_threads,
+									cr
+								)) {
+									#ifdef HANDLER_DEBUG
+									char *status = c_string_create (
+										"Added work for sock fd <%d> connection to the thpool!",
+										connection->socket->sock_fd
+									);
 
-                                    status = c_string_create (
-                                        "Cerver %s thpool - %d / %d threads working",
-                                        cerver->info->name->str,
-                                        thpool_get_num_threads_working (cerver->thpool),
-                                        cerver->thpool->num_threads_alive
-                                    );
+									if (status) {
+										cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+										free (status);
+									}
 
-                                    if (status) {
-                                        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-                                        free (status);
-                                    }
-                                    #endif
+									status = c_string_create (
+										"Cerver %s thpool - %d / %d threads working",
+										cerver->info->name->str,
+										thpool_get_num_threads_working (cerver->thpool),
+										cerver->thpool->num_threads_alive
+									);
 
-                                    retval = 0;     // success
-                                }
+									if (status) {
+										cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
+										free (status);
+									}
+									#endif
 
-                                else {
-                                    cerver_receive_delete (cr);
-                                }
-                            }
-                        }
-                    }
-                } break;
+									retval = 0;     // success
+								}
 
-                default: break;
-            }
-        }
-    }
+								else {
+									cerver_receive_delete (cr);
+								}
+							}
+						}
+					}
+				} break;
 
-    else {
-        char *status = c_string_create (
-            "cerver_register_new_connection_normal_default () - Failed to create new client for new connection with sock fd <%d>!",
-            connection->socket->sock_fd
-        );
+				default: break;
+			}
+		}
+	}
 
-        if (status) {
-            cerver_log_error (status);
-            free (status);
-        }
-    }
+	else {
+		char *status = c_string_create (
+			"cerver_register_new_connection_normal_default () - Failed to create new client for new connection with sock fd <%d>!",
+			connection->socket->sock_fd
+		);
 
-    return retval;
+		if (status) {
+			cerver_log_error (status);
+			free (status);
+		}
+	}
+
+	return retval;
 
 }
 
 static u8 cerver_register_new_connection_normal (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    switch (cerver->type) {
-        case CERVER_TYPE_WEB: {
-            retval = cerver_register_new_connection_normal_web (cerver, connection);
-        } break;
-        
-        default: {
-            retval = cerver_register_new_connection_normal_default (cerver, connection);
-        } break;
-    }
+	switch (cerver->type) {
+		case CERVER_TYPE_WEB: {
+			retval = cerver_register_new_connection_normal_web (cerver, connection);
+		} break;
 
-    return retval;
+		default: {
+			retval = cerver_register_new_connection_normal_default (cerver, connection);
+		} break;
+	}
+
+	return retval;
 
 }
 
 static inline u8 cerver_register_new_connection_select (Cerver *cerver, Connection *connection) {
 
-    return cerver->auth_required ? 
-        cerver_register_new_connection_auth_required (cerver, connection) :
-        cerver_register_new_connection_normal (cerver, connection);
+	return cerver->auth_required ?
+		cerver_register_new_connection_auth_required (cerver, connection) :
+		cerver_register_new_connection_normal (cerver, connection);
 
 }
 
-static void cerver_register_new_connection (Cerver *cerver, 
-    const i32 new_fd, const struct sockaddr_storage client_address) {
+static void cerver_register_new_connection (Cerver *cerver,
+	const i32 new_fd, const struct sockaddr_storage client_address) {
 
-    Connection *connection = cerver_connection_create (cerver, new_fd, client_address);
-    if (connection) {
-        // #ifdef CERVER_DEBUG
-        char *s = c_string_create ("New connection from IP address: %s -- Port: %d", 
-            connection->ip->str, connection->port);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, s);
-            free (s);
-        }
-        // #endif
+	Connection *connection = cerver_connection_create (cerver, new_fd, client_address);
+	if (connection) {
+		// #ifdef CERVER_DEBUG
+		char *s = c_string_create ("New connection from IP address: %s -- Port: %d",
+			connection->ip->str, connection->port);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, s);
+			free (s);
+		}
+		// #endif
 
-        connection->active = true;
+		connection->active = true;
 
-        if (!cerver_register_new_connection_select (cerver, connection)) {
-            #ifdef CERVER_DEBUG
-            s = c_string_create ("New connection to cerver %s!", cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-                free (s);
-            }
-            #endif
-        }
+		if (!cerver_register_new_connection_select (cerver, connection)) {
+			#ifdef CERVER_DEBUG
+			s = c_string_create ("New connection to cerver %s!", cerver->info->name->str);
+			if (s) {
+				cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
+				free (s);
+			}
+			#endif
+		}
 
-        // internal server error - failed to handle the new connection
-        else {
-            char *status = c_string_create (
-                "cerver_register_new_connection () - internal error - dropping sock fd <%d> connection...",
-                connection->socket->sock_fd
-            );
+		// internal server error - failed to handle the new connection
+		else {
+			char *status = c_string_create (
+				"cerver_register_new_connection () - internal error - dropping sock fd <%d> connection...",
+				connection->socket->sock_fd
+			);
 
-            if (status) {
-                cerver_log_error (status);
-                free (status);
-            }
+			if (status) {
+				cerver_log_error (status);
+				free (status);
+			}
 
-            connection_drop (cerver, connection);
-        }
-    }
+			connection_drop (cerver, connection);
+		}
+	}
 
-    else {
-        // #ifdef CERVER_DEBUG
-        cerver_log_msg (
-            stdout, LOG_TYPE_ERROR, LOG_TYPE_CLIENT, 
-            "cerver_register_new_connection () - failed to create a new connection!"
-        );
-        // #endif
-    }
+	else {
+		// #ifdef CERVER_DEBUG
+		cerver_log_msg (
+			stdout, LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+			"cerver_register_new_connection () - failed to create a new connection!"
+		);
+		// #endif
+	}
 
 }
 
 // accepst a new connection to the cerver
 static void cerver_accept (void *cerver_ptr) {
 
-    if (cerver_ptr) {
-        Cerver *cerver = (Cerver *) cerver_ptr;
+	if (cerver_ptr) {
+		Cerver *cerver = (Cerver *) cerver_ptr;
 
-        struct sockaddr_storage client_address;
-        memset (&client_address, 0, sizeof (struct sockaddr_storage));
-        socklen_t socklen = sizeof (struct sockaddr_storage);
+		struct sockaddr_storage client_address;
+		memset (&client_address, 0, sizeof (struct sockaddr_storage));
+		socklen_t socklen = sizeof (struct sockaddr_storage);
 
-        // accept the new connection
-        i32 new_fd = accept (cerver->sock, (struct sockaddr *) &client_address, &socklen);
-        if (new_fd > 0) {
-            printf ("Accepted fd: %d\n", new_fd);
-            cerver_register_new_connection (cerver, new_fd, client_address);
-        } 
+		// accept the new connection
+		i32 new_fd = accept (cerver->sock, (struct sockaddr *) &client_address, &socklen);
+		if (new_fd > 0) {
+			printf ("Accepted fd: %d\n", new_fd);
+			cerver_register_new_connection (cerver, new_fd, client_address);
+		}
 
-        else {
-            // if we get EWOULDBLOCK, we have accepted all connections
-            if (errno != EWOULDBLOCK) {
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Accept failed!");
-                perror ("Error");
-            } 
-        }
-    }
+		else {
+			// if we get EWOULDBLOCK, we have accepted all connections
+			if (errno != EWOULDBLOCK) {
+				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Accept failed!");
+				perror ("Error");
+			}
+		}
+	}
 
 }
 
@@ -2569,87 +2569,87 @@ static void cerver_accept (void *cerver_ptr) {
 // returns 0 on success, 1 on error
 u8 cerver_realloc_main_poll_fds (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        u32 current_max = cerver->max_n_fds;
-        cerver->max_n_fds *= 2;
-        cerver->fds = (struct pollfd *) realloc (cerver->fds, cerver->max_n_fds * sizeof (struct pollfd));
-        if (cerver->fds) {
-            #pragma GCC diagnostic push
-            #pragma GCC diagnostic ignored "-Wunused-value"
+	if (cerver) {
+		u32 current_max = cerver->max_n_fds;
+		cerver->max_n_fds *= 2;
+		cerver->fds = (struct pollfd *) realloc (cerver->fds, cerver->max_n_fds * sizeof (struct pollfd));
+		if (cerver->fds) {
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wunused-value"
 
-            for (u32 i = current_max; i < cerver->max_n_fds; i++)
-                cerver->fds[i].fd == -1;
+			for (u32 i = current_max; i < cerver->max_n_fds; i++)
+				cerver->fds[i].fd == -1;
 
-            #pragma GCC diagnostic pop
+			#pragma GCC diagnostic pop
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // get a free index in the main cerver poll array
 i32 cerver_poll_get_free_idx (Cerver *cerver) {
 
-    if (cerver) {
-        for (u32 i = 0; i < cerver->max_n_fds; i++)
-            if (cerver->fds[i].fd == -1) return i;
-    }
+	if (cerver) {
+		for (u32 i = 0; i < cerver->max_n_fds; i++)
+			if (cerver->fds[i].fd == -1) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
 // get the idx of the connection sock fd in the cerver poll fds
 i32 cerver_poll_get_idx_by_sock_fd (Cerver *cerver, i32 sock_fd) {
 
-    if (cerver) {
-        for (u32 i = 0; i < cerver->max_n_fds; i++)
-            if (cerver->fds[i].fd == sock_fd) return i;
-    }
+	if (cerver) {
+		for (u32 i = 0; i < cerver->max_n_fds; i++)
+			if (cerver->fds[i].fd == sock_fd) return i;
+	}
 
-    return -1;
+	return -1;
 
 }
 
 static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    i32 idx = cerver_poll_get_free_idx (cerver);
-    if (idx > 0) {
-        cerver->fds[idx].fd = connection->socket->sock_fd;
-        cerver->fds[idx].events = POLLIN;
-        cerver->current_n_fds++;
+	i32 idx = cerver_poll_get_free_idx (cerver);
+	if (idx > 0) {
+		cerver->fds[idx].fd = connection->socket->sock_fd;
+		cerver->fds[idx].events = POLLIN;
+		cerver->current_n_fds++;
 
-        cerver->stats->current_active_client_connections++;
+		cerver->stats->current_active_client_connections++;
 
-        #ifdef CERVER_DEBUG
-        char *s = c_string_create ("Added sock fd <%d> to cerver %s MAIN poll, idx: %i", 
-            connection->socket->sock_fd, cerver->info->name->str, idx);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-            free (s);
-        }
-        #endif
+		#ifdef CERVER_DEBUG
+		char *s = c_string_create ("Added sock fd <%d> to cerver %s MAIN poll, idx: %i",
+			connection->socket->sock_fd, cerver->info->name->str, idx);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
+			free (s);
+		}
+		#endif
 
-        #ifdef CERVER_STATS
-        char *status = c_string_create ("Cerver %s current active connections: %ld", 
-            cerver->info->name->str, cerver->stats->current_active_client_connections);
-        if (status) {
-            cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
-            free (status);
-        }
-        #endif
+		#ifdef CERVER_STATS
+		char *status = c_string_create ("Cerver %s current active connections: %ld",
+			cerver->info->name->str, cerver->stats->current_active_client_connections);
+		if (status) {
+			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
+			free (status);
+		}
+		#endif
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2658,43 +2658,43 @@ static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *
 // returns 0 on success, 1 on error
 u8 cerver_poll_register_connection (Cerver *cerver, Connection *connection) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver && connection) {
-        pthread_mutex_lock (cerver->poll_lock);
+	if (cerver && connection) {
+		pthread_mutex_lock (cerver->poll_lock);
 
-        if (!cerver_poll_register_connection_internal (cerver, connection)) {
-            retval = 0;
-        }
+		if (!cerver_poll_register_connection_internal (cerver, connection)) {
+			retval = 0;
+		}
 
-        else {
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Cerver %s main poll is full -- we need to realloc...", 
-                cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, s);
-                free (s);
-            }
-            #endif
-            if (cerver_realloc_main_poll_fds (cerver)) {
-                char *s = c_string_create ("Failed to realloc cerver %s main poll fds!", 
-                    cerver->info->name->str);
-                if (s) {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                    free (s);
-                }
-            }
+		else {
+			#ifdef CERVER_DEBUG
+			char *s = c_string_create ("Cerver %s main poll is full -- we need to realloc...",
+				cerver->info->name->str);
+			if (s) {
+				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, s);
+				free (s);
+			}
+			#endif
+			if (cerver_realloc_main_poll_fds (cerver)) {
+				char *s = c_string_create ("Failed to realloc cerver %s main poll fds!",
+					cerver->info->name->str);
+				if (s) {
+					cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
+					free (s);
+				}
+			}
 
-            // try again to register the connection
-            else {
-                retval = cerver_poll_register_connection_internal (cerver, connection);
-            }
-        }
+			// try again to register the connection
+			else {
+				retval = cerver_poll_register_connection_internal (cerver, connection);
+			}
+		}
 
-        pthread_mutex_unlock (cerver->poll_lock);
-    }
+		pthread_mutex_unlock (cerver->poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2702,56 +2702,56 @@ u8 cerver_poll_register_connection (Cerver *cerver, Connection *connection) {
 // returns 0 on success, 1 on error
 u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        pthread_mutex_lock (cerver->poll_lock);
+	if (cerver) {
+		pthread_mutex_lock (cerver->poll_lock);
 
-        // get the idx of the sock fd in the cerver poll fds
-        i32 idx = cerver_poll_get_idx_by_sock_fd (cerver, sock_fd);
-        if (idx > 0) {
-            cerver->fds[idx].fd = -1;
-            cerver->fds[idx].events = -1;
-            cerver->current_n_fds--;
+		// get the idx of the sock fd in the cerver poll fds
+		i32 idx = cerver_poll_get_idx_by_sock_fd (cerver, sock_fd);
+		if (idx > 0) {
+			cerver->fds[idx].fd = -1;
+			cerver->fds[idx].events = -1;
+			cerver->current_n_fds--;
 
-            cerver->stats->current_active_client_connections--;
+			cerver->stats->current_active_client_connections--;
 
-            #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Removed sock fd <%d> from cerver %s MAIN poll, idx: %d",
-                sock_fd, cerver->info->name->str, idx);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-                free (s);
-            }
-            #endif
+			#ifdef CERVER_DEBUG
+			char *s = c_string_create ("Removed sock fd <%d> from cerver %s MAIN poll, idx: %d",
+				sock_fd, cerver->info->name->str, idx);
+			if (s) {
+				cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
+				free (s);
+			}
+			#endif
 
-            #ifdef CERVER_STATS
-            char *status = c_string_create ("Cerver %s current active connections: %ld", 
-                cerver->info->name->str, cerver->stats->current_active_client_connections);
-            if (status) {
-                cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
-                free (status);
-            }
-            #endif
+			#ifdef CERVER_STATS
+			char *status = c_string_create ("Cerver %s current active connections: %ld",
+				cerver->info->name->str, cerver->stats->current_active_client_connections);
+			if (status) {
+				cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
+				free (status);
+			}
+			#endif
 
-            retval = 0;     // removed the sock fd form the cerver poll
-        }
+			retval = 0;     // removed the sock fd form the cerver poll
+		}
 
-        else {
-            // #ifdef CERVER_DEBUG
-            char *s = c_string_create ("Sock fd <%d> was NOT found in cerver %s MAIN poll!",
-                sock_fd, cerver->info->name->str);
-            if (s) {
-                cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
-                free (s);
-            }
-            // #endif
-        }
+		else {
+			// #ifdef CERVER_DEBUG
+			char *s = c_string_create ("Sock fd <%d> was NOT found in cerver %s MAIN poll!",
+				sock_fd, cerver->info->name->str);
+			if (s) {
+				cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
+				free (s);
+			}
+			// #endif
+		}
 
-        pthread_mutex_unlock (cerver->poll_lock);
-    }
+		pthread_mutex_unlock (cerver->poll_lock);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2759,191 +2759,191 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 // returns 0 on success, 1 on error
 u8 cerver_poll_unregister_connection (Cerver *cerver, Connection *connection) {
 
-    return (cerver && connection) ?
-        cerver_poll_unregister_sock_fd (cerver, connection->socket->sock_fd) : 1;
+	return (cerver && connection) ?
+		cerver_poll_unregister_sock_fd (cerver, connection->socket->sock_fd) : 1;
 
 }
 
 static inline void cerver_poll_handle_actual_accept (Cerver *cerver) {
 
-    if (cerver->thpool) {
-        if (thpool_add_work (cerver->thpool, cerver_accept, cerver))  {
-            char *s = c_string_create (
-                "Failed to add cerver_accept () to cerver's %s thpool!",
-                cerver->info->name->str
-            );
+	if (cerver->thpool) {
+		if (thpool_add_work (cerver->thpool, cerver_accept, cerver))  {
+			char *s = c_string_create (
+				"Failed to add cerver_accept () to cerver's %s thpool!",
+				cerver->info->name->str
+			);
 
-            if (s) {
-                cerver_log_error (s);
-                free (s);
-            }
-        }
-    }
+			if (s) {
+				cerver_log_error (s);
+				free (s);
+			}
+		}
+	}
 
-    else {
-        cerver_accept (cerver);
-    }
+	else {
+		cerver_accept (cerver);
+	}
 
 }
 
 static inline void cerver_poll_handle_actual_receive (Cerver *cerver, const u32 idx, CerverReceive *cr) {
 
-    switch (cerver->fds[idx].revents) {
-        // A connection setup has been completed or new data arrived
-        case POLLIN: {
-            // printf ("Receive fd: %d\n", cerver->fds[i].fd);
-                
-            if (cerver->thpool) {
-                // pthread_mutex_lock (socket->mutex);
+	switch (cerver->fds[idx].revents) {
+		// A connection setup has been completed or new data arrived
+		case POLLIN: {
+			// printf ("Receive fd: %d\n", cerver->fds[i].fd);
 
-                // handle received packets using multiple threads
-                // if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
-                //     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!", 
-                //         cerver->info->name->str);
-                //     if (s) {
-                //         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-                //         free (s);
-                //     }
-                // }
+			if (cerver->thpool) {
+				// pthread_mutex_lock (socket->mutex);
 
-                // 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
-                // and the received buffer handler method is the one that is called 
-                // inside the thread pool - using this method we were able to get a correct behaviour
-                // however, we still may have room form improvement as we original though ->
-                // by performing reading also inside the thpool
-                cerver_receive (cr);
+				// handle received packets using multiple threads
+				// if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
+				//     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!",
+				//         cerver->info->name->str);
+				//     if (s) {
+				//         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
+				//         free (s);
+				//     }
+				// }
 
-                // pthread_mutex_unlock (socket->mutex);
-            }
+				// 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
+				// and the received buffer handler method is the one that is called
+				// inside the thread pool - using this method we were able to get a correct behaviour
+				// however, we still may have room form improvement as we original though ->
+				// by performing reading also inside the thpool
+				cerver_receive (cr);
 
-            else {
-                // handle all received packets in the same thread
-                cerver_receive (cr);
-            }
-        } break;
+				// pthread_mutex_unlock (socket->mutex);
+			}
 
-        // A disconnection request has been initiated by the other end
-        // or a connection is broken (SIGPIPE is also set when we try to write to it)
-        // or The other end has shut down one direction
-        case POLLHUP: {
-            // printf ("POLLHUP\n");
-            cerver_switch_receive_handle_failed (cr);
-        } break;
+			else {
+				// handle all received packets in the same thread
+				cerver_receive (cr);
+			}
+		} break;
 
-        // An asynchronous error occurred
-        case POLLERR: {
-            // printf ("POLLERR\n");
-            cerver_switch_receive_handle_failed (cr);
-        } break;
+		// A disconnection request has been initiated by the other end
+		// or a connection is broken (SIGPIPE is also set when we try to write to it)
+		// or The other end has shut down one direction
+		case POLLHUP: {
+			// printf ("POLLHUP\n");
+			cerver_switch_receive_handle_failed (cr);
+		} break;
 
-        // Urgent data arrived. SIGURG is sent then.
-        case POLLPRI: {
-        } break;
+		// An asynchronous error occurred
+		case POLLERR: {
+			// printf ("POLLERR\n");
+			cerver_switch_receive_handle_failed (cr);
+		} break;
 
-        default: {
-            if (cerver->fds[idx].revents != 0) {
-                // 17/06/2020 -- 15:06 -- handle as failed any other signal
-                // to avoid hanging up at 100% or getting a segfault
-                cerver_switch_receive_handle_failed (cr);
-            }
-        } break;
-    }
+		// Urgent data arrived. SIGURG is sent then.
+		case POLLPRI: {
+		} break;
+
+		default: {
+			if (cerver->fds[idx].revents != 0) {
+				// 17/06/2020 -- 15:06 -- handle as failed any other signal
+				// to avoid hanging up at 100% or getting a segfault
+				cerver_switch_receive_handle_failed (cr);
+			}
+		} break;
+	}
 
 }
 
 static inline void cerver_poll_handle (Cerver *cerver) {
 
-    if (cerver) {
-        if (cerver->thpool) pthread_mutex_lock (cerver->poll_lock);
-    
-        // one or more fd(s) are readable, need to determine which ones they are
-        for (u32 idx = 0; idx < cerver->max_n_fds; idx++) {
-            if (cerver->fds[idx].fd != -1) {
-                if (idx == 0) {
-                    cerver_poll_handle_actual_accept (cerver);
-                }
+	if (cerver) {
+		if (cerver->thpool) pthread_mutex_lock (cerver->poll_lock);
 
-                else {
-                    CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_NORMAL, cerver, cerver->fds[idx].fd);
-                    if (cr) {
-                        cerver_poll_handle_actual_receive (cerver, idx, cr);
-                    }
-                }
-            }
-        }
+		// one or more fd(s) are readable, need to determine which ones they are
+		for (u32 idx = 0; idx < cerver->max_n_fds; idx++) {
+			if (cerver->fds[idx].fd != -1) {
+				if (idx == 0) {
+					cerver_poll_handle_actual_accept (cerver);
+				}
 
-        if (cerver->thpool) pthread_mutex_unlock (cerver->poll_lock);
-    }
+				else {
+					CerverReceive *cr = cerver_receive_create (RECEIVE_TYPE_NORMAL, cerver, cerver->fds[idx].fd);
+					if (cr) {
+						cerver_poll_handle_actual_receive (cerver, idx, cr);
+					}
+				}
+			}
+		}
+
+		if (cerver->thpool) pthread_mutex_unlock (cerver->poll_lock);
+	}
 
 }
 
 // cerver poll loop to handle events in the registered socket's fds
 u8 cerver_poll (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-            free (s);
-        }
-        #ifdef CERVER_DEBUG
-        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
-        #endif
+	if (cerver) {
+		char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
+			free (s);
+		}
+		#ifdef CERVER_DEBUG
+		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
+		#endif
 
-        int poll_retval = 0;
-        while (cerver->isRunning) {
-            poll_retval = poll (cerver->fds, cerver->max_n_fds, cerver->poll_timeout);
+		int poll_retval = 0;
+		while (cerver->isRunning) {
+			poll_retval = poll (cerver->fds, cerver->max_n_fds, cerver->poll_timeout);
 
-            switch (poll_retval) {
-                case -1: {
-                    char *s = c_string_create ("Cerver %s main poll has failed!", cerver->info->name->str);
-                    if (s) {
-                        cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
-                        free (s);
-                    }
+			switch (poll_retval) {
+				case -1: {
+					char *s = c_string_create ("Cerver %s main poll has failed!", cerver->info->name->str);
+					if (s) {
+						cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
+						free (s);
+					}
 
-                    perror ("Error");
-                    cerver->isRunning = false;
-                } break;
+					perror ("Error");
+					cerver->isRunning = false;
+				} break;
 
-                case 0: {
-                    // #ifdef CERVER_DEBUG
-                    // char *status = c_string_create ("Cerver %s MAIN poll timeout", cerver->info->name->str);
-                    // if (status) {
-                    //     cerver_log_debug (status);
-                    //     free (status);
-                    // }
-                    // #endif
-                } break;
+				case 0: {
+					// #ifdef CERVER_DEBUG
+					// char *status = c_string_create ("Cerver %s MAIN poll timeout", cerver->info->name->str);
+					// if (status) {
+					//     cerver_log_debug (status);
+					//     free (status);
+					// }
+					// #endif
+				} break;
 
-                default: {
-                    cerver_poll_handle (cerver);
-                } break;
-            }
-        }
+				default: {
+					cerver_poll_handle (cerver);
+				} break;
+			}
+		}
 
-        #ifdef CERVER_DEBUG
-        s = c_string_create ("Cerver %s main poll has stopped!", cerver->info->name->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
-            free (s);
-        }
-        #endif
+		#ifdef CERVER_DEBUG
+		s = c_string_create ("Cerver %s main poll has stopped!", cerver->info->name->str);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
+			free (s);
+		}
+		#endif
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        cerver_log_msg (
-            stderr, 
-            LOG_TYPE_ERROR, LOG_TYPE_CERVER, 
-            "Can't listen for connections on a NULL cerver!"
-        );
-    }
+	else {
+		cerver_log_msg (
+			stderr,
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Can't listen for connections on a NULL cerver!"
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -2954,42 +2954,42 @@ u8 cerver_poll (Cerver *cerver) {
 // handle new connections in dedicated threads
 u8 cerver_threads (Cerver *cerver) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (cerver) {
-        char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-            free (s);
-        }
-        #ifdef CERVER_DEBUG
-        cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
-        #endif
+	if (cerver) {
+		char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
+			free (s);
+		}
+		#ifdef CERVER_DEBUG
+		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
+		#endif
 
-        while (cerver->isRunning) {
-            cerver_accept (cerver);
-        }
+		while (cerver->isRunning) {
+			cerver_accept (cerver);
+		}
 
-        #ifdef CERVER_DEBUG
-        s = c_string_create ("Cerver %s accept thread has stopped!", cerver->info->name->str);
-        if (s) {
-            cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
-            free (s);
-        }
-        #endif
+		#ifdef CERVER_DEBUG
+		s = c_string_create ("Cerver %s accept thread has stopped!", cerver->info->name->str);
+		if (s) {
+			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
+			free (s);
+		}
+		#endif
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    else {
-        cerver_log_msg (
-            stderr, 
-            LOG_TYPE_ERROR, LOG_TYPE_CERVER, 
-            "Can't listen for connections on a NULL cerver!"
-        );
-    }
+	else {
+		cerver_log_msg (
+			stderr,
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Can't listen for connections on a NULL cerver!"
+		);
+	}
 
-    return retval;
+	return retval;
 
 }
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -2085,11 +2085,11 @@ static u8 cerver_register_new_connection_auth_required (Cerver *cerver, Connecti
 
 	if (!on_hold_connection (cerver, connection)) {
 		#ifdef CERVER_DEBUG
-		char *status = c_string_create ("Connection is on hold on cerver %s!", cerver->info->name->str);
-		if (status) {
-			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, status);
-			free (status);
-		}
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Connection is on hold on cerver %s!",
+			cerver->info->name->str
+		);
 		#endif
 
 		cerver->stats->total_on_hold_connections += 1;
@@ -2108,12 +2108,10 @@ static u8 cerver_register_new_connection_auth_required (Cerver *cerver, Connecti
 	}
 
 	else {
-		char *status = c_string_create ("Failed to put connection on hold in cerver %s",
-			cerver->info->name->str);
-		if (status) {
-			cerver_log_error (status);
-			free (status);
-		}
+		cerver_log_error (
+			"Failed to put connection on hold in cerver %s",
+			cerver->info->name->str
+		);
 	}
 
 	return retval;
@@ -2133,15 +2131,11 @@ static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection 
 	if (cr) {
 		if (thpool_is_full (cerver->thpool)) {
 			#ifdef HANDLER_DEBUG
-			char *status = c_string_create (
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 				"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
 				cerver->info->name->str, connection->socket->sock_fd
 			);
-
-			if (status) {
-				cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-				free (status);
-			}
 			#endif
 
 			pthread_t thread_id = 0;
@@ -2166,27 +2160,19 @@ static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection 
 				cr
 			)) {
 				#ifdef HANDLER_DEBUG
-				char *status = c_string_create (
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 					"Added work for sock fd <%d> connection to the thpool!",
 					connection->socket->sock_fd
 				);
 
-				if (status) {
-					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-					free (status);
-				}
-
-				status = c_string_create (
+				cerver_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 					"Cerver %s thpool - %d / %d threads working",
 					cerver->info->name->str,
 					thpool_get_num_threads_working (cerver->thpool),
 					cerver->thpool->num_threads_alive
 				);
-
-				if (status) {
-					cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-					free (status);
-				}
 				#endif
 
 				retval = 0;     // success
@@ -2213,30 +2199,21 @@ static u8 cerver_register_new_connection_normal_default_create_detachable (Cerve
 		cr
 	)) {
 		#ifdef HANDLER_DEBUG
-		char *status = c_string_create (
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 			"Created detachable thread for sock fd <%d> connection",
 			cr->connection->socket->sock_fd
 		);
-
-		if (status) {
-			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-			free (status);
-		}
 		#endif
 
 		retval = 0;     // success
 	}
 
 	else {
-		char *status = c_string_create (
+		cerver_log_error (
 			"cerver_register_new_connection_normal_default () - Failed to create detachable thread for sock fd <%d> connection!",
 			cr->connection->socket->sock_fd
 		);
-
-		if (status) {
-			cerver_log_error (status);
-			free (status);
-		}
 
 		cerver_receive_delete (cr);
 	}
@@ -2290,15 +2267,11 @@ static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connect
 						else {
 							if (thpool_is_full (cerver->thpool)) {
 								#ifdef HANDLER_DEBUG
-								char *status = c_string_create (
+								cerver_log (
+									LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 									"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
 									cerver->info->name->str, connection->socket->sock_fd
 								);
-
-								if (status) {
-									cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-									free (status);
-								}
 								#endif
 
 								retval = cerver_register_new_connection_normal_default_create_detachable (cr);
@@ -2311,27 +2284,19 @@ static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connect
 									cr
 								)) {
 									#ifdef HANDLER_DEBUG
-									char *status = c_string_create (
+									cerver_log (
+										LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 										"Added work for sock fd <%d> connection to the thpool!",
 										connection->socket->sock_fd
 									);
 
-									if (status) {
-										cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-										free (status);
-									}
-
-									status = c_string_create (
+									cerver_log (
+										LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
 										"Cerver %s thpool - %d / %d threads working",
 										cerver->info->name->str,
 										thpool_get_num_threads_working (cerver->thpool),
 										cerver->thpool->num_threads_alive
 									);
-
-									if (status) {
-										cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, status);
-										free (status);
-									}
 									#endif
 
 									retval = 0;     // success
@@ -2351,15 +2316,10 @@ static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connect
 	}
 
 	else {
-		char *status = c_string_create (
+		cerver_log_error (
 			"cerver_register_new_connection_normal_default () - Failed to create new client for new connection with sock fd <%d>!",
 			connection->socket->sock_fd
 		);
-
-		if (status) {
-			cerver_log_error (status);
-			free (status);
-		}
 	}
 
 	return retval;
@@ -2392,43 +2352,38 @@ static inline u8 cerver_register_new_connection_select (Cerver *cerver, Connecti
 
 }
 
-static void cerver_register_new_connection (Cerver *cerver,
-	const i32 new_fd, const struct sockaddr_storage client_address) {
+static void cerver_register_new_connection (
+	Cerver *cerver,
+	const i32 new_fd, const struct sockaddr_storage client_address
+) {
 
 	Connection *connection = cerver_connection_create (cerver, new_fd, client_address);
 	if (connection) {
 		// #ifdef CERVER_DEBUG
-		char *s = c_string_create ("New connection from IP address: %s -- Port: %d",
-			connection->ip->str, connection->port);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+			"New connection from IP address: %s -- Port: %d",
+			connection->ip->str, connection->port
+		);
 		// #endif
 
 		connection->active = true;
 
 		if (!cerver_register_new_connection_select (cerver, connection)) {
 			#ifdef CERVER_DEBUG
-			s = c_string_create ("New connection to cerver %s!", cerver->info->name->str);
-			if (s) {
-				cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-				free (s);
-			}
+			cerver_log (
+				LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+				"New connection to cerver %s!", cerver->info->name->str
+			);
 			#endif
 		}
 
 		// internal server error - failed to handle the new connection
 		else {
-			char *status = c_string_create (
+			cerver_log_error (
 				"cerver_register_new_connection () - internal error - dropping sock fd <%d> connection...",
 				connection->socket->sock_fd
 			);
-
-			if (status) {
-				cerver_log_error (status);
-				free (status);
-			}
 
 			connection_drop (cerver, connection);
 		}
@@ -2436,8 +2391,8 @@ static void cerver_register_new_connection (Cerver *cerver,
 
 	else {
 		// #ifdef CERVER_DEBUG
-		cerver_log_msg (
-			stdout, LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
 			"cerver_register_new_connection () - failed to create a new connection!"
 		);
 		// #endif
@@ -2465,7 +2420,7 @@ static void cerver_accept (void *cerver_ptr) {
 		else {
 			// if we get EWOULDBLOCK, we have accepted all connections
 			if (errno != EWOULDBLOCK) {
-				cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Accept failed!");
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Accept failed!");
 				perror ("Error");
 			}
 		}
@@ -2541,21 +2496,19 @@ static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *
 		cerver->stats->current_active_client_connections++;
 
 		#ifdef CERVER_DEBUG
-		char *s = c_string_create ("Added sock fd <%d> to cerver %s MAIN poll, idx: %i",
-			connection->socket->sock_fd, cerver->info->name->str, idx);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Added sock fd <%d> to cerver %s MAIN poll, idx: %i",
+			connection->socket->sock_fd, cerver->info->name->str, idx
+		);
 		#endif
 
 		#ifdef CERVER_STATS
-		char *status = c_string_create ("Cerver %s current active connections: %ld",
-			cerver->info->name->str, cerver->stats->current_active_client_connections);
-		if (status) {
-			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
-			free (status);
-		}
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Cerver %s current active connections: %ld",
+			cerver->info->name->str, cerver->stats->current_active_client_connections
+		);
 		#endif
 
 		retval = 0;
@@ -2581,20 +2534,19 @@ u8 cerver_poll_register_connection (Cerver *cerver, Connection *connection) {
 
 		else {
 			#ifdef CERVER_DEBUG
-			char *s = c_string_create ("Cerver %s main poll is full -- we need to realloc...",
-				cerver->info->name->str);
-			if (s) {
-				cerver_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, s);
-				free (s);
-			}
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_NONE,
+				"Cerver %s main poll is full -- we need to realloc...",
+				cerver->info->name->str
+			);
 			#endif
+
 			if (cerver_realloc_main_poll_fds (cerver)) {
-				char *s = c_string_create ("Failed to realloc cerver %s main poll fds!",
-					cerver->info->name->str);
-				if (s) {
-					cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-					free (s);
-				}
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_NONE,
+					"Failed to realloc cerver %s main poll fds!",
+					cerver->info->name->str
+				);
 			}
 
 			// try again to register the connection
@@ -2629,21 +2581,19 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 			cerver->stats->current_active_client_connections--;
 
 			#ifdef CERVER_DEBUG
-			char *s = c_string_create ("Removed sock fd <%d> from cerver %s MAIN poll, idx: %d",
-				sock_fd, cerver->info->name->str, idx);
-			if (s) {
-				cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, s);
-				free (s);
-			}
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"Removed sock fd <%d> from cerver %s MAIN poll, idx: %d",
+				sock_fd, cerver->info->name->str, idx
+			);
 			#endif
 
 			#ifdef CERVER_STATS
-			char *status = c_string_create ("Cerver %s current active connections: %ld",
-				cerver->info->name->str, cerver->stats->current_active_client_connections);
-			if (status) {
-				cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, status);
-				free (status);
-			}
+			cerver_log (
+				LOG_TYPE_CERVER, LOG_TYPE_NONE,
+				"Cerver %s current active connections: %ld",
+				cerver->info->name->str, cerver->stats->current_active_client_connections
+			);
 			#endif
 
 			retval = 0;     // removed the sock fd form the cerver poll
@@ -2651,12 +2601,11 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 
 		else {
 			// #ifdef CERVER_DEBUG
-			char *s = c_string_create ("Sock fd <%d> was NOT found in cerver %s MAIN poll!",
-				sock_fd, cerver->info->name->str);
-			if (s) {
-				cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_CERVER, s);
-				free (s);
-			}
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+				"Sock fd <%d> was NOT found in cerver %s MAIN poll!",
+				sock_fd, cerver->info->name->str
+			);
 			// #endif
 		}
 
@@ -2680,15 +2629,10 @@ static inline void cerver_poll_handle_actual_accept (Cerver *cerver) {
 
 	if (cerver->thpool) {
 		if (thpool_add_work (cerver->thpool, cerver_accept, cerver))  {
-			char *s = c_string_create (
+			cerver_log_error (
 				"Failed to add cerver_accept () to cerver's %s thpool!",
 				cerver->info->name->str
 			);
-
-			if (s) {
-				cerver_log_error (s);
-				free (s);
-			}
 		}
 	}
 
@@ -2710,12 +2654,11 @@ static inline void cerver_poll_handle_actual_receive (Cerver *cerver, const u32 
 
 				// handle received packets using multiple threads
 				// if (thpool_add_work (cerver->thpool, cerver_receive, cr)) {
-				//     char *s = c_string_create ("Failed to add cerver_receive () to cerver's %s thpool!",
-				//         cerver->info->name->str);
-				//     if (s) {
-				//         cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, s);
-				//         free (s);
-				//     }
+				// 	cerver_log (
+				// 		LOG_TYPE_ERROR, LOG_TYPE_NONE,
+				// 		"Failed to add cerver_receive () to cerver's %s thpool!",
+				//         cerver->info->name->str
+				// 	);
 				// }
 
 				// 28/05/2020 -- 02:43 -- handling all recv () calls from the main thread
@@ -2795,13 +2738,14 @@ u8 cerver_poll (Cerver *cerver) {
 	u8 retval = 1;
 
 	if (cerver) {
-		char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+			"Cerver %s ready in port %d!",
+			cerver->info->name->str, cerver->port
+		);
+
 		#ifdef CERVER_DEBUG
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
 		#endif
 
 		int poll_retval = 0;
@@ -2810,11 +2754,10 @@ u8 cerver_poll (Cerver *cerver) {
 
 			switch (poll_retval) {
 				case -1: {
-					char *s = c_string_create ("Cerver %s main poll has failed!", cerver->info->name->str);
-					if (s) {
-						cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, s);
-						free (s);
-					}
+					cerver_log (
+						LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+						"Cerver %s main poll has failed!", cerver->info->name->str
+					);
 
 					perror ("Error");
 					cerver->isRunning = false;
@@ -2822,11 +2765,9 @@ u8 cerver_poll (Cerver *cerver) {
 
 				case 0: {
 					// #ifdef CERVER_DEBUG
-					// char *status = c_string_create ("Cerver %s MAIN poll timeout", cerver->info->name->str);
-					// if (status) {
-					//     cerver_log_debug (status);
-					//     free (status);
-					// }
+					// cerver_log_debug (
+					// 	"Cerver %s MAIN poll timeout", cerver->info->name->str
+					// );
 					// #endif
 				} break;
 
@@ -2837,19 +2778,17 @@ u8 cerver_poll (Cerver *cerver) {
 		}
 
 		#ifdef CERVER_DEBUG
-		s = c_string_create ("Cerver %s main poll has stopped!", cerver->info->name->str);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Cerver %s main poll has stopped!", cerver->info->name->str
+		);
 		#endif
 
 		retval = 0;
 	}
 
 	else {
-		cerver_log_msg (
-			stderr,
+		cerver_log (
 			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
 			"Can't listen for connections on a NULL cerver!"
 		);
@@ -2869,13 +2808,14 @@ u8 cerver_threads (Cerver *cerver) {
 	u8 retval = 1;
 
 	if (cerver) {
-		char *s = c_string_create ("Cerver %s ready in port %d!", cerver->info->name->str, cerver->port);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_CERVER, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_SUCCESS, LOG_TYPE_CERVER,
+			"Cerver %s ready in port %d!",
+			cerver->info->name->str, cerver->port
+		);
+
 		#ifdef CERVER_DEBUG
-		cerver_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
+		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
 		#endif
 
 		while (cerver->isRunning) {
@@ -2883,19 +2823,17 @@ u8 cerver_threads (Cerver *cerver) {
 		}
 
 		#ifdef CERVER_DEBUG
-		s = c_string_create ("Cerver %s accept thread has stopped!", cerver->info->name->str);
-		if (s) {
-			cerver_log_msg (stdout, LOG_TYPE_CERVER, LOG_TYPE_NONE, s);
-			free (s);
-		}
+		cerver_log (
+			LOG_TYPE_CERVER, LOG_TYPE_NONE,
+			"Cerver %s accept thread has stopped!", cerver->info->name->str
+		);
 		#endif
 
 		retval = 0;
 	}
 
 	else {
-		cerver_log_msg (
-			stderr,
+		cerver_log (
 			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
 			"Can't listen for connections on a NULL cerver!"
 		);

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1936,7 +1936,7 @@ static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *htt
 
 						default: {
 							#ifdef HANDLER_DEBUG
-							cerver_log_msg (
+							cerver_log (
 								LOG_TYPE_ERROR, LOG_TYPE_CERVER,
 								"cerver_receive_http () - rc < 0 - sock fd: %d",
 								cr->socket->sock_fd
@@ -1951,7 +1951,7 @@ static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *htt
 
 			case 0: {
 				#ifdef HANDLER_DEBUG
-				cerver_log_msg (
+				cerver_log (
 					LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
 					"cerver_receive_http () - rc == 0 - sock fd: %d",
 					cr->socket->sock_fd
@@ -1984,7 +1984,7 @@ static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *htt
 	}
 
 	else {
-		cerver_log_msg (
+		cerver_log (
 			LOG_TYPE_ERROR, LOG_TYPE_HANDLER,
 			"cerver_receive_http () - Failed to allocate packet buffer for connection with sock fd <%d>!",
 			cr->connection->socket->sock_fd

--- a/src/cerver/input.c
+++ b/src/cerver/input.c
@@ -60,7 +60,6 @@ unsigned int input_password (char *password) {
 		new_term = old_term;
 		new_term.c_lflag &= ~ECHO;
 		if (!tcsetattr (fileno (stdin), TCSAFLUSH, &new_term) != 0) {
-			printf ("Enter password: ");
 			scanf ("%128s", password);
 
 			/* Restore terminal. */

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -37,7 +37,7 @@ char *sock_ip_to_string (const struct sockaddr *address) {
 			switch (address->sa_family) {
 				case AF_INET:
 					inet_ntop (
-						AF_INET, 
+						AF_INET,
 						&((struct sockaddr_in *) address)->sin_addr,
 						ipstr, INET6_ADDRSTRLEN
 					);
@@ -45,7 +45,7 @@ char *sock_ip_to_string (const struct sockaddr *address) {
 
 				case AF_INET6:
 					inet_ntop (
-						AF_INET6, 
+						AF_INET6,
 						&((struct sockaddr_in6 *) address)->sin6_addr,
 						ipstr, INET6_ADDRSTRLEN
 					);
@@ -121,8 +121,8 @@ int sock_set_timeout (int sock_fd, time_t timeout) {
 	tv.tv_usec = 0;
 
 	return setsockopt (
-		sock_fd, 
-		SOL_SOCKET, SO_RCVTIMEO, 
+		sock_fd,
+		SOL_SOCKET, SO_RCVTIMEO,
 		(const char *) &tv, sizeof (struct timeval)
 	);
 

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -42,13 +42,13 @@ void packets_set_protocol_version (ProtocolVersion version) { protocol_version =
 
 PacketVersion *packet_version_new (void) {
 
-    PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
-    if (version) {
-        version->protocol_id = 0;
-        version->protocol_version.minor = version->protocol_version.major = 0;
-    }
+	PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
+	if (version) {
+		version->protocol_id = 0;
+		version->protocol_version.minor = version->protocol_version.major = 0;
+	}
 
-    return version;
+	return version;
 
 }
 
@@ -56,22 +56,22 @@ void packet_version_delete (PacketVersion *version) { if (version) free (version
 
 PacketVersion *packet_version_create (void) {
 
-    PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
-    if (version) {
-        version->protocol_id = protocol_id;
-        version->protocol_version = protocol_version;
-    }
+	PacketVersion *version = (PacketVersion *) malloc (sizeof (PacketVersion));
+	if (version) {
+		version->protocol_id = protocol_id;
+		version->protocol_version = protocol_version;
+	}
 
-    return version;
+	return version;
 
 }
 
 void packet_version_print (PacketVersion *version) {
 
-    if (version) {
-        printf ("Protocol id: %d\n", version->protocol_id);
-        printf ("Protocol version: { %d - %d }\n", version->protocol_version.major, version->protocol_version.minor);        
-    }
+	if (version) {
+		printf ("Protocol id: %d\n", version->protocol_id);
+		printf ("Protocol version: { %d - %d }\n", version->protocol_version.major, version->protocol_version.minor);
+	}
 
 }
 
@@ -81,9 +81,9 @@ void packet_version_print (PacketVersion *version) {
 
 PacketsPerType *packets_per_type_new (void) {
 
-    PacketsPerType *packets_per_type = (PacketsPerType *) malloc (sizeof (PacketsPerType));
-    if (packets_per_type) memset (packets_per_type, 0, sizeof (PacketsPerType));
-    return packets_per_type;
+	PacketsPerType *packets_per_type = (PacketsPerType *) malloc (sizeof (PacketsPerType));
+	if (packets_per_type) memset (packets_per_type, 0, sizeof (PacketsPerType));
+	return packets_per_type;
 
 }
 
@@ -91,19 +91,20 @@ void packets_per_type_delete (void *ptr) { if (ptr) free (ptr); }
 
 void packets_per_type_print (PacketsPerType *packets_per_type) {
 
-    if (packets_per_type) {
-        printf ("Cerver:            %ld\n", packets_per_type->n_cerver_packets);
-        printf ("Error:             %ld\n", packets_per_type->n_error_packets);
-        printf ("Auth:              %ld\n", packets_per_type->n_auth_packets);
-        printf ("Request:           %ld\n", packets_per_type->n_request_packets);
-        printf ("Game:              %ld\n", packets_per_type->n_game_packets);
-        printf ("App:               %ld\n", packets_per_type->n_app_packets);
-        printf ("App Error:         %ld\n", packets_per_type->n_app_error_packets);
-        printf ("Custom:            %ld\n", packets_per_type->n_custom_packets);
-        printf ("Test:              %ld\n", packets_per_type->n_test_packets);
-        printf ("Unknown:           %ld\n", packets_per_type->n_unknown_packets);
-        printf ("Bad:               %ld\n", packets_per_type->n_bad_packets);
-    }
+	if (packets_per_type) {
+		printf ("Cerver:            %ld\n", packets_per_type->n_cerver_packets);
+		printf ("Client:            %ld\n", packets_per_type->n_client_packets);
+		printf ("Error:             %ld\n", packets_per_type->n_error_packets);
+		printf ("Request:           %ld\n", packets_per_type->n_request_packets);
+		printf ("Auth:              %ld\n", packets_per_type->n_auth_packets);
+		printf ("Game:              %ld\n", packets_per_type->n_game_packets);
+		printf ("App:               %ld\n", packets_per_type->n_app_packets);
+		printf ("App Error:         %ld\n", packets_per_type->n_app_error_packets);
+		printf ("Custom:            %ld\n", packets_per_type->n_custom_packets);
+		printf ("Test:              %ld\n", packets_per_type->n_test_packets);
+		printf ("Unknown:           %ld\n", packets_per_type->n_unknown_packets);
+		printf ("Bad:               %ld\n", packets_per_type->n_bad_packets);
+	}
 
 }
 
@@ -113,12 +114,12 @@ void packets_per_type_print (PacketsPerType *packets_per_type) {
 
 PacketHeader *packet_header_new (void) {
 
-    PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
-    if (header) {
-        memset (header, 0, sizeof (PacketHeader));
-    }
+	PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
+	if (header) {
+		memset (header, 0, sizeof (PacketHeader));
+	}
 
-    return header;
+	return header;
 
 }
 
@@ -126,28 +127,31 @@ void packet_header_delete (PacketHeader *header) { if (header) free (header); }
 
 PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, u32 req_type) {
 
-    PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
-    if (header) {
-        header->packet_type = packet_type;
-        header->packet_size = packet_size;
+	PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
+	if (header) {
+		header->packet_type = packet_type;
+		header->packet_size = packet_size;
 
-        header->handler_id = 0;
+		header->handler_id = 0;
 
-        header->request_type = req_type;
-    }
+		header->request_type = req_type;
 
-    return header;
+		header->sock_fd = 0;
+	}
+
+	return header;
 
 }
 
 void packet_header_print (PacketHeader *header) {
 
-    if (header) {
-        printf ("Packet type: %d\n", header->packet_type);
-        printf ("Packet size: %ld\n", header->packet_size);
-        printf ("Handler id: %d\n", header->handler_id);
-        printf ("Request type: %d\n", header->request_type);
-    }
+	if (header) {
+		printf ("Packet type: %d\n", header->packet_type);
+		printf ("Packet size: %ld\n", header->packet_size);
+		printf ("Handler id: %d\n", header->handler_id);
+		printf ("Request type: %d\n", header->request_type);
+		printf ("Sock fd: %d\n", header->sock_fd);
+	}
 
 }
 
@@ -155,17 +159,17 @@ void packet_header_print (PacketHeader *header) {
 // returns 0 on success, 1 on error
 u8 packet_header_copy (PacketHeader **dest, PacketHeader *source) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (source) {
-        *dest = (PacketHeader *) malloc (sizeof (PacketHeader));
-        if (*dest) {
-            memcpy (*dest, source, sizeof (PacketHeader));
-            retval = 0;
-        }
-    }
+	if (source) {
+		*dest = (PacketHeader *) malloc (sizeof (PacketHeader));
+		if (*dest) {
+			memcpy (*dest, source, sizeof (PacketHeader));
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -177,30 +181,30 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size);
 
 Packet *packet_new (void) {
 
-    Packet *packet = (Packet *) malloc (sizeof (Packet));
-    if (packet) {
-        packet->cerver = NULL;
-        packet->client = NULL;
-        packet->connection = NULL;
-        packet->lobby = NULL;
+	Packet *packet = (Packet *) malloc (sizeof (Packet));
+	if (packet) {
+		packet->cerver = NULL;
+		packet->client = NULL;
+		packet->connection = NULL;
+		packet->lobby = NULL;
 
-        packet->packet_type = DONT_CHECK_TYPE;
-        packet->req_type = 0;
+		packet->packet_type = PACKET_TYPE_NONE;
+		packet->req_type = 0;
 
-        packet->data_size = 0;
-        packet->data = NULL;
-        packet->data_ptr = NULL;
-        packet->data_end = NULL;
-        packet->data_ref = false;
+		packet->data_size = 0;
+		packet->data = NULL;
+		packet->data_ptr = NULL;
+		packet->data_end = NULL;
+		packet->data_ref = false;
 
-        packet->header = NULL;
-        packet->version = NULL;
-        packet->packet_size = 0;
-        packet->packet = NULL;
-        packet->packet_ref = false;
-    }
+		packet->header = NULL;
+		packet->version = NULL;
+		packet->packet_size = 0;
+		packet->packet = NULL;
+		packet->packet_ref = false;
+	}
 
-    return packet;
+	return packet;
 
 }
 
@@ -208,52 +212,85 @@ Packet *packet_new (void) {
 // data is copied into packet buffer and can be safely freed
 Packet *packet_create (PacketType type, void *data, size_t data_size) {
 
-    Packet *packet = packet_new ();
-    if (packet) {
-        packet->packet_type = type;
-        if (data) packet_append_data (packet, data, data_size);
-    }
+	Packet *packet = packet_new ();
+	if (packet) {
+		packet->packet_type = type;
+		if (data) packet_append_data (packet, data, data_size);
+	}
 
-    return packet;
+	return packet;
 
 }
 
 void packet_delete (void *ptr) {
 
-    if (ptr) {
-        Packet *packet = (Packet *) ptr;
+	if (ptr) {
+		Packet *packet = (Packet *) ptr;
 
-        packet->cerver = NULL;
-        packet->client = NULL;
-        packet->connection = NULL;
-        packet->lobby = NULL;
+		packet->cerver = NULL;
+		packet->client = NULL;
+		packet->connection = NULL;
+		packet->lobby = NULL;
 
-        if (!packet->data_ref) {
-            if (packet->data) free (packet->data);
-        }
+		if (!packet->data_ref) {
+			if (packet->data) free (packet->data);
+		}
 
-        packet_header_delete (packet->header);
-        packet_version_delete (packet->version);
+		packet_header_delete (packet->header);
+		packet_version_delete (packet->version);
 
-        if (!packet->packet_ref) {
-            if (packet->packet) free (packet->packet);
-        }
+		if (!packet->packet_ref) {
+			if (packet->packet) free (packet->packet);
+		}
 
-        free (packet);
-    }
+		free (packet);
+	}
 
 }
 
 // sets the pakcet destinatary is directed to and the protocol to use
-void packet_set_network_values (Packet *packet, Cerver *cerver, 
-    Client *client, Connection *connection, Lobby *lobby) {
+void packet_set_network_values (Packet *packet, Cerver *cerver,
+	Client *client, Connection *connection, Lobby *lobby) {
 
-    if (packet) {
-        packet->cerver = cerver;
-        packet->client = client;
-        packet->connection = connection;
-        packet->lobby = lobby;
-    }
+	if (packet) {
+		packet->cerver = cerver;
+		packet->client = client;
+		packet->connection = connection;
+		packet->lobby = lobby;
+	}
+
+}
+
+// sets the packet's header
+// copies the header's values into the packet
+void packet_set_header (Packet *packet, PacketHeader *header) {
+
+	if (packet && header) {
+		if (!packet->header) packet->header = (PacketHeader *) malloc (sizeof (PacketHeader));
+		if (packet->header) memcpy (&packet->header, header, sizeof (PacketHeader));
+	}
+
+}
+
+// sets the packet's header values
+// if the packet does NOT yet have a header, it will be created
+void packet_set_header_values (
+	Packet *packet,
+	PacketType packet_type, size_t packet_size,
+	u8 handler_id, u32 request_type,
+	u16 sock_fd
+) {
+
+	if (packet) {
+		if (!packet->header) packet->header = (PacketHeader *) malloc (sizeof (PacketHeader));
+		if (packet->header) {
+			packet->header->packet_type = packet_type;
+			packet->header->packet_size = packet_size;
+			packet->header->handler_id = handler_id;
+			packet->header->request_type = request_type;
+			packet->header->sock_fd = sock_fd;
+		}
+	}
 
 }
 
@@ -262,29 +299,29 @@ void packet_set_network_values (Packet *packet, Cerver *cerver,
 // returns 0 on success, 1 on error
 u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && data) {
-        // check if there was data in the packet before
-        if (!packet->data_ref) {
-            if (packet->data) free (packet->data);
-        }
+	if (packet && data) {
+		// check if there was data in the packet before
+		if (!packet->data_ref) {
+			if (packet->data) free (packet->data);
+		}
 
-        packet->data_size = data_size;
-        packet->data = malloc (packet->data_size);
-        if (packet->data) {
-            memcpy (packet->data, data, data_size);
-            packet->data_end = (char *) packet->data;
-            packet->data_end += packet->data_size;
+		packet->data_size = data_size;
+		packet->data = malloc (packet->data_size);
+		if (packet->data) {
+			memcpy (packet->data, data, data_size);
+			packet->data_end = (char *) packet->data;
+			packet->data_end += packet->data_size;
 
-            // point to the start of the data
-            packet->data_ptr = (char *) packet->data;
+			// point to the start of the data
+			packet->data_ptr = (char *) packet->data;
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -294,66 +331,66 @@ u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
 // this does not work if the data has been set using a reference
 u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && data) {
-        // append the data to the end if the packet already has data
-        if (packet->data) {
-            size_t new_size = packet->data_size + data_size;
-            void *new_data = realloc (packet->data, new_size);
-            if (new_data) {
-                packet->data_end = (char *) new_data;
-                packet->data_end += packet->data_size;
+	if (packet && data) {
+		// append the data to the end if the packet already has data
+		if (packet->data) {
+			size_t new_size = packet->data_size + data_size;
+			void *new_data = realloc (packet->data, new_size);
+			if (new_data) {
+				packet->data_end = (char *) new_data;
+				packet->data_end += packet->data_size;
 
-                // copy the new buffer
-                memcpy (packet->data_end, data, data_size);
-                packet->data_end += data_size;
+				// copy the new buffer
+				memcpy (packet->data_end, data, data_size);
+				packet->data_end += data_size;
 
-                packet->data = new_data;
-                packet->data_size = new_size;
+				packet->data = new_data;
+				packet->data_size = new_size;
 
-                // point to the start of the data
-                packet->data_ptr = (char *) packet->data;
+				// point to the start of the data
+				packet->data_ptr = (char *) packet->data;
 
-                retval = 0;
-            }
+				retval = 0;
+			}
 
-            else {
-                #ifdef PACKETS_DEBUG
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to realloc packet data!");
-                #endif
-                packet->data = NULL;
-                packet->data_size = 0;
-            }
-        }
+			else {
+				#ifdef PACKETS_DEBUG
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to realloc packet data!");
+				#endif
+				packet->data = NULL;
+				packet->data_size = 0;
+			}
+		}
 
-        // if the packet is empty, create a new buffer
-        else {
-            packet->data_size = data_size;
-            packet->data = malloc (packet->data_size);
-            if (packet->data) {
-                // copy the data to the packet data buffer
-                memcpy (packet->data, data, data_size);
-                packet->data_end = (char *) packet->data;
-                packet->data_end += packet->data_size;
+		// if the packet is empty, create a new buffer
+		else {
+			packet->data_size = data_size;
+			packet->data = malloc (packet->data_size);
+			if (packet->data) {
+				// copy the data to the packet data buffer
+				memcpy (packet->data, data, data_size);
+				packet->data_end = (char *) packet->data;
+				packet->data_end += packet->data_size;
 
-                // point to the start of the data
-                packet->data_ptr = (char *) packet->data;
+				// point to the start of the data
+				packet->data_ptr = (char *) packet->data;
 
-                retval = 0;
-            }
+				retval = 0;
+			}
 
-            else {
-                #ifdef PACKETS_DEBUG
-                cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to allocate packet data!");
-                #endif
-                packet->data = NULL;
-                packet->data_size = 0;
-            }
-        }
-    }
+			else {
+				#ifdef PACKETS_DEBUG
+				cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to allocate packet data!");
+				#endif
+				packet->data = NULL;
+				packet->data_size = 0;
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -362,22 +399,22 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 // this method is usefull for example if you just want to send a raw json packet to a non-cerver
 // use this method with packet_send () with the raw flag on
 u8 packet_set_data_ref (Packet *packet, void *data, size_t data_size) {
-    
-    u8 retval = 1;
 
-    if (packet && data) {
-        if (!packet->data_ref) {
-            if (packet->data) free (packet->data);
-        }
+	u8 retval = 1;
 
-        packet->data = data;
-        packet->data_size = data_size;
-        packet->data_ref = true;
+	if (packet && data) {
+		if (!packet->data_ref) {
+			if (packet->data) free (packet->data);
+		}
 
-        retval = 0;
-    }
+		packet->data = data;
+		packet->data_size = data_size;
+		packet->data_ref = true;
 
-    return retval;
+		retval = 0;
+	}
+
+	return retval;
 
 }
 
@@ -386,46 +423,46 @@ u8 packet_set_data_ref (Packet *packet, void *data, size_t data_size) {
 // returns 0 on succes, 1 on error
 u8 packet_set_packet (Packet *packet, void *data, size_t data_size) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && data) {
-        if (!packet->packet_ref) {
-            if (packet->packet) free (packet->packet);
-        }
+	if (packet && data) {
+		if (!packet->packet_ref) {
+			if (packet->packet) free (packet->packet);
+		}
 
-        packet->packet_size = data_size;
-        packet->packet = malloc (packet->packet_size);
-        if (packet->packet) {
-            memcpy (packet->packet, data, data_size);
+		packet->packet_size = data_size;
+		packet->packet = malloc (packet->packet_size);
+		if (packet->packet) {
+			memcpy (packet->packet, data, data_size);
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
-}   
+}
 
 // sets a reference to a data buffer to send as the packet
 // data will not be copied into the packet and will not be freed after use
 // usefull when you need to generate your own cerver type packet by hand
 u8 packet_set_packet_ref (Packet *packet, void *data, size_t packet_size) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && data) {
-        if (!packet->packet_ref) {
-            if (packet->packet) free (packet->packet);
-        }
+	if (packet && data) {
+		if (!packet->packet_ref) {
+			if (packet->packet) free (packet->packet);
+		}
 
-        packet->packet = data;
-        packet->packet_size = packet_size;
-        packet->packet_ref = true;
+		packet->packet = data;
+		packet->packet_size = packet_size;
+		packet->packet_ref = true;
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -433,97 +470,109 @@ u8 packet_set_packet_ref (Packet *packet, void *data, size_t packet_size) {
 // returns 0 on sucess, 1 on error
 u8 packet_generate (Packet *packet) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (packet) {
-        if (packet->packet) {
-            free (packet->packet);
-            packet->packet = NULL;
-            packet->packet_size = 0;
-        }   
+	if (packet) {
+		if (packet->packet) {
+			free (packet->packet);
+			packet->packet = NULL;
+			packet->packet_size = 0;
+		}
 
-        packet->packet_size = sizeof (PacketHeader) + packet->data_size;
-        packet->header = packet_header_create (packet->packet_type, packet->packet_size, packet->req_type);
+		packet->packet_size = sizeof (PacketHeader) + packet->data_size;
+		if (!packet->header)
+			packet->header = packet_header_create (packet->packet_type, packet->packet_size, packet->req_type);
 
-        // create the packet buffer to be sent
-        packet->packet = malloc (packet->packet_size);
-        if (packet->packet) {
-            char *end = (char *) packet->packet;
-            memcpy (end, packet->header, sizeof (PacketHeader));
+		// create the packet buffer to be sent
+		packet->packet = malloc (packet->packet_size);
+		if (packet->packet) {
+			char *end = (char *) packet->packet;
+			memcpy (end, packet->header, sizeof (PacketHeader));
 
-            if (packet->data_size > 0) {
-                end += sizeof (PacketHeader);
-                memcpy (end, packet->data, packet->data_size);
-            }
+			if (packet->data_size > 0) {
+				end += sizeof (PacketHeader);
+				memcpy (end, packet->data, packet->data_size);
+			}
 
-            retval = 0;
-        }
-    }
+			retval = 0;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
-// generates a simple request packet of the requested type reday to be sent, 
+// generates a simple request packet of the requested type reday to be sent,
 // and with option to pass some data
-Packet *packet_generate_request (PacketType packet_type, u32 req_type, 
-    void *data, size_t data_size) {
+Packet *packet_generate_request (
+	PacketType packet_type, u32 req_type,
+	void *data, size_t data_size
+) {
 
-    Packet *packet = packet_new ();
-    if (packet) {
-        packet->packet_type = packet_type;
-        packet->req_type = req_type;
+	Packet *packet = packet_new ();
+	if (packet) {
+		packet->packet_type = packet_type;
+		packet->req_type = req_type;
 
-        // if there is data, append it to the packet data buffer
-        if (data) {
-            if (packet_append_data (packet, data, data_size)) {
-                // we failed to appedn the data into the packet
-                packet_delete (packet);
-                packet = NULL;
-            }
-        } 
+		// if there is data, append it to the packet data buffer
+		if (data) {
+			if (packet_append_data (packet, data, data_size)) {
+				// we failed to appedn the data into the packet
+				packet_delete (packet);
+				packet = NULL;
+			}
+		}
 
-        // make the packet ready to be sent, and check for errors
-        if (packet_generate (packet)) {
-            packet_delete (packet);
-            packet = NULL;
-        }
-    }
+		// make the packet ready to be sent, and check for errors
+		if (packet_generate (packet)) {
+			packet_delete (packet);
+			packet = NULL;
+		}
+	}
 
-    return packet;
+	return packet;
+
+}
+
+static inline u8 packet_send_tcp_actual (
+	const Packet *packet, Connection *connection, int flags, size_t *total_sent, bool raw
+) {
+
+	ssize_t sent = 0;
+	char *p = raw ? (char *) packet->data : (char *) packet->packet;
+	size_t packet_size = raw ? packet->data_size : packet->packet_size;
+
+	while (packet_size > 0) {
+		sent = send (connection->socket->sock_fd, p, packet_size, flags);
+		if (sent < 0) {
+			return 1;
+		}
+
+		p += sent;
+		packet_size -= (size_t) sent;
+	}
+
+	if (total_sent) *total_sent = (size_t) sent;
+
+	return 0;
 
 }
 
 // sends a packet directly using the tcp protocol and the packet sock fd
 // returns 0 on success, 1 on error
-static u8 packet_send_tcp (const Packet *packet, Connection *connection, int flags, size_t *total_sent, bool raw) {
+static u8 packet_send_tcp (
+	const Packet *packet, Connection *connection, int flags, size_t *total_sent, bool raw
+) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && connection) {
-        pthread_mutex_lock (connection->socket->write_mutex);
+	pthread_mutex_lock (connection->socket->write_mutex);
 
-        ssize_t sent = 0;
-        char *p = raw ? (char *) packet->data : (char *) packet->packet;
-        size_t packet_size = raw ? packet->data_size : packet->packet_size;
+	retval = packet_send_tcp_actual (packet, connection, flags, total_sent, raw);
 
-        while (packet_size > 0) {
-            sent = send (connection->socket->sock_fd, p, packet_size, flags);
-            if (sent < 0) {
-                break;
-            }
+	pthread_mutex_unlock (connection->socket->write_mutex);
 
-            p += sent;
-            packet_size -= (size_t) sent;
-            retval = 0;
-        }
-
-        if (total_sent) *total_sent = (size_t) sent;
-
-        pthread_mutex_unlock (connection->socket->write_mutex);
-    }
-
-    return retval;
+	return retval;
 
 }
 
@@ -531,55 +580,55 @@ static u8 packet_send_tcp (const Packet *packet, Connection *connection, int fla
 // returns 0 on success, 1 on error
 static u8 packet_send_split_tcp (const Packet *packet, Connection *connection, int flags, size_t *total_sent) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && connection) {
-        pthread_mutex_lock (connection->socket->write_mutex);
+	if (packet && connection) {
+		pthread_mutex_lock (connection->socket->write_mutex);
 
-        size_t actual_sent = 0;
+		size_t actual_sent = 0;
 
-        // first send the header
-        bool fail = false;
-        ssize_t sent = 0;
-        char *p = (char *) packet->header;
-        size_t packet_size = sizeof (PacketHeader);
+		// first send the header
+		bool fail = false;
+		ssize_t sent = 0;
+		char *p = (char *) packet->header;
+		size_t packet_size = sizeof (PacketHeader);
 
-        while (packet_size > 0) {
-            sent = send (connection->socket->sock_fd, p, packet_size, flags);
-            if (sent < 0) {
-                fail = true;
-                break;
-            }
+		while (packet_size > 0) {
+			sent = send (connection->socket->sock_fd, p, packet_size, flags);
+			if (sent < 0) {
+				fail = true;
+				break;
+			}
 
-            p += sent;
-            actual_sent += (size_t) sent;
-            packet_size -= (size_t) sent;
-            fail = false;
-        }
+			p += sent;
+			actual_sent += (size_t) sent;
+			packet_size -= (size_t) sent;
+			fail = false;
+		}
 
-        // now send the data
-        if (!fail) {
-            sent = 0;
-            p = (char *) packet->data;
-            packet_size = packet->data_size;
+		// now send the data
+		if (!fail) {
+			sent = 0;
+			p = (char *) packet->data;
+			packet_size = packet->data_size;
 
-            while (packet_size > 0) {
-                sent = send (connection->socket->sock_fd, p, packet_size, flags);
-                if (sent < 0) break;
-                p += sent;
-                actual_sent += (size_t) sent;
-                packet_size -= (size_t) sent;
-            }
+			while (packet_size > 0) {
+				sent = send (connection->socket->sock_fd, p, packet_size, flags);
+				if (sent < 0) break;
+				p += sent;
+				actual_sent += (size_t) sent;
+				packet_size -= (size_t) sent;
+			}
 
-            if (total_sent) *total_sent = actual_sent;
+			if (total_sent) *total_sent = actual_sent;
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        pthread_mutex_unlock (connection->socket->write_mutex);
-    }
+		pthread_mutex_unlock (connection->socket->write_mutex);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -587,158 +636,170 @@ static u8 packet_send_split_tcp (const Packet *packet, Connection *connection, i
 #pragma GCC diagnostic ignored "-Wunused-function"
 static u8 packet_send_udp (const void *packet, size_t packet_size) {
 
-    // TODO:
+	// TODO:
 
-    return 0;
+	return 0;
 
 }
 #pragma GCC diagnostic pop
 
-static void packet_send_update_stats (PacketType packet_type, size_t sent,
-    Cerver *cerver, Client *client, Connection *connection, Lobby *lobby) {
+static void packet_send_update_stats (
+	PacketType packet_type, size_t sent,
+	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+) {
 
-    if (cerver) {
-        cerver->stats->n_packets_sent += 1;
-        cerver->stats->total_bytes_sent += sent;
-    }
+	if (cerver) {
+		cerver->stats->n_packets_sent += 1;
+		cerver->stats->total_bytes_sent += sent;
+	}
 
-    if (client) {
-        client->stats->n_packets_sent += 1;
-        client->stats->total_bytes_sent += sent;
-    }
+	if (client) {
+		client->stats->n_packets_sent += 1;
+		client->stats->total_bytes_sent += sent;
+	}
 
-    connection->stats->n_packets_sent += 1;
-    connection->stats->total_bytes_sent += sent; 
+	connection->stats->n_packets_sent += 1;
+	connection->stats->total_bytes_sent += sent;
 
-    if (lobby) {
-        lobby->stats->n_packets_sent += 1;
-        lobby->stats->bytes_sent += sent;
-    }
+	if (lobby) {
+		lobby->stats->n_packets_sent += 1;
+		lobby->stats->bytes_sent += sent;
+	}
 
-    switch (packet_type) {
-        case CERVER_PACKET:
-            if (cerver) cerver->stats->sent_packets->n_cerver_packets += 1;
-            if (client) client->stats->sent_packets->n_cerver_packets += 1;
-            connection->stats->sent_packets->n_cerver_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_cerver_packets += 1;
-            break;
+	switch (packet_type) {
+		case PACKET_TYPE_NONE: break;
 
-        case CLIENT_PACKET: break;
+		case PACKET_TYPE_CERVER:
+			if (cerver) cerver->stats->sent_packets->n_cerver_packets += 1;
+			if (client) client->stats->sent_packets->n_cerver_packets += 1;
+			connection->stats->sent_packets->n_cerver_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_cerver_packets += 1;
+			break;
 
-        case ERROR_PACKET: 
-            if (cerver) cerver->stats->sent_packets->n_error_packets += 1;
-            if (client) client->stats->sent_packets->n_error_packets += 1;
-            connection->stats->sent_packets->n_error_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_error_packets += 1;
-            break;
+		case PACKET_TYPE_CLIENT:
+			if (cerver) cerver->stats->sent_packets->n_client_packets += 1;
+			if (client) client->stats->sent_packets->n_client_packets += 1;
+			connection->stats->sent_packets->n_client_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_client_packets += 1;
+			break;
 
-        case AUTH_PACKET: 
-            if (cerver) cerver->stats->sent_packets->n_auth_packets += 1;
-            if (client) client->stats->sent_packets->n_auth_packets += 1;
-            connection->stats->sent_packets->n_auth_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_auth_packets += 1;
-            break;
+		case PACKET_TYPE_ERROR:
+			if (cerver) cerver->stats->sent_packets->n_error_packets += 1;
+			if (client) client->stats->sent_packets->n_error_packets += 1;
+			connection->stats->sent_packets->n_error_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_error_packets += 1;
+			break;
 
-        case REQUEST_PACKET: 
-            if (cerver) cerver->stats->sent_packets->n_request_packets += 1;
-            if (client) client->stats->sent_packets->n_request_packets += 1;
-            connection->stats->sent_packets->n_request_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_request_packets += 1;
-            break;
+		case PACKET_TYPE_REQUEST:
+			if (cerver) cerver->stats->sent_packets->n_request_packets += 1;
+			if (client) client->stats->sent_packets->n_request_packets += 1;
+			connection->stats->sent_packets->n_request_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_request_packets += 1;
+			break;
 
-        case GAME_PACKET:
-            if (cerver) cerver->stats->sent_packets->n_game_packets += 1; 
-            if (client) client->stats->sent_packets->n_game_packets += 1;
-            connection->stats->sent_packets->n_game_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_game_packets += 1;
-            break;
+		case PACKET_TYPE_AUTH:
+			if (cerver) cerver->stats->sent_packets->n_auth_packets += 1;
+			if (client) client->stats->sent_packets->n_auth_packets += 1;
+			connection->stats->sent_packets->n_auth_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_auth_packets += 1;
+			break;
 
-        case APP_PACKET:
-            if (cerver) cerver->stats->sent_packets->n_app_packets += 1;
-            if (client) client->stats->sent_packets->n_app_packets += 1;
-            connection->stats->sent_packets->n_app_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_app_packets += 1;
-            break;
+		case PACKET_TYPE_GAME:
+			if (cerver) cerver->stats->sent_packets->n_game_packets += 1;
+			if (client) client->stats->sent_packets->n_game_packets += 1;
+			connection->stats->sent_packets->n_game_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_game_packets += 1;
+			break;
 
-        case APP_ERROR_PACKET: 
-            if (cerver) cerver->stats->sent_packets->n_app_error_packets += 1;
-            if (client) client->stats->sent_packets->n_app_error_packets += 1;
-            connection->stats->sent_packets->n_app_error_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_app_error_packets += 1;
-            break;
+		case PACKET_TYPE_APP:
+			if (cerver) cerver->stats->sent_packets->n_app_packets += 1;
+			if (client) client->stats->sent_packets->n_app_packets += 1;
+			connection->stats->sent_packets->n_app_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_app_packets += 1;
+			break;
 
-        case CUSTOM_PACKET:
-            if (cerver) cerver->stats->sent_packets->n_custom_packets += 1;
-            if (client) client->stats->sent_packets->n_custom_packets += 1;
-            connection->stats->sent_packets->n_custom_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_custom_packets += 1;
-            break;
+		case PACKET_TYPE_APP_ERROR:
+			if (cerver) cerver->stats->sent_packets->n_app_error_packets += 1;
+			if (client) client->stats->sent_packets->n_app_error_packets += 1;
+			connection->stats->sent_packets->n_app_error_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_app_error_packets += 1;
+			break;
 
-        case TEST_PACKET: 
-            if (cerver) cerver->stats->sent_packets->n_test_packets += 1;
-            if (client) client->stats->sent_packets->n_test_packets += 1;
-            connection->stats->sent_packets->n_test_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_test_packets += 1;
-            break;
+		case PACKET_TYPE_CUSTOM:
+			if (cerver) cerver->stats->sent_packets->n_custom_packets += 1;
+			if (client) client->stats->sent_packets->n_custom_packets += 1;
+			connection->stats->sent_packets->n_custom_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_custom_packets += 1;
+			break;
 
-        case DONT_CHECK_TYPE: break;
+		case PACKET_TYPE_TEST:
+			if (cerver) cerver->stats->sent_packets->n_test_packets += 1;
+			if (client) client->stats->sent_packets->n_test_packets += 1;
+			connection->stats->sent_packets->n_test_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_test_packets += 1;
+			break;
 
-        default: 
-            if (cerver) cerver->stats->sent_packets->n_unknown_packets += 1;
-            if (client) client->stats->sent_packets->n_unknown_packets += 1;
-            connection->stats->sent_packets->n_unknown_packets += 1;
-            if (lobby) lobby->stats->sent_packets->n_unknown_packets += 1;
-            break;
-    }
+		default:
+			if (cerver) cerver->stats->sent_packets->n_unknown_packets += 1;
+			if (client) client->stats->sent_packets->n_unknown_packets += 1;
+			connection->stats->sent_packets->n_unknown_packets += 1;
+			if (lobby) lobby->stats->sent_packets->n_unknown_packets += 1;
+			break;
+	}
 
 }
 
-static inline u8 packet_send_internal (const Packet *packet, int flags, size_t *total_sent, 
-    bool raw, bool split,
-    Cerver *cerver, Client *client, Connection *connection, Lobby *lobby) {
+static inline u8 packet_send_internal (
+	const Packet *packet,
+	int flags, size_t *total_sent,
+	bool raw, bool split, bool unsafe,
+	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && connection) {
-        switch (connection->protocol) {
-            case PROTOCOL_TCP: {
-                size_t sent = 0;
+	if (packet && connection) {
+		switch (connection->protocol) {
+			case PROTOCOL_TCP: {
+				size_t sent = 0;
 
-                if (!(split ? packet_send_split_tcp (packet, connection, flags, &sent)
-                    : packet_send_tcp (packet, connection, flags, &sent, raw))) {
-                    if (total_sent) *total_sent = sent;
+				if (!(split ? packet_send_split_tcp (packet, connection, flags, &sent)
+					: unsafe ? packet_send_tcp_actual (packet, connection, flags, &sent, raw)
+						: packet_send_tcp (packet, connection, flags, &sent, raw))
+				) {
+					if (total_sent) *total_sent = sent;
 
-                    packet_send_update_stats (
-                        packet->packet_type, sent,
-                        cerver, client, connection, lobby
-                    );
+					packet_send_update_stats (
+						packet->packet_type, sent,
+						cerver, client, connection, lobby
+					);
 
-                    retval = 0;
-                }
+					retval = 0;
+				}
 
-                else {
-                    #ifdef PACKETS_DEBUG
-                    printf ("\n");
-                    perror ("Error");
-                    printf ("\n");
-                    #endif
+				else {
+					#ifdef PACKETS_DEBUG
+					printf ("\n");
+					perror ("packet_send_internal () - Error");
+					printf ("\n");
+					#endif
 
-                    if (cerver) cerver->stats->sent_packets->n_bad_packets += 1;
-                    if (client) client->stats->sent_packets->n_bad_packets += 1;
-                    if (connection) connection->stats->sent_packets->n_bad_packets += 1;
+					if (cerver) cerver->stats->sent_packets->n_bad_packets += 1;
+					if (client) client->stats->sent_packets->n_bad_packets += 1;
+					if (connection) connection->stats->sent_packets->n_bad_packets += 1;
 
-                    if (total_sent) *total_sent = 0;
-                }
-            } break;
+					if (total_sent) *total_sent = 0;
+				}
+			} break;
 
-            case PROTOCOL_UDP:
-                break;
+			case PROTOCOL_UDP:
+				break;
 
-            default: break;
-        }
-    }
+			default: break;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -747,11 +808,24 @@ static inline u8 packet_send_internal (const Packet *packet, int flags, size_t *
 // returns 0 on success, 1 on error
 u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw) {
 
-    return packet_send_internal (
-        packet, flags, total_sent, 
-        raw, false,
-        packet->cerver, packet->client, packet->connection, packet->lobby
-    );
+	return packet_send_internal (
+		packet, flags, total_sent,
+		raw, false, false,
+		packet->cerver, packet->client, packet->connection, packet->lobby
+	);
+
+}
+
+// works just as packet_send () but the socket's write mutex won't be locked
+// useful when you need to lock the mutex manually
+// returns 0 on success, 1 on error
+u8 packet_send_unsafe (const Packet *packet, int flags, size_t *total_sent, bool raw) {
+
+	return packet_send_internal (
+		packet, flags, total_sent,
+		raw, false, true,
+		packet->cerver, packet->client, packet->connection, packet->lobby
+	);
 
 }
 
@@ -760,71 +834,77 @@ u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw) {
 // at least a packet & an active connection are required for this method to succeed
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-u8 packet_send_to (const Packet *packet, size_t *total_sent, bool raw,
-    Cerver *cerver, Client *client, Connection *connection, Lobby *lobby) {
+u8 packet_send_to (
+	const Packet *packet,
+	size_t *total_sent, bool raw,
+	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+) {
 
-    return packet_send_internal (
-        packet, 0, total_sent, 
-        raw, false,
-        cerver, client, connection, lobby
-    );
+	return packet_send_internal (
+		packet, 0, total_sent,
+		raw, false, false,
+		cerver, client, connection, lobby
+	);
 
 }
 
 // sends a packet to the socket in two parts, first the header & then the data
-// this method can be useful when trying to forward a big received packet without the overhead of 
+// this method can be useful when trying to forward a big received packet without the overhead of
 // performing and additional copy to create a continuos data (packet) buffer
 // the socket's write mutex will be locked to ensure that the packet
 // is sent correctly and to avoid race conditions
 // returns 0 on success, 1 on error
 u8 packet_send_split (const Packet *packet, int flags, size_t *total_sent) {
 
-    return packet_send_internal (
-        packet, flags, total_sent, 
-        false, true,
-        packet->cerver, packet->client, packet->connection, packet->lobby
-    );
+	return packet_send_internal (
+		packet, flags, total_sent,
+		false, true, false,
+		packet->cerver, packet->client, packet->connection, packet->lobby
+	);
 
 }
 
 // sends a packet to the socket in two parts, first the header & then the data
 // works just as packet_send_split () but with the flags set to 0
 // returns 0 on success, 1 on error
-u8 packet_send_to_split (const Packet *packet, size_t *total_sent,
-    Cerver *cerver, Client *client, Connection *connection, Lobby *lobby) {
+u8 packet_send_to_split (
+	const Packet *packet,
+	size_t *total_sent,
+	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+) {
 
-    return packet_send_internal (
-        packet, 0, total_sent, 
-        false, true,
-        cerver, client, connection, lobby
-    );
+	return packet_send_internal (
+		packet, 0, total_sent,
+		false, true, false,
+		cerver, client, connection, lobby
+	);
 
 }
 
 static u8 packet_send_pieces_actual (
-    Socket *socket, 
-    char *data, size_t data_size, 
-    int flags, 
-    size_t *actual_sent
+	Socket *socket,
+	char *data, size_t data_size,
+	int flags,
+	size_t *actual_sent
 ) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    ssize_t sent = 0;
-    char *p = data;
-    while (data_size > 0) {
-        sent = send (socket->sock_fd, p, data_size, flags);
-        if (sent < 0) {
-            retval = 1;
-            break;
-        }
+	ssize_t sent = 0;
+	char *p = data;
+	while (data_size > 0) {
+		sent = send (socket->sock_fd, p, data_size, flags);
+		if (sent < 0) {
+			retval = 1;
+			break;
+		}
 
-        p += sent;
-        *actual_sent += (size_t) sent;
-        data_size -= (size_t) sent;
-    }
+		p += sent;
+		*actual_sent += (size_t) sent;
+		data_size -= (size_t) sent;
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -833,85 +913,87 @@ static u8 packet_send_pieces_actual (
 // socket mutex will be locked for the entire operation
 // returns 0 on success, 1 on error
 u8 packet_send_pieces (
-    const Packet *packet, 
-    void **pieces, size_t *sizes, u32 n_pieces, 
-    int flags, 
-    size_t *total_sent
+	const Packet *packet,
+	void **pieces, size_t *sizes, u32 n_pieces,
+	int flags,
+	size_t *total_sent
 ) {
 
-    u8 retval = 1;
+	u8 retval = 1;
 
-    if (packet && pieces && sizes) {
-        pthread_mutex_lock (packet->connection->socket->write_mutex);
+	if (packet && pieces && sizes) {
+		pthread_mutex_lock (packet->connection->socket->write_mutex);
 
-        size_t actual_sent = 0;
+		size_t actual_sent = 0;
 
-        // first send the header
-        if (!packet_send_pieces_actual (
-            packet->connection->socket,
-            (char *) packet->header, sizeof (PacketHeader),
-            flags,
-            &actual_sent
-        )) {
-            // send the pieces of data
-            for (u32 i = 0; i < n_pieces; i++) {
-                (void) packet_send_pieces_actual (
-                    packet->connection->socket,
-                    (char *) pieces[i], sizes[i],
-                    flags,
-                    &actual_sent
-                );
-            }
+		// first send the header
+		if (!packet_send_pieces_actual (
+			packet->connection->socket,
+			(char *) packet->header, sizeof (PacketHeader),
+			flags,
+			&actual_sent
+		)) {
+			// send the pieces of data
+			for (u32 i = 0; i < n_pieces; i++) {
+				(void) packet_send_pieces_actual (
+					packet->connection->socket,
+					(char *) pieces[i], sizes[i],
+					flags,
+					&actual_sent
+				);
+			}
 
-            retval = 0;
-        }
+			retval = 0;
+		}
 
-        packet_send_update_stats (
-            packet->packet_type, actual_sent,
-            packet->cerver, packet->client, packet->connection, packet->lobby
-        );
+		packet_send_update_stats (
+			packet->packet_type, actual_sent,
+			packet->cerver, packet->client, packet->connection, packet->lobby
+		);
 
-        if (total_sent) *total_sent = actual_sent;
+		if (total_sent) *total_sent = actual_sent;
 
-        pthread_mutex_unlock (packet->connection->socket->write_mutex);
-    }
+		pthread_mutex_unlock (packet->connection->socket->write_mutex);
+	}
 
-    return retval;
+	return retval;
 
 }
 
 // sends a packet directly to the socket
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-u8 packet_send_to_socket (const Packet *packet, Socket *socket, 
-    int flags, size_t *total_sent, bool raw) {
+u8 packet_send_to_socket (
+	const Packet *packet,
+	Socket *socket, int flags, size_t *total_sent, bool raw
+) {
 
-    u8 retval = 0;
+	u8 retval = 0;
 
-    if (packet) {
-        ssize_t sent = 0;
-        const char *p = raw ? (char *) packet->data : (char *) packet->packet;
-        size_t packet_size = raw ? packet->data_size : packet->packet_size;
+	if (packet) {
+		ssize_t sent = 0;
+		const char *p = raw ? (char *) packet->data : (char *) packet->packet;
+		size_t packet_size = raw ? packet->data_size : packet->packet_size;
 
-        pthread_mutex_lock (socket->write_mutex);
+		pthread_mutex_lock (socket->write_mutex);
 
-        while (packet_size > 0) {
-            sent = send (socket->sock_fd, p, packet_size, flags);
-            if (sent < 0) {
-                retval = 1;
-                break;
-            };
+		while (packet_size > 0) {
+			sent = send (socket->sock_fd, p, packet_size, flags);
+			if (sent < 0) {
+				retval = 1;
+				break;
+			};
 
-            p += sent;
-            packet_size -= sent;
-        }
+			p += sent;
+			packet_size -= sent;
+		}
 
-        if (total_sent) *total_sent = (size_t) sent;
+		if (total_sent) *total_sent = (size_t) sent;
 
-        pthread_mutex_unlock (socket->write_mutex);
-    }
+		pthread_mutex_unlock (socket->write_mutex);
+	}
 
-    return retval;
+	return retval;
 
 }
 
@@ -919,32 +1001,32 @@ u8 packet_send_to_socket (const Packet *packet, Socket *socket,
 // returns false on a bad packet
 bool packet_check (Packet *packet) {
 
-    bool retval = false;
+	bool retval = false;
 
-    if (packet) {
-        if (packet->version) {
-            if (packet->version->protocol_id == protocol_id) {
-                if ((packet->version->protocol_version.major <= protocol_version.major)
-                    && (packet->version->protocol_version.minor >= protocol_version.minor)) {
-                    retval = true;
-                }
+	if (packet) {
+		if (packet->version) {
+			if (packet->version->protocol_id == protocol_id) {
+				if ((packet->version->protocol_version.major <= protocol_version.major)
+					&& (packet->version->protocol_version.minor >= protocol_version.minor)) {
+					retval = true;
+				}
 
-                else {
-                    #ifdef PACKETS_DEBUG
-                    cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with incompatible version.");
-                    #endif
-                }
-            }
+				else {
+					#ifdef PACKETS_DEBUG
+					cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with incompatible version.");
+					#endif
+				}
+			}
 
-            else {
-                #ifdef PACKETS_DEBUG
-                cerver_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with unknown protocol ID.");
-                #endif
-            }
-        }
-    }
+			else {
+				#ifdef PACKETS_DEBUG
+				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with unknown protocol ID.");
+				#endif
+			}
+		}
+	}
 
-    return retval;
+	return retval;
 
 }
 

--- a/src/cerver/serializer.c
+++ b/src/cerver/serializer.c
@@ -29,7 +29,7 @@ bool s_relative_valid (void *relative_ptr, void *valid_begin, void *valid_end) {
 
 	void *pointee = s_relative_to_ptr (relative_ptr);
 	return pointee >= valid_begin && pointee < valid_end;
-    
+
 }
 
 bool s_array_valid (void *array, size_t elem_size, void *valid_begin, void *valid_end) {
@@ -42,7 +42,7 @@ bool s_array_valid (void *array, size_t elem_size, void *valid_begin, void *vali
 
 	return array_.n_elems == 0
 		|| (begin >= valid_begin && begin < valid_end &&
-		    end >= valid_begin && end <= valid_end);
+			end >= valid_begin && end <= valid_end);
 
 }
 

--- a/src/cerver/sessions.c
+++ b/src/cerver/sessions.c
@@ -15,49 +15,49 @@
 
 SessionData *session_data_new (Packet *packet, AuthData *auth_data, Client *client) {
 
-    SessionData *session_data = (SessionData *) malloc (sizeof (SessionData));
-    if (session_data) {
-        session_data->packet = packet;
-        session_data->auth_data = auth_data;
-        session_data->client = client;
-    }
+	SessionData *session_data = (SessionData *) malloc (sizeof (SessionData));
+	if (session_data) {
+		session_data->packet = packet;
+		session_data->auth_data = auth_data;
+		session_data->client = client;
+	}
 
-    return session_data;
+	return session_data;
 
 }
 
 void session_data_delete (void *ptr) {
 
-    if (ptr) { free (ptr); }
+	if (ptr) { free (ptr); }
 
 }
 
 // create a unique session id for each client based on the current time
 void *session_default_generate_id (const void *session_data) {
 
-    char *retval = NULL;
+	char *retval = NULL;
 
-    if (session_data) {
-        // SessionData *data = (SessionData *) session_data;
+	if (session_data) {
+		// SessionData *data = (SessionData *) session_data;
 
-        // get current time
-        time_t now = time (NULL);
-        char buf[128] = { 0 };
-        strftime (buf, 128, "%Y-%m-%d.%X", localtime (&now));
+		// get current time
+		time_t now = time (NULL);
+		char buf[128] = { 0 };
+		strftime (buf, 128, "%Y-%m-%d.%X", localtime (&now));
 
-        char *temp = c_string_create ("%s-%d", buf, random_int_in_range (0, 8096));
-        if (temp) {
-            uint8_t hash[32] = { 0 };
-            char hash_string[65] = { 0 };
-            sha_256_calc (hash, temp, strlen (temp));
-            sha_256_hash_to_string (hash_string, hash);
+		char *temp = c_string_create ("%s-%d", buf, random_int_in_range (0, 8096));
+		if (temp) {
+			uint8_t hash[32] = { 0 };
+			char hash_string[65] = { 0 };
+			sha_256_calc (hash, temp, strlen (temp));
+			sha_256_hash_to_string (hash_string, hash);
 
-            retval = c_string_create ("%s", hash_string);
+			retval = c_string_create ("%s", hash_string);
 
-            free (temp);
-        }
-    }
+			free (temp);
+		}
+	}
 
-    return retval;
+	return retval;
 
 }

--- a/src/cerver/socket.c
+++ b/src/cerver/socket.c
@@ -9,70 +9,70 @@
 
 Socket *socket_new (void) {
 
-    Socket *socket = (Socket *) malloc (sizeof (Socket));
-    if (socket) {
-        socket->sock_fd = -1;
+	Socket *socket = (Socket *) malloc (sizeof (Socket));
+	if (socket) {
+		socket->sock_fd = -1;
 
-        socket->packet_buffer = NULL;
-        socket->packet_buffer_size = 0;
+		socket->packet_buffer = NULL;
+		socket->packet_buffer_size = 0;
 
-        socket->read_mutex = NULL;
-        socket->write_mutex = NULL;
-    }
+		socket->read_mutex = NULL;
+		socket->write_mutex = NULL;
+	}
 
-    return socket;
+	return socket;
 
 }
 
 void socket_delete (void *socket_ptr) {
 
-    if (socket_ptr) {
-        Socket *socket = (Socket *) socket_ptr;
+	if (socket_ptr) {
+		Socket *socket = (Socket *) socket_ptr;
 
-        if (socket->read_mutex) pthread_mutex_lock (socket->read_mutex);
-        if (socket->write_mutex) pthread_mutex_lock (socket->write_mutex);
+		if (socket->read_mutex) pthread_mutex_lock (socket->read_mutex);
+		if (socket->write_mutex) pthread_mutex_lock (socket->write_mutex);
 
-        if (socket->packet_buffer) free (socket->packet_buffer);
+		if (socket->packet_buffer) free (socket->packet_buffer);
 
-        if (socket->read_mutex) {
-            pthread_mutex_unlock (socket->read_mutex);
-            pthread_mutex_destroy (socket->read_mutex);
-            free (socket->read_mutex);
-        }
+		if (socket->read_mutex) {
+			pthread_mutex_unlock (socket->read_mutex);
+			pthread_mutex_destroy (socket->read_mutex);
+			free (socket->read_mutex);
+		}
 
-        if (socket->write_mutex) {
-            pthread_mutex_unlock (socket->write_mutex);
-            pthread_mutex_destroy (socket->write_mutex);
-            free (socket->write_mutex);
-        }
+		if (socket->write_mutex) {
+			pthread_mutex_unlock (socket->write_mutex);
+			pthread_mutex_destroy (socket->write_mutex);
+			free (socket->write_mutex);
+		}
 
-        free (socket_ptr);
-    }
+		free (socket_ptr);
+	}
 
 }
 
 void *socket_create_empty (void) {
 
-    Socket *socket = socket_new ();
-    if (socket) {
-        socket->read_mutex = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (socket->read_mutex, NULL);
+	Socket *socket = socket_new ();
+	if (socket) {
+		socket->read_mutex = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (socket->read_mutex, NULL);
 
-        socket->write_mutex = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
-        pthread_mutex_init (socket->write_mutex, NULL);
-    }
+		socket->write_mutex = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
+		pthread_mutex_init (socket->write_mutex, NULL);
+	}
 
-    return socket;
+	return socket;
 
 }
 
 Socket *socket_create (int fd) {
 
-    Socket *socket = (Socket *) socket_create_empty ();
-    if (socket) {
-        socket->sock_fd = fd;
-    }
+	Socket *socket = (Socket *) socket_create_empty ();
+	if (socket) {
+		socket->sock_fd = fd;
+	}
 
-    return socket;
+	return socket;
 
 }

--- a/src/cerver/threads/thread.c
+++ b/src/cerver/threads/thread.c
@@ -29,7 +29,7 @@ u8 thread_create_detachable (pthread_t *thread, void *(*work) (void *), void *ar
                 }
 
                 else {
-                    cerver_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create detachable thread!");
+                    cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create detachable thread!");
                     perror ("Error");
                 }
             }

--- a/src/cerver/types/string.c
+++ b/src/cerver/types/string.c
@@ -8,129 +8,129 @@
 
 static inline void char_copy (char *to, char *from) {
 
-    while (*from) *to++ = *from++;
-    *to = '\0';
+	while (*from) *to++ = *from++;
+	*to = '\0';
 
 }
 
 String *str_new (const char *str) {
 
-    String *s = (String *) malloc (sizeof (String));
-    if (s) {
-        if (str) {
-            s->len = strlen (str);
-            s->str = (char *) calloc (s->len + 1, sizeof (char));
-            if (s->str) char_copy (s->str, (char *) str);
-        }
+	String *s = (String *) malloc (sizeof (String));
+	if (s) {
+		if (str) {
+			s->len = strlen (str);
+			s->str = (char *) calloc (s->len + 1, sizeof (char));
+			if (s->str) char_copy (s->str, (char *) str);
+		}
 
-        else {
+		else {
 			s->len = 0;
 			s->str = NULL;
 		}
-    }
+	}
 
-    return s;
+	return s;
 
 }
 
 void str_delete (void *str_ptr) {
 
-    if (str_ptr) {
-        String *str = (String *) str_ptr;
+	if (str_ptr) {
+		String *str = (String *) str_ptr;
 
-        if (str->str) free (str->str);
-        free (str);
-    }
+		if (str->str) free (str->str);
+		free (str);
+	}
 
 }
 
 String *str_create (const char *format, ...) {
 
-    String *s = NULL;
+	String *s = NULL;
 
-    if (format) {
-        char *fmt = strdup (format);
+	if (format) {
+		char *fmt = strdup (format);
 
-        va_list argp;
-        va_start (argp, format);
-        char oneChar[1];
-        int len = vsnprintf (oneChar, 1, fmt, argp);
-        va_end (argp);
+		va_list argp;
+		va_start (argp, format);
+		char oneChar[1];
+		int len = vsnprintf (oneChar, 1, fmt, argp);
+		va_end (argp);
 
-        char *str = (char *) calloc (len + 1, sizeof (char));
+		char *str = (char *) calloc (len + 1, sizeof (char));
 
-        va_start (argp, format);
-        vsnprintf (str, len + 1, fmt, argp);
-        va_end (argp);
+		va_start (argp, format);
+		vsnprintf (str, len + 1, fmt, argp);
+		va_end (argp);
 
-        s = str_new (str);
+		s = str_new (str);
 
-        free (str);
-        free (fmt);
-    }
+		free (str);
+		free (fmt);
+	}
 
-    return s;
+	return s;
 
 }
 
-int str_compare (const String *s1, const String *s2) { 
+int str_compare (const String *s1, const String *s2) {
 
-    if (s1 && s2) return strcmp (s1->str, s2->str); 
-    else if (s1 && !s2) return -1;
-    else if (!s1 && s2) return 1;
-    return 0;
-    
+	if (s1 && s2) return strcmp (s1->str, s2->str);
+	else if (s1 && !s2) return -1;
+	else if (!s1 && s2) return 1;
+	return 0;
+
 }
 
 int str_comparator (const void *a, const void *b) {
 
-    if (a && b) return strcmp (((String *) a)->str, ((String *) b)->str);
-    else if (a && !b) return -1;
-    else if (!a && b) return 1;
-    return 0;
+	if (a && b) return strcmp (((String *) a)->str, ((String *) b)->str);
+	else if (a && !b) return -1;
+	else if (!a && b) return 1;
+	return 0;
 
 }
 
 void str_copy (String *to, String *from) {
 
-    if (to && from) {
-        while (*from->str)
-            *to->str++ = *from->str++;
+	if (to && from) {
+		while (*from->str)
+			*to->str++ = *from->str++;
 
-        *to->str = '\0';
-        to->len = from->len;
-    }
+		*to->str = '\0';
+		to->len = from->len;
+	}
 
 }
 
 void str_replace (String *old, const char *str) {
 
-    if (old && str) {
-        if (old->str) free (old->str);
-        old->len = strlen (str);
-        old->str = (char *) calloc (old->len + 1, sizeof (char));
+	if (old && str) {
+		if (old->str) free (old->str);
+		old->len = strlen (str);
+		old->str = (char *) calloc (old->len + 1, sizeof (char));
 		if (old->str) char_copy (old->str, (char *) str);
-    }
+	}
 
 }
 
 String *str_concat (String *s1, String *s2) {
 
-    String *des = NULL;
+	String *des = NULL;
 
-    if (s1 && s2) {
-        des = str_new (NULL);
-        des->str = (char *) calloc (s1->len + s2->len + 1, sizeof (char));
+	if (s1 && s2) {
+		des = str_new (NULL);
+		des->str = (char *) calloc (s1->len + s2->len + 1, sizeof (char));
 
-        while (*s1->str) *des->str++ = *s1->str++;
-        while (*s2->str) *des->str++ = *s2->str++;
+		while (*s1->str) *des->str++ = *s1->str++;
+		while (*s2->str) *des->str++ = *s2->str++;
 
-        *des->str = '\0';
+		*des->str = '\0';
 
-        des->len = s1->len + s2->len;
-    }
+		des->len = s1->len + s2->len;
+	}
 
-    return des;
+	return des;
 
 }
 
@@ -138,16 +138,16 @@ String *str_concat (String *s1, String *s2) {
 // reallocates the same string
 void str_append_char (String *s, const char c) {
 
-    if (s) {
-        unsigned int new_len = s->len + 1;   
+	if (s) {
+		unsigned int new_len = s->len + 1;
 
-        s->str = (char *) realloc (s->str, new_len);
-        if (s->str) {
-            char *des = s->str + (s->len);
-            *des = c;
-            s->len = new_len;
-        }
-    }
+		s->str = (char *) realloc (s->str, new_len);
+		if (s->str) {
+			char *des = s->str + (s->len);
+			*des = c;
+			s->len = new_len;
+		}
+	}
 
 }
 
@@ -155,28 +155,28 @@ void str_append_char (String *s, const char c) {
 // reallocates the same string
 void str_append_c_string (String *s, const char *c_str) {
 
-    if (s && c_str) {
-        unsigned int new_len = s->len + strlen (c_str);
+	if (s && c_str) {
+		unsigned int new_len = s->len + strlen (c_str);
 
-        s->str = (char *) realloc (s->str, new_len);
-        if (s->str) {
-            char *des = s->str + (s->len);
-            char_copy (des, (char *) c_str);
-            s->len = new_len;
-        }
-    }
+		s->str = (char *) realloc (s->str, new_len);
+		if (s->str) {
+			char *des = s->str + (s->len);
+			char_copy (des, (char *) c_str);
+			s->len = new_len;
+		}
+	}
 
 }
 
 void str_to_upper (String *str) {
 
-    if (str) for (unsigned int i = 0; i < str->len; i++) str->str[i] = toupper (str->str[i]);
+	if (str) for (unsigned int i = 0; i < str->len; i++) str->str[i] = toupper (str->str[i]);
 
 }
 
 void str_to_lower (String *str) {
 
-    if (str) for (unsigned int i = 0; i < str->len; i++) str->str[i] = tolower (str->str[i]);
+	if (str) for (unsigned int i = 0; i < str->len; i++) str->str[i] = tolower (str->str[i]);
 
 }
 
@@ -243,55 +243,55 @@ char **str_split (String *str, const char delim, int *n_tokens) {
 
 void str_remove_char (String *str, char garbage) {
 
-    char *src, *dst;
-    for (src = dst = str->str; *src != '\0'; src++) {
-        *dst = *src;
-        if (*dst != garbage) dst++;
-    }
-    *dst = '\0';
+	char *src, *dst;
+	for (src = dst = str->str; *src != '\0'; src++) {
+		*dst = *src;
+		if (*dst != garbage) dst++;
+	}
+	*dst = '\0';
 
 }
 
 // removes the last char from a string
 void str_remove_last_char (String *s) {
 
-    if (s) {
-        if (s->len > 0) {
-            unsigned int new_len = s->len - 1;
+	if (s) {
+		if (s->len > 0) {
+			unsigned int new_len = s->len - 1;
 
-            s->str = (char *) realloc (s->str, s->len);
-            if (s->str) {
-                s->str[s->len - 1] = '\0';
-                s->len = new_len;
-            }
-        }
-    }
+			s->str = (char *) realloc (s->str, s->len);
+			if (s->str) {
+				s->str[s->len - 1] = '\0';
+				s->len = new_len;
+			}
+		}
+	}
 
 }
 
 int str_contains (String *str, char *to_find) {
 
-    unsigned int slen = str->len;
-    unsigned int tFlen = strlen (to_find);
-    unsigned int found = 0;
+	unsigned int slen = str->len;
+	unsigned int tFlen = strlen (to_find);
+	unsigned int found = 0;
 
-    if (slen >= tFlen) {
-        for (unsigned int s = 0, t = 0; s < slen; s++) {
-            do {
-                if (str->str[s] == to_find[t] ) {
-                    if (++found == tFlen) return 0;
-                    s++;
-                    t++;
-                }
+	if (slen >= tFlen) {
+		for (unsigned int s = 0, t = 0; s < slen; s++) {
+			do {
+				if (str->str[s] == to_find[t] ) {
+					if (++found == tFlen) return 0;
+					s++;
+					t++;
+				}
 
-                else { s -= found; found = 0; t = 0; }
-            } while(found);
-        }
+				else { s -= found; found = 0; t = 0; }
+			} while(found);
+		}
 
-        return 1;
-    }
+		return 1;
+	}
 
-    else return -1;
+	else return -1;
 
 }
 
@@ -300,51 +300,51 @@ int str_contains (String *str, char *to_find) {
 // returns a ptr to a serialized str
 void *str_selialize (String *str, SStringSize size) {
 
-    void *retval = NULL;
+	void *retval = NULL;
 
-    if (str) {
-        switch (size) {
-            case SS_SMALL: {
-                SStringS *s_small = (SStringS *) malloc (sizeof (SStringS));
-                if (s_small) {
-                    memset (s_small, 0, sizeof (SStringS));
-                    strncpy (s_small->str, str->str, 64);
-                    s_small->len = str->len > 64 ? 64 : str->len;
-                    retval = s_small;
-                }
-            } break;
-            case SS_MEDIUM: {
-                SStringM *s_medium = (SStringM *) malloc (sizeof (SStringM));
-                if (s_medium) {
-                    memset (s_medium, 0, sizeof (SStringM));
-                    strncpy (s_medium->str, str->str, 128);
-                    s_medium->len = str->len > 128 ? 128 : str->len;
-                    retval = s_medium;
-                }
-            } break;
-            case SS_LARGE: {
-                SStringL *s_large = (SStringL *) malloc (sizeof (SStringL));
-                if (s_large) {
-                    memset (s_large, 0, sizeof (SStringL));
-                    strncpy (s_large->str, str->str, 256);
-                    s_large->len = str->len > 256 ? 256 : str->len;
-                    retval = s_large;
-                }
-            } break;
-            case SS_EXTRA_LARGE: {
-                SStringXL *s_xlarge = (SStringXL *) malloc (sizeof (SStringXL));
-                if (s_xlarge) {
-                    memset (s_xlarge, 0, sizeof (SStringXL));
-                    strncpy (s_xlarge->str, str->str, 512);
-                    s_xlarge->len = str->len > 512 ? 512 : str->len;
-                    retval = s_xlarge;
-                }
-            } break;
+	if (str) {
+		switch (size) {
+			case SS_SMALL: {
+				SStringS *s_small = (SStringS *) malloc (sizeof (SStringS));
+				if (s_small) {
+					memset (s_small, 0, sizeof (SStringS));
+					strncpy (s_small->str, str->str, 64);
+					s_small->len = str->len > 64 ? 64 : str->len;
+					retval = s_small;
+				}
+			} break;
+			case SS_MEDIUM: {
+				SStringM *s_medium = (SStringM *) malloc (sizeof (SStringM));
+				if (s_medium) {
+					memset (s_medium, 0, sizeof (SStringM));
+					strncpy (s_medium->str, str->str, 128);
+					s_medium->len = str->len > 128 ? 128 : str->len;
+					retval = s_medium;
+				}
+			} break;
+			case SS_LARGE: {
+				SStringL *s_large = (SStringL *) malloc (sizeof (SStringL));
+				if (s_large) {
+					memset (s_large, 0, sizeof (SStringL));
+					strncpy (s_large->str, str->str, 256);
+					s_large->len = str->len > 256 ? 256 : str->len;
+					retval = s_large;
+				}
+			} break;
+			case SS_EXTRA_LARGE: {
+				SStringXL *s_xlarge = (SStringXL *) malloc (sizeof (SStringXL));
+				if (s_xlarge) {
+					memset (s_xlarge, 0, sizeof (SStringXL));
+					strncpy (s_xlarge->str, str->str, 512);
+					s_xlarge->len = str->len > 512 ? 512 : str->len;
+					retval = s_xlarge;
+				}
+			} break;
 
-            default: break;
-        }
-    }
+			default: break;
+		}
+	}
 
-    return retval;
+	return retval;
 
 }

--- a/src/cerver/utils/base64.c
+++ b/src/cerver/utils/base64.c
@@ -1,70 +1,64 @@
 #include <string.h>
 
-/* ASCII table */
-/* aaaack but it's fast and const should make it shared text page. */
 static const unsigned char pr2six[256] = {
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
-    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
-    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+	52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+	64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+	15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+	64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+	41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
 };
 
 int base64_decode (char *bufplain, const char *bufcoded) {
 
-    int nbytesdecoded = 0;
-    register const unsigned char *bufin = NULL;
-    register unsigned char *bufout = NULL;
-    register int nprbytes = 0;
+	int nbytesdecoded = 0;
+	register const unsigned char *bufin = NULL;
+	register unsigned char *bufout = NULL;
+	register int nprbytes = 0;
 
-    bufin = (const unsigned char *) bufcoded;
-    while (pr2six[*(bufin++)] <= 63);
-    nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
-    nbytesdecoded = ((nprbytes + 3) / 4) * 3;
+	bufin = (const unsigned char *) bufcoded;
+	while (pr2six[*(bufin++)] <= 63);
+	nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+	nbytesdecoded = ((nprbytes + 3) / 4) * 3;
 
-    bufout = (unsigned char *) bufplain;
-    bufin = (const unsigned char *) bufcoded;
+	bufout = (unsigned char *) bufplain;
+	bufin = (const unsigned char *) bufcoded;
 
-    while (nprbytes > 4) {
-		*(bufout++) =
-			(unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
-		*(bufout++) =
-			(unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
-		*(bufout++) =
-			(unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+	while (nprbytes > 4) {
+		*(bufout++) = (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+		*(bufout++) = (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+		*(bufout++) = (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
 		bufin += 4;
 		nprbytes -= 4;
-    }
+	}
 
-    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
-    if (nprbytes > 1) {
-    *(bufout++) =
-        (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
-    }
-    if (nprbytes > 2) {
-    *(bufout++) =
-        (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
-    }
-    if (nprbytes > 3) {
-    *(bufout++) =
-        (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
-    }
+	/* Note: (nprbytes == 1) would be an error, so just ingore that case */
+	if (nprbytes > 1) {
+		*(bufout++) = (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+	}
 
-    *(bufout++) = '\0';
-    nbytesdecoded -= (4 - nprbytes) & 3;
+	if (nprbytes > 2) {
+		*(bufout++) = (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+	}
 
-    return nbytesdecoded;
+	if (nprbytes > 3) {
+		*(bufout++) = (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+	}
+
+	*(bufout++) = '\0';
+	nbytesdecoded -= (4 - nprbytes) & 3;
+
+	return nbytesdecoded;
 
 }
 
@@ -72,33 +66,32 @@ static const char basis_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv
 
 int base64_encode (char *encoded, const char *string, int len) {
 
-    int i = 0;
-    char *p = encoded;
-    for (i = 0; i < len - 2; i += 3) {
+	int i = 0;
+	char *p = encoded;
+	for (i = 0; i < len - 2; i += 3) {
 		*p++ = basis_64[(string[i] >> 2) & 0x3F];
-		*p++ = basis_64[((string[i] & 0x3) << 4) |
-						((int) (string[i + 1] & 0xF0) >> 4)];
-		*p++ = basis_64[((string[i + 1] & 0xF) << 2) |
-						((int) (string[i + 2] & 0xC0) >> 6)];
+		*p++ = basis_64[((string[i] & 0x3) << 4) | ((int) (string[i + 1] & 0xF0) >> 4)];
+		*p++ = basis_64[((string[i + 1] & 0xF) << 2) | ((int) (string[i + 2] & 0xC0) >> 6)];
 		*p++ = basis_64[string[i + 2] & 0x3F];
-    }
+	}
 
-    if (i < len) {
+	if (i < len) {
 		*p++ = basis_64[(string[i] >> 2) & 0x3F];
 		if (i == (len - 1)) {
 			*p++ = basis_64[((string[i] & 0x3) << 4)];
 			*p++ = '=';
 		}
+
 		else {
-			*p++ = basis_64[((string[i] & 0x3) << 4) |
-							((int) (string[i + 1] & 0xF0) >> 4)];
+			*p++ = basis_64[((string[i] & 0x3) << 4) | ((int) (string[i + 1] & 0xF0) >> 4)];
 			*p++ = basis_64[((string[i + 1] & 0xF) << 2)];
 		}
+
 		*p++ = '=';
-    }
+	}
 
-    *p++ = '\0';
+	*p++ = '\0';
 
-    return p - encoded;
+	return p - encoded;
 
 }

--- a/src/cerver/utils/log.c
+++ b/src/cerver/utils/log.c
@@ -1,15 +1,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include <stdarg.h>
+#include <time.h>
+
+#include "cerver/types/string.h"
 
 #include "cerver/collections/pool.h"
 
+#include "cerver/files.h"
+#include "cerver/version.h"
+
 #include "cerver/utils/utils.h"
 #include "cerver/utils/log.h"
-
-static Pool *log_pool = NULL;
 
 #pragma region types
 
@@ -27,10 +32,108 @@ static const char *log_get_msg_type (LogType type) {
 
 #pragma endregion
 
+#pragma region configuration
+
+static LogOutputType log_output_type = LOG_OUTPUT_TYPE_STD;
+
+static LogTimeType log_time_type = LOG_TIME_TYPE_NONE;
+static bool use_local_time = false;
+
+static String *logs_pathname = NULL;
+static FILE *logfile = NULL;
+
+// returns the current log output type
+LogOutputType cerver_log_get_output_type (void) {
+
+	return log_output_type;
+
+}
+
+// sets the log output type to use
+void cerver_log_set_output_type (LogOutputType type) {
+
+	log_output_type = type;
+
+}
+
+// sets the path where logs files will be stored
+// returns 0 on success, 1 on error
+unsigned int cerver_log_set_path (const char *pathname) {
+
+	unsigned int retval = 1;
+
+	if (pathname) {
+		if (!file_exists (pathname)) {
+			if (!files_create_dir (pathname, 0755)) {
+				logs_pathname = str_new (pathname);
+				retval = 0;
+			}
+		}
+
+		else {
+			logs_pathname = str_new (pathname);
+			retval = 0;
+		}
+	}
+
+	return retval;
+
+}
+
+const char *cerver_log_time_type_to_string (LogTimeType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case LOG_TIME_TYPE_##name: return #string;
+		LOG_TIME_TYPE_MAP(XX)
+		#undef XX
+
+		default: return cerver_log_time_type_to_string (LOG_TIME_TYPE_NONE);
+	}
+
+}
+
+const char *cerver_log_time_type_description (LogTimeType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case LOG_TIME_TYPE_##name: return #description;
+		LOG_TIME_TYPE_MAP(XX)
+		#undef XX
+
+		default: return cerver_log_time_type_description (LOG_TIME_TYPE_NONE);
+	}
+
+}
+
+// returns the current log time configuration
+LogTimeType cerver_log_get_time_config (void) {
+
+	return log_time_type;
+
+}
+
+// sets the log time configuration to be used by log methods
+// none: print logs with no dates
+// time: 24h time format
+// date: day/month/year format
+// both: day/month/year - 24h date time format
+void cerver_log_set_time_config (LogTimeType type) {
+
+	log_time_type = type;
+
+}
+
+// set if logs datetimes will use local time or not
+void cerver_log_set_local_time (bool value) { use_local_time = value; }
+
+#pragma endregion
+
 #pragma region internal
+
+static Pool *log_pool = NULL;
 
 typedef struct {
 
+	char datetime[LOG_DATETIME_SIZE];
 	char header[LOG_HEADER_SIZE];
 	char *second;
 
@@ -42,6 +145,7 @@ static void *cerver_log_new (void) {
 
 	CerverLog *log = (CerverLog *) malloc (sizeof (CerverLog));
 	if (log) {
+		memset (log->datetime, 0, LOG_DATETIME_SIZE);
 		memset (log->header, 0, LOG_HEADER_SIZE);
 		log->second = log->header + LOG_HEADER_HALF_SIZE;
 
@@ -107,16 +211,193 @@ static FILE *cerver_log_get_stream (LogType first_type) {
 
 	FILE *retval = stdout;
 
+	if (logfile) retval = logfile;
+	else {
+		switch (first_type) {
+			case LOG_TYPE_ERROR:
+			case LOG_TYPE_WARNING:
+				retval = stderr;
+				break;
+
+			default: break;
+		}
+	}
+
+	return retval;
+
+}
+
+static void cerver_log_internal_normal_std (
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
 	switch (first_type) {
-		case LOG_TYPE_ERROR:
-		case LOG_TYPE_WARNING:
-			retval = stderr;
+		case LOG_TYPE_NONE: fprintf (stdout, "%s\n", log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (stderr, LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (stderr, LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (stdout, LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+			else fprintf (stdout, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+			else fprintf (stdout, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (stdout, LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (stdout, LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+		default: fprintf (stdout, "%s: %s\n", log->header, log->message); break;
+	}
+
+}
+
+static void cerver_log_internal_normal_file (
+	FILE *__restrict __stream,
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (__stream, "%s\n", log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE) fprintf (__stream, "%s%s: %s\n", log->header, log->second, log->message);
+			else fprintf (__stream,  "%s: %s\n", log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE) fprintf (__stream, "%s%s: %s\n", log->header, log->second, log->message);
+			else fprintf (__stream, "%s: %s\n", log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+
+		default: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+	}
+
+}
+
+static void cerver_log_internal_normal (
+	FILE *__restrict __stream,
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_STD: cerver_log_internal_normal_std (log, first_type, second_type); break;
+		case LOG_OUTPUT_TYPE_FILE: cerver_log_internal_normal_file (__stream, log, first_type, second_type); break;
+
+		case LOG_OUTPUT_TYPE_BOTH:
+			cerver_log_internal_normal_std (log, first_type, second_type);
+			cerver_log_internal_normal_file (__stream, log, first_type, second_type);
 			break;
 
 		default: break;
 	}
 
-	return retval;
+}
+
+static void cerver_log_internal_with_time_std (
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (stdout, "[%s]: %s\n", log->datetime, log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (stderr, "[%s]" LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (stderr, "[%s]" LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (stdout, "[%s]" LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->datetime, log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, "[%s]" LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (stdout, "[%s]" LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->datetime, log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (stdout, "[%s]" LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+
+		default: fprintf (stdout, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+	}
+
+}
+
+static void cerver_log_internal_with_time_file (
+	FILE *__restrict __stream,
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (__stream, "[%s]: %s\n", log->datetime, log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (__stream, "[%s]%s%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (__stream, "[%s]%s%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+
+		default: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+	}
+
+}
+
+static void cerver_log_internal_with_time (
+	FILE *__restrict __stream,
+	CerverLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_STD: cerver_log_internal_with_time_std (log, first_type, second_type); break;
+		case LOG_OUTPUT_TYPE_FILE: cerver_log_internal_with_time_file (__stream, log, first_type, second_type); break;
+
+		case LOG_OUTPUT_TYPE_BOTH:
+			cerver_log_internal_with_time_std (log, first_type, second_type);
+			cerver_log_internal_with_time_file (__stream, log, first_type, second_type);
+			break;
+
+		default: break;
+	}
 
 }
 
@@ -128,33 +409,26 @@ static void cerver_log_internal (
 
 	CerverLog *log = (CerverLog *) pool_pop (log_pool);
 	if (log) {
-		cerver_log_header_create (log, first_type, second_type);
+		if (first_type != LOG_TYPE_NONE) cerver_log_header_create (log, first_type, second_type);
 		(void) vsnprintf (log->message, LOG_MESSAGE_SIZE, format, args);
 
-		switch (first_type) {
-			case LOG_TYPE_ERROR: fprintf (__stream, LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-			case LOG_TYPE_WARNING: fprintf (__stream, LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-			case LOG_TYPE_SUCCESS: fprintf (__stream, LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		if (log_time_type != LOG_TIME_TYPE_NONE) {
+			time_t datetime = time (NULL);
+			struct tm *timeinfo = use_local_time ? localtime (&datetime) : gmtime (&datetime);
 
-			case LOG_TYPE_DEBUG: {
-				if (second_type != LOG_TYPE_NONE)
-					fprintf (__stream, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+			switch (log_time_type) {
+				case LOG_TIME_TYPE_TIME: strftime (log->datetime, LOG_DATETIME_SIZE, "%T", timeinfo); break;
+				case LOG_TIME_TYPE_DATE: strftime (log->datetime, LOG_DATETIME_SIZE, "%d/%m/%y", timeinfo); break;
+				case LOG_TIME_TYPE_BOTH: strftime (log->datetime, LOG_DATETIME_SIZE, "%d/%m/%y - %T", timeinfo); break;
 
-				else fprintf (__stream, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
-			} break;
-			
-			case LOG_TYPE_TEST: {
-				if (second_type != LOG_TYPE_NONE)
-					fprintf (__stream, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+				default: break;
+			}
 
-				else fprintf (__stream, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
-			} break;
+			cerver_log_internal_with_time (__stream, log, first_type, second_type);
+		}
 
-			case LOG_TYPE_CERVER: fprintf (__stream, LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-
-			case LOG_TYPE_EVENT: fprintf (__stream, LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-
-			default: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		else {
+			cerver_log_internal_normal (__stream, log, first_type, second_type);
 		}
 
 		pool_push (log_pool, log);
@@ -166,6 +440,8 @@ static void cerver_log_internal (
 
 #pragma region public
 
+// creates and prints a message of custom types
+// based on the first type, the message can be printed with colors to stdout
 void cerver_log (
 	LogType first_type, LogType second_type,
 	const char *format, ...
@@ -186,20 +462,20 @@ void cerver_log (
 
 }
 
-void cerver_log_msg (
-	FILE *__restrict __stream, 
-	LogType first_type, LogType second_type,
-	const char *msg
-) {
+// prints a message with no type, effectively making this a custom printf ()
+void cerver_log_msg (const char *msg, ...) {
 
-	if (__stream && msg) {
+	if (msg) {
 		va_list args;
+		va_start (args, msg);
 
 		cerver_log_internal (
-			__stream,
-			first_type, second_type,
+			cerver_log_get_stream (LOG_TYPE_NONE),
+			LOG_TYPE_NONE, LOG_TYPE_NONE,
 			msg, args
 		);
+
+		va_end (args);
 	}
 
 }
@@ -212,7 +488,7 @@ void cerver_log_error (const char *msg, ...) {
 		va_start (args, msg);
 
 		cerver_log_internal (
-			stderr,
+			cerver_log_get_stream (LOG_TYPE_ERROR),
 			LOG_TYPE_ERROR, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -230,7 +506,7 @@ void cerver_log_warning (const char *msg, ...) {
 		va_start (args, msg);
 
 		cerver_log_internal (
-			stderr,
+			cerver_log_get_stream (LOG_TYPE_WARNING),
 			LOG_TYPE_WARNING, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -248,7 +524,7 @@ void cerver_log_success (const char *msg, ...) {
 		va_start (args, msg);
 
 		cerver_log_internal (
-			stdout,
+			cerver_log_get_stream (LOG_TYPE_SUCCESS),
 			LOG_TYPE_SUCCESS, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -266,7 +542,7 @@ void cerver_log_debug (const char *msg, ...) {
 		va_start (args, msg);
 
 		cerver_log_internal (
-			stdout,
+			cerver_log_get_stream (LOG_TYPE_DEBUG),
 			LOG_TYPE_DEBUG, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -289,9 +565,43 @@ void cerver_log_init (void) {
 		pool_init (log_pool, cerver_log_new, LOG_POOL_INIT);
 	}
 
+	if (!logs_pathname) {
+		logs_pathname = str_new (LOG_DEFAULT_PATH);
+	}
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_FILE:
+		case LOG_OUTPUT_TYPE_BOTH: {
+			char filename[1024] = { 0 };
+			snprintf (filename, 1024, "%s/%ld.log", logs_pathname->str, time (NULL));
+
+			logfile = fopen (filename, "w+");
+			if (logfile) {
+				fprintf (logfile, "\nCerver Version: %s\n", CERVER_VERSION_NAME);
+				fprintf (logfile, "Release Date & time: %s - %s\n", CERVER_VERSION_DATE, CERVER_VERSION_TIME);
+				fprintf (logfile, "Author: %s\n\n", CERVER_VERSION_AUTHOR);
+			}
+
+			else {
+				fprintf (stderr, "\n\nFailed to open %s log file!\n", filename);
+				perror ("Error");
+				printf ("\n\n");
+			}
+		} break;
+
+		default: break;
+	}
+
 }
 
 void cerver_log_end (void) {
+
+	if (logfile) {
+		fclose (logfile);
+		logfile = NULL;
+	}
+
+	str_delete (logs_pathname);
 
 	pool_delete (log_pool);
 	log_pool = NULL;

--- a/src/cerver/utils/sha-256.c
+++ b/src/cerver/utils/sha-256.c
@@ -31,48 +31,52 @@ static const uint32_t k[] = {
 };
 
 struct buffer_state {
+
 	const uint8_t * p;
 	size_t len;
 	size_t total_len;
 	int single_one_delivered; /* bool */
 	int total_len_delivered; /* bool */
+
 };
 
-static inline uint32_t right_rot(uint32_t value, unsigned int count)
-{
-	/*
-	 * Defined behaviour in standard C for all count where 0 < count < 32,
-	 * which is what we need here.
-	 */
+/*
+* Defined behaviour in standard C for all count where 0 < count < 32,
+* which is what we need here.
+*/
+static inline uint32_t right_rot (uint32_t value, unsigned int count) {
+
 	return value >> count | value << (32 - count);
+
 }
 
-static void init_buf_state(struct buffer_state * state, const void * input, size_t len)
-{
+static void init_buf_state (struct buffer_state *state, const void *input, size_t len) {
+
 	state->p = (uint8_t *) input;
 	state->len = len;
 	state->total_len = len;
 	state->single_one_delivered = 0;
 	state->total_len_delivered = 0;
+
 }
 
 /* Return value: bool */
-static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
-{
-	size_t space_in_chunk;
+static int calc_chunk (uint8_t chunk[CHUNK_SIZE], struct buffer_state * state) {
+
+	size_t space_in_chunk = 0;
 
 	if (state->total_len_delivered) {
 		return 0;
 	}
 
 	if (state->len >= CHUNK_SIZE) {
-		memcpy(chunk, state->p, CHUNK_SIZE);
+		memcpy (chunk, state->p, CHUNK_SIZE);
 		state->p += CHUNK_SIZE;
 		state->len -= CHUNK_SIZE;
 		return 1;
 	}
 
-	memcpy(chunk, state->p, state->len);
+	memcpy (chunk, state->p, state->len);
 	chunk += state->len;
 	space_in_chunk = CHUNK_SIZE - state->len;
 	state->p += state->len;
@@ -95,7 +99,7 @@ static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
 		const size_t left = space_in_chunk - TOTAL_LEN_LEN;
 		size_t len = state->total_len;
 		int i;
-		memset(chunk, 0x00, left);
+		memset (chunk, 0x00, left);
 		chunk += left;
 
 		/* Storing of len * 8 as a big endian 64-bit without overflow. */
@@ -122,6 +126,7 @@ static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
  *   In particular, the len parameter is a number of bytes.
  */
 void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
+
 	/*
 	 * Note 1: All integers (expect indexes) are 32-bit unsigned integers and addition is calculated modulo 2^32.
 	 * Note 2: For each round, there is one round constant k[i] and one entry in the message schedule array w[i], 0 = i = 63
@@ -136,18 +141,18 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 	 * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
 	 */
 	uint32_t h[] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
-	int i, j;
+	int i = 0, j = 0;
 
 	/* 512-bit chunks is what we will operate on. */
-	uint8_t chunk[64];
+	uint8_t chunk[64] = { 0 };
 
-	struct buffer_state state;
+	struct buffer_state state = { 0 };
 
-	init_buf_state(&state, input, len);
+	init_buf_state (&state, input, len);
 
-	while (calc_chunk(chunk, &state)) {
-		uint32_t ah[8];
-		
+	while (calc_chunk (chunk, &state)) {
+		uint32_t ah[8] = { 0 };
+
 		/*
 		 * create a 64-entry message schedule array w[0..63] of 32-bit words
 		 * (The initial values in w[0..63] don't matter, so many implementations zero them here)
@@ -156,7 +161,7 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 		uint32_t w[64];
 		const uint8_t *p = chunk;
 
-		memset(w, 0x00, sizeof w);
+		memset (w, 0x00, sizeof w);
 		for (i = 0; i < 16; i++) {
 			w[i] = (uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 |
 				(uint32_t) p[2] << 8 | (uint32_t) p[3];
@@ -165,21 +170,21 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 
 		/* Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array: */
 		for (i = 16; i < 64; i++) {
-			const uint32_t s0 = right_rot(w[i - 15], 7) ^ right_rot(w[i - 15], 18) ^ (w[i - 15] >> 3);
-			const uint32_t s1 = right_rot(w[i - 2], 17) ^ right_rot(w[i - 2], 19) ^ (w[i - 2] >> 10);
+			const uint32_t s0 = right_rot (w[i - 15], 7) ^ right_rot (w[i - 15], 18) ^ (w[i - 15] >> 3);
+			const uint32_t s1 = right_rot (w[i - 2], 17) ^ right_rot (w[i - 2], 19) ^ (w[i - 2] >> 10);
 			w[i] = w[i - 16] + s0 + w[i - 7] + s1;
 		}
-		
+
 		/* Initialize working variables to current hash value: */
 		for (i = 0; i < 8; i++)
 			ah[i] = h[i];
 
 		/* Compression function main loop: */
 		for (i = 0; i < 64; i++) {
-			const uint32_t s1 = right_rot(ah[4], 6) ^ right_rot(ah[4], 11) ^ right_rot(ah[4], 25);
+			const uint32_t s1 = right_rot (ah[4], 6) ^ right_rot (ah[4], 11) ^ right_rot (ah[4], 25);
 			const uint32_t ch = (ah[4] & ah[5]) ^ (~ah[4] & ah[6]);
 			const uint32_t temp1 = ah[7] + s1 + ch + k[i] + w[i];
-			const uint32_t s0 = right_rot(ah[0], 2) ^ right_rot(ah[0], 13) ^ right_rot(ah[0], 22);
+			const uint32_t s0 = right_rot (ah[0], 2) ^ right_rot (ah[0], 13) ^ right_rot (ah[0], 22);
 			const uint32_t maj = (ah[0] & ah[1]) ^ (ah[0] & ah[2]) ^ (ah[1] & ah[2]);
 			const uint32_t temp2 = s0 + maj;
 
@@ -199,19 +204,19 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 	}
 
 	/* Produce the final hash value (big-endian): */
-	for (i = 0, j = 0; i < 8; i++)
-	{
+	for (i = 0, j = 0; i < 8; i++) {
 		hash[j++] = (uint8_t) (h[i] >> 24);
 		hash[j++] = (uint8_t) (h[i] >> 16);
 		hash[j++] = (uint8_t) (h[i] >> 8);
 		hash[j++] = (uint8_t) h[i];
 	}
+
 }
 
 void sha_256_hash_to_string (char string[65], const uint8_t hash[32]) {
 
 	size_t i;
-	for (i = 0; i < 32; i++) 
+	for (i = 0; i < 32; i++)
 		string += sprintf(string, "%02x", hash[i]);
-	
-}	
+
+}

--- a/src/cerver/version.c
+++ b/src/cerver/version.c
@@ -2,25 +2,25 @@
 
 #include "cerver/version.h"
 
-// print full erver version information 
+// print full erver version information
 void cerver_version_print_full (void) {
 
-    printf ("\nCerver Version: %s\n", CERVER_VERSION_NAME);
-    printf ("Release Date & time: %s - %s\n", CERVER_VERSION_DATE, CERVER_VERSION_TIME);
-    printf ("Author: %s\n\n", CERVER_VERSION_AUTHOR);
+	printf ("\nCerver Version: %s\n", CERVER_VERSION_NAME);
+	printf ("Release Date & time: %s - %s\n", CERVER_VERSION_DATE, CERVER_VERSION_TIME);
+	printf ("Author: %s\n\n", CERVER_VERSION_AUTHOR);
 
 }
 
 // print the version id
 void cerver_version_print_version_id (void) {
 
-    printf ("\nCerver Version ID: %s\n", CERVER_VERSION);
+	printf ("\nCerver Version ID: %s\n", CERVER_VERSION);
 
 }
 
 // print the version name
 void cerver_version_print_version_name (void) {
 
-    printf ("\nCerver Version: %s\n", CERVER_VERSION_NAME);
+	printf ("\nCerver Version: %s\n", CERVER_VERSION_NAME);
 
 }


### PR DESCRIPTION
## General
- Removed _GNU_SOURCE definition from cerver source & header
- Added -std=gnu99 & -D _GNU_SOURCE flags in makefile
- Changes sources indentation from spaces to tabs
- Refactor utilities source structure
- Added logs to .gitignore

## Handler
- Added cerver_client_packet_handler ()
- Updated cerver_request_packet_handler () with file send & get handlers

## Updates
- Updated packets source with new methods & packets types definitions
- Updated cerver events & errors to be organized in an array rather than in a dlist
- Updated admin & auth sources
- Updated client source with latest methods & definitions
- Updated files source to include FileCerver & receive/send files methods

## Fixes
- Added extra check in http_receive_handle_mpart_headers_completed ()
- Small fixes in cerver init logs

## Examples
- Updated examples with latest log methods
- Added files example
- Added client files example
- Added public files configuration in sockets example