### PR TITLE
HTTP Beta 2.0b-4

### DIFF
--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -467,6 +467,16 @@ typedef struct ClientErrorData {
 
 CERVER_PUBLIC void client_error_data_delete (ClientErrorData *error_data);
 
+// creates an error packet ready to be sent
+CERVER_PUBLIC struct _Packet *client_error_packet_generate (const ClientErrorType type, const char *msg);
+
+// creates and send a new error packet
+// returns 0 on success, 1 on error
+CERVER_PUBLIC u8 client_error_packet_generate_and_send (
+	const ClientErrorType type, const char *msg,
+	Client *client, Connection *connection
+);
+
 #pragma endregion
 
 #pragma region client

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-3"
-#define CERVER_VERSION_NAME             "Beta 2.0b-3"
+#define CERVER_VERSION                  "2.0b-4"
+#define CERVER_VERSION_NAME             "Beta 2.0b-4"
 #define CERVER_VERSION_DATE			    "22/10/2020"
-#define CERVER_VERSION_TIME			    "05:25 CST"
+#define CERVER_VERSION_TIME			    "06:38 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ SRCEXT      := c
 DEPEXT      := d
 OBJEXT      := o
 
-CFLAGS      := $(DEVELOPMENT) $(DEFINES) -Wall -Wno-unknown-pragmas -std=gnu99 -fPIC
+CFLAGS      := $(DEVELOPMENT) $(DEFINES) -Wall -Wno-unknown-pragmas -fPIC
 LIB         := $(PTHREAD) $(MATH) $(OPENSSL)
 INC         := -I $(INCDIR) -I /usr/local/include
 INCDEP      := -I $(INCDIR)

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -79,7 +79,7 @@ const char *cerver_handler_type_to_string (CerverHandlerType type) {
 		#undef XX
 	}
 
-	return cerver_handler_type_to_string (CERVER_TYPE_NONE);
+	return cerver_handler_type_to_string (CERVER_HANDLER_TYPE_NONE);
 
 }
 
@@ -91,7 +91,7 @@ const char *cerver_handler_type_description (CerverHandlerType type) {
 		#undef XX
 	}
 
-	return cerver_handler_type_description (CERVER_TYPE_NONE);
+	return cerver_handler_type_description (CERVER_HANDLER_TYPE_NONE);
 
 }
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -1552,6 +1552,56 @@ static void client_error_packet_handler (Packet *packet) {
 
 }
 
+// creates an error packet ready to be sent
+Packet *client_error_packet_generate (const ClientErrorType type, const char *msg) {
+
+	Packet *packet = packet_new ();
+	if (packet) {
+		size_t packet_len = sizeof (PacketHeader) + sizeof (SError);
+
+		packet->packet = malloc (packet_len);
+		packet->packet_size = packet_len;
+
+		char *end = (char *) packet->packet;
+		PacketHeader *header = (PacketHeader *) end;
+		header->packet_type = PACKET_TYPE_ERROR;
+		header->packet_size = packet_len;
+
+		header->request_type = REQUEST_PACKET_TYPE_NONE;
+
+		end += sizeof (PacketHeader);
+
+		SError *s_error = (SError *) end;
+		s_error->error_type = type;
+		s_error->timestamp = time (NULL);
+		memset (s_error->msg, 0, ERROR_MESSAGE_LENGTH);
+		if (msg) strncpy (s_error->msg, msg, ERROR_MESSAGE_LENGTH);
+	}
+
+	return packet;
+
+}
+
+// creates and send a new error packet
+// returns 0 on success, 1 on error
+u8 client_error_packet_generate_and_send (
+	const ClientErrorType type, const char *msg,
+	Client *client, Connection *connection
+) {
+
+	u8 retval = 1;
+
+	Packet *error_packet = client_error_packet_generate (type, msg);
+	if (error_packet) {
+		packet_set_network_values (error_packet, NULL, client, connection, NULL);
+		retval = packet_send (error_packet, 0, NULL, false);
+		packet_delete (error_packet);
+	}
+
+	return retval;
+
+}
+
 #pragma endregion
 
 #pragma region client
@@ -2269,7 +2319,7 @@ u8 client_file_send (Client *client, Connection *connection, const char *filenam
 	u8 retval = 1;
 
 	if (client && connection && filename) {
-		char *last = strrchr (filename, '/');
+		char *last = strrchr ((char *) filename, '/');
 		const char *actual_filename = last ? last + 1 : NULL;
 		if (actual_filename) {
 			// try to open the file
@@ -2284,7 +2334,7 @@ u8 client_file_send (Client *client, Connection *connection, const char *filenam
 				client->file_stats->n_files_sent += 1;
 				client->file_stats->n_bytes_sent += sent;
 
-				if (sent == filestatus.st_size) retval = 0;
+				if (sent == (size_t) filestatus.st_size) retval = 0;
 
 				close (file_fd);
 			}
@@ -2381,7 +2431,7 @@ static void client_request_get_file (Packet *packet) {
 
 	// get the necessary information to fulfil the request
 	if (packet->data_size >= sizeof (FileHeader)) {
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 		FileHeader *file_header = (FileHeader *) end;
 
 		// search for the requested file in the configured paths
@@ -2424,9 +2474,9 @@ static void client_request_get_file (Packet *packet) {
 			#endif
 
 			// if not found, return an error to the client
-			(void) error_packet_generate_and_send (
+			(void) client_error_packet_generate_and_send (
 				CLIENT_ERROR_FILE_NOT_FOUND, "File not found",
-				NULL, packet->client, packet->connection
+				packet->client, packet->connection
 			);
 
 			client->file_stats->n_bad_files_requests += 1;
@@ -2440,9 +2490,9 @@ static void client_request_get_file (Packet *packet) {
 		#endif
 
 		// return a bad request error packet
-		(void) error_packet_generate_and_send (
+		(void) client_error_packet_generate_and_send (
 			CLIENT_ERROR_GET_FILE, "Missing file header",
-			NULL, packet->client, packet->connection
+			packet->client, packet->connection
 		);
 
 		client->file_stats->n_bad_files_requests += 1;
@@ -2458,7 +2508,7 @@ static void client_request_send_file_actual (Packet *packet) {
 
 	// get the necessary information to fulfil the request
 	if (packet->data_size >= sizeof (FileHeader)) {
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 		FileHeader *file_header = (FileHeader *) end;
 
 		const char *file_data = NULL;
@@ -2506,9 +2556,9 @@ static void client_request_send_file_actual (Packet *packet) {
 		#endif
 
 		// return a bad request error packet
-		(void) error_packet_generate_and_send (
+		(void) client_error_packet_generate_and_send (
 			CLIENT_ERROR_SEND_FILE, "Missing file header",
-			NULL, client, packet->connection
+			client, packet->connection
 		);
 
 		client->file_stats->n_bad_files_upload_requests += 1;
@@ -2526,9 +2576,9 @@ static void client_request_send_file (Packet *packet) {
 
 	else {
 		// return a bad request error packet
-		(void) error_packet_generate_and_send (
+		(void) client_error_packet_generate_and_send (
 			CLIENT_ERROR_SEND_FILE, "Unable to process request",
-			NULL, packet->client, packet->connection
+			packet->client, packet->connection
 		);
 
 		#ifdef CLIENT_DEBUG

--- a/src/cerver/errors.c
+++ b/src/cerver/errors.c
@@ -266,9 +266,9 @@ void cerver_error_packet_handler (Packet *packet) {
 				);
 				break;
 			case CERVER_ERROR_FILE_NOT_FOUND:
-				client_error_trigger (
+				cerver_error_event_trigger (
 					CERVER_ERROR_FILE_NOT_FOUND,
-					packet->client, packet->connection,
+					packet->cerver, packet->client, packet->connection,
 					s_error->msg
 				);
 				break;

--- a/src/cerver/files.c
+++ b/src/cerver/files.c
@@ -635,7 +635,7 @@ static int file_send_open (
 
 	int file_fd = -1;
 
-	char *last = strrchr (filename, '/');
+	char *last = strrchr ((char *) filename, '/');
 	*actual_filename = last ? last + 1 : NULL;
 	if (actual_filename) {
 		// try to open the file
@@ -795,7 +795,7 @@ static u8 file_receive_internal (Connection *connection, size_t filelen, int fil
 
 	u8 retval = 1;
 
-	int buff_size = 4096;
+	size_t buff_size = 4096;
 	int pipefds[2] = { 0 };
 	ssize_t received = 0;
 	ssize_t moved = 0;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -545,7 +545,7 @@ static inline void cerver_request_get_file_actual (Packet *packet) {
 
 	// get the necessary information to fulfil the request
 	if (packet->data_size >= sizeof (FileHeader)) {
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 		FileHeader *file_header = (FileHeader *) end;
 
 		// search for the requested file in the configured paths
@@ -654,7 +654,7 @@ static inline void cerver_request_send_file_actual (Packet *packet) {
 
 	// get the necessary information to fulfil the request
 	if (packet->data_size >= sizeof (FileHeader)) {
-		char *end = packet->data;
+		char *end = (char *) packet->data;
 		FileHeader *file_header = (FileHeader *) end;
 
 		const char *file_data = NULL;


### PR DESCRIPTION
## General
- Removed -std=gnu99 option from makefile

## Clients
- Added dedicated client error packets methods

## Fixes
- Fixed cast errors in handler file requests methods
- Small warnings fixes in files methods
- Fixed warnings in cerver_handler_type related methods
- Fixed wrong method call in cerver_error_packet_handler ()