### PR TITLE
HTTP Beta 2.0b-5

### DIFF
--- a/examples/web/public/echo.html
+++ b/examples/web/public/echo.html
@@ -29,7 +29,8 @@
     
       function onOpen (evt) {
         writeToScreen("CONNECTED");
-        doSend("Cerver web sockets work!");
+        // doSend("Cerver web sockets work!");
+        doSend("Cerver is a development framework, created by Ermiry, designed to provide you with the necessary tools for creating fast and reliable multipurpose servers written in C.");
       }
     
       function onClose (evt) {

--- a/examples/web/sockets.c
+++ b/examples/web/sockets.c
@@ -92,7 +92,7 @@ void echo_handler_on_message (
 
 	printf ("echo_handler_on_message ()\n");
 
-	printf ("message[%ld]: %s\n", msg_len, msg);
+	printf ("message[%ld]: %.*s\n", msg_len, (int) msg_len, msg);
 
 	http_web_sockets_send (
 		cerver, connection,

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-4"
-#define CERVER_VERSION_NAME             "Beta 2.0b-4"
-#define CERVER_VERSION_DATE			    "22/10/2020"
-#define CERVER_VERSION_TIME			    "06:38 CST"
+#define CERVER_VERSION                  "2.0b-5"
+#define CERVER_VERSION_NAME             "Beta 2.0b-5"
+#define CERVER_VERSION_DATE			    "25/10/2020"
+#define CERVER_VERSION_TIME			    "19:20 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ DEVELOPMENT	:= -g \
 				-D AUTH_DEBUG 					\
 				-D ADMIN_DEBUG					\
 				-D FILES_DEBUG					\
-				-D HTTP_DEBUG
+				-D HTTP_DEBUG -D HTTP_HEADERS_DEBUG -D HTTP_AUTH_DEBUG -D HTTP_MPART_DEBUG
 
 CC          := gcc
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1528,7 +1528,10 @@ void cerver_receive_handle_buffer (void *receive_handle_ptr) {
 
 		// 28/05/2020 -- deleting the created buffer from cerver_receive ()
 		// to correct handle both cases: using thpool and single threaded
-		if (buffer) free (receive_handle->buffer);
+		if (cerver->handler_type != CERVER_HANDLER_TYPE_THREADS) {
+			// TODO: avoid deleting buffer every time
+			if (buffer) free (receive_handle->buffer);
+		}
 
 		// free (receive->socket->packet_buffer);
 		// receive->socket->packet_buffer = NULL;
@@ -1605,7 +1608,10 @@ void cerver_switch_receive_handle_failed (CerverReceive *cr) {
 
 }
 
-static inline void cerver_receive_success_receive_handle (CerverReceive *cr, ssize_t rc, char *packet_buffer) {
+static inline void cerver_receive_success_receive_handle (
+	CerverReceive *cr, ssize_t rc,
+	char *packet_buffer
+) {
 
 	ReceiveHandle *receive_handle = receive_handle_new ();
 	if (receive_handle) {
@@ -1813,74 +1819,57 @@ void cerver_receive (void *cerver_receive_ptr) {
 }
 
 // packet buffer only gets deleted if cerver_receive_handle_buffer () is used
-static inline u8 cerver_receive_threads_actual (CerverReceive *cr) {
+static inline u8 cerver_receive_threads_actual (
+	CerverReceive *cr,
+	char *buffer, const size_t buffer_size
+) {
 
 	u8 retval = 1;
+	
+	ssize_t rc = recv (cr->socket->sock_fd, buffer, buffer_size, 0);
+	switch (rc) {
+		case -1: {
+			if (errno == EAGAIN) {
+				#ifdef HANDLER_DEBUG
+				cerver_log_debug (
+					"cerver_receive_threads () - sock fd: %d timed out",
+					cr->socket->sock_fd
+				);
+				#endif
 
-	char *packet_buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
-	if (packet_buffer) {
-		ssize_t rc = recv (cr->socket->sock_fd, packet_buffer, cr->cerver->receive_buffer_size, 0);
+				retval = 0;
+			}
 
-		switch (rc) {
-			case -1: {
-				if (cr->socket->sock_fd > -1) {
-					switch (errno) {
-						case EAGAIN: {
-							#ifdef HANDLER_DEBUG
-							cerver_log_debug (
-								"cerver_receive_threads () - sock fd: %d timed out",
-								cr->socket->sock_fd
-							);
-							#endif
-
-							retval = 0;
-						} break;
-
-						default: {
-							#ifdef HANDLER_DEBUG
-							cerver_log (
-								LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-								"cerver_receive_threads () - rc < 0 - sock fd: %d",
-								cr->socket->sock_fd
-							);
-
-							perror ("Error ");
-							#endif
-						} break;
-					}
-				}
-
-				free (packet_buffer);
-			} break;
-
-			case 0: {
+			else {
 				#ifdef HANDLER_DEBUG
 				cerver_log (
-					LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-					"cerver_receive_threads () - rc == 0 - sock fd: %d",
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"cerver_receive_threads () - rc < 0 - sock fd: %d",
 					cr->socket->sock_fd
 				);
 
-				// perror ("Error ");
+				perror ("Error ");
 				#endif
+			}
+		} break;
 
-				free (packet_buffer);
-			} break;
+		case 0: {
+			#ifdef HANDLER_DEBUG
+			cerver_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+				"cerver_receive_threads () - rc == 0 - sock fd: %d",
+				cr->socket->sock_fd
+			);
 
-			default: {
-				cerver_receive_success (cr, rc, packet_buffer);
+			// perror ("Error ");
+			#endif
+		} break;
 
-				retval = 0;
-			} break;
-		}
-	}
+		default: {
+			cerver_receive_success (cr, rc, buffer);
 
-	else {
-		cerver_log (
-			LOG_TYPE_ERROR, LOG_TYPE_HANDLER,
-			"cerver_receive_threads () - Failed to allocate packet buffer for sock fd <%d> connection!",
-			cr->connection->socket->sock_fd
-		);
+			retval = 0;
+		} break;
 	}
 
 	return retval;
@@ -1891,10 +1880,30 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 
 	CerverReceive *cr = (CerverReceive *) cerver_receive_ptr;
 
-	// set the socket's timeout to prevent thread from getting stuck if no more data to read
-	(void) sock_set_timeout (cr->connection->socket->sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
+	i32 sock_fd = cr->socket->sock_fd;
 
-	while (!cerver_receive_threads_actual (cr) && (cr->socket->sock_fd > 0) && cr->cerver->isRunning);
+	// set the socket's timeout to prevent thread from getting stuck if no more data to read
+	(void) sock_set_timeout (sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
+
+	const size_t buffer_size = cr->cerver->receive_buffer_size;
+	char *buffer = (char *) calloc (buffer_size, sizeof (char));
+	if (buffer) {
+		while (
+			(cr->socket->sock_fd > 0)
+			&& cr->cerver->isRunning
+			&& !cerver_receive_threads_actual (cr, buffer, buffer_size)
+		);
+
+		free (buffer);
+	}
+
+	else {
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_HANDLER,
+			"cerver_receive_threads () - Failed to allocate packet buffer for sock fd <%d> connection!",
+			cr->connection->socket->sock_fd
+		);
+	}
 
 	// check if the connection has already ended
 	if (cr->socket->sock_fd > 0) {
@@ -1904,18 +1913,25 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 	cerver_receive_delete (cr);
 
 	#ifdef HANDLER_DEBUG
-	cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_HANDLER, "cerver_receive_threads () - loop has ended");
+	cerver_log (
+		LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
+		"cerver_receive_threads () - loop has ended - dropping sock fd <%d> connection...",
+		sock_fd
+	);
 	#endif
 
 	return NULL;
 
 }
 
-static inline u8 cerver_receive_http_actual (CerverReceive *cr, HttpReceive *http_receive, char *buffer) {
+static inline u8 cerver_receive_http_actual (
+	CerverReceive *cr, HttpReceive *http_receive,
+	char *buffer, const size_t buffer_size
+) {
 
 	u8 retval = 1;
 
-	ssize_t rc = recv (cr->socket->sock_fd, buffer, cr->cerver->receive_buffer_size, 0);
+	ssize_t rc = recv (cr->socket->sock_fd, buffer, buffer_size, 0);
 	switch (rc) {
 		case -1: {
 			if (errno == EAGAIN) {
@@ -1992,12 +2008,13 @@ static void *cerver_receive_http (void *cerver_receive_ptr) {
 	// set the socket's timeout to prevent thread from getting stuck if no more data to read
 	(void) sock_set_timeout (sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
 
-	char *buffer = (char *) calloc (cr->cerver->receive_buffer_size, sizeof (char));
+	const size_t buffer_size = cr->cerver->receive_buffer_size;
+	char *buffer = (char *) calloc (buffer_size, sizeof (char));
 	if (buffer) {
 		while (
 			(cr->socket->sock_fd > -1)
 			&& cr->cerver->isRunning
-			&& !cerver_receive_http_actual (cr, http_receive, buffer) 
+			&& !cerver_receive_http_actual (cr, http_receive, buffer, buffer_size) 
 		);
 
 		free (buffer);

--- a/src/cerver/http/http.c
+++ b/src/cerver/http/http.c
@@ -1827,7 +1827,6 @@ static void http_receive_handle (
 
 #pragma region websockets
 
-// FIXME: handle msg_len >= 126 packets
 // sends a ws message to the selected connection
 // returns 0 on success, 1 on error
 u8 http_web_sockets_send (
@@ -1839,27 +1838,65 @@ u8 http_web_sockets_send (
 
 	unsigned char fin_rsv_opcode = 129;
 
+	size_t header_len = 0;
 	unsigned char res[128] = { 0 };
 
+	unsigned char *end = res;
 	res[0] = fin_rsv_opcode;
-	res[1] = (unsigned char) msg_len;
 
+	ssize_t sent = 0;
+
+	// Unmasked (first length byte < 128)
 	if (msg_len >= 126) {
-		// TODO:
+		ssize_t num_bytes = 0;
+		if (msg_len > 0xffff) {
+			num_bytes = 8;
+			res[1] = 127;
+		}
+
+		else {
+			num_bytes = 2;
+			res[1] = 126;
+		}
+
+		header_len = 2;
+		end += 2;
+		for (ssize_t c = num_bytes -1; c != -1; c--) {
+			*end++ = ((unsigned long long) msg_len >> (8 * c)) % 256;
+			header_len += 1;
+		}
+
+		// first send the header
+		ssize_t s = send (connection->socket->sock_fd, res, header_len, 0);
+		if (s > 0) {
+			sent = s;
+
+			// send the message contents
+			s = send (connection->socket->sock_fd, msg, msg_len, 0);
+			if (s > 0) {
+				sent += s;
+				retval = 0;
+			}
+		}
 	}
 
 	else {
-		for (unsigned int i = 0; i < msg_len; i++) {
-			res[i + 2] = msg[i];
-		}
+		res[1] = (unsigned char) msg_len;
+		end += 2;
+
+		// for (unsigned int i = 0; i < msg_len; i++) {
+		// 	res[i + 2] = msg[i];
+		// }
+
+		memcpy (end, msg, msg_len);
+
+		// send the message contents
+		sent = send (connection->socket->sock_fd, res, msg_len + 2, 0);
+		if (sent > 0) retval = 0;
 	}
 
 	printf ("fin_rsv_opcode: %d\n", res[0]);
 	printf ("res len: %d\n", res[1]);
-	printf ("response: %s\n", res + 2);
-
-	ssize_t sent = send (connection->socket->sock_fd, res, msg_len + 2, 0);
-	if (sent > 0) retval = 0;
 
 	printf ("sent: %ld\n", sent);
 	printf ("\n");
@@ -1877,22 +1914,25 @@ static void http_web_sockets_handler (
 
 	// if connection close
 	if ((fin_rsv_opcode & 0x0f) == 8) {
-
+		// TODO:
+		printf ("connection close\n");
 	}
 
 	// if ping
 	else if ((fin_rsv_opcode & 0x0f) == 9) {
 		printf ("\nPING!\n\n");
+		// TODO:
 	}
 
 	// if pong
 	else if ((fin_rsv_opcode & 0x0f) == 10) {
 		printf ("\nPONG\n\n");
+		// TODO:
 	}
 
 	// if fragmented message and not final fragment
 	else if ((fin_rsv_opcode & 0x80) == 0) {
-
+		// TODO: read the next message
 	}
 
 	else {
@@ -1924,10 +1964,11 @@ static void http_web_sockets_read_message_content (
 
 	// if fragmented message
 	if ((fin_rsv_opcode & 0x80) == 0 || (fin_rsv_opcode & 0x0f) == 0) {
+		printf ("fragmented message\n");
 		if (!http_receive->fragmented_message) {
-			http_receive->fin_rsv_opcode = fin_rsv_opcode;
+			http_receive->fin_rsv_opcode = fin_rsv_opcode |= 0x80;
 			http_receive->fragmented_message = (char *) calloc (message_size, sizeof (char));
-			http_receive->fragmented_message_len = message_size;
+			// http_receive->fragmented_message_len = message_size;
 		}
 
 		else {
@@ -1937,6 +1978,7 @@ static void http_web_sockets_read_message_content (
 		message = http_receive->fragmented_message;
 	}
 
+	// complete message
 	else {
 		message = (char *) calloc (message_size, sizeof (char));
 	}
@@ -1989,7 +2031,7 @@ static void http_web_sockets_receive_handle (
 			length += length_bytes[c] << (8 * (num_bytes - 1 - c));
 		}
 
-		printf ("length: %ld\n", length);
+		printf ("message length: %ld\n", length);
 
 		http_web_sockets_read_message_content (
 			http_receive, 
@@ -2015,6 +2057,8 @@ static void http_web_sockets_receive_handle (
 			length += length_bytes[c] << (8 * (num_bytes - 1 - c));
 		}
 
+		printf ("message length: %ld\n", length);
+
 		http_web_sockets_read_message_content (
 			http_receive, 
 			rc - 10, packet_buffer + 10,
@@ -2023,7 +2067,7 @@ static void http_web_sockets_receive_handle (
 	}
 
 	else {
-		printf ("length: %ld\n", length);
+		printf ("message length: %ld\n", length);
 
 		http_web_sockets_read_message_content (
 			http_receive,

--- a/src/cerver/http/http.c
+++ b/src/cerver/http/http.c
@@ -1308,7 +1308,7 @@ static void http_receive_handle_match_web_socket (
 			char buffer[128] = { 0 };
 			snprintf (buffer, 128, "%s%s", web_socket_key->str, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
 
-			unsigned char hash[SHA_DIGEST_LENGTH];
+			unsigned char hash[SHA_DIGEST_LENGTH] = { 0 };
 			SHA1 ((const unsigned char *) buffer, strlen (buffer), hash);
 
 			memset (buffer, 0, 128);
@@ -1345,7 +1345,8 @@ static void http_receive_handle_match_web_socket (
 					cr->connection->socket->sock_fd
 				);
 
-				// FIXME: end connection with error
+				// end connection to avoid wasting a thread
+				connection_end (http_receive->cr->connection);
 			}
 		}
 
@@ -1569,7 +1570,7 @@ static void http_receive_handle_select_auth_bearer (
 				http_cerver->n_failed_auth_requests += 1;
 			}
 
-			jwt_free(jwt);
+			jwt_free (jwt);
 		}
 
 		else {

--- a/src/cerver/http/multipart.c
+++ b/src/cerver/http/multipart.c
@@ -66,9 +66,9 @@ void http_multi_part_headers_print (MultiPart *mpart) {
 			header = mpart->headers[i];
 
 			switch (i) {
-				case MULTI_PART_HEADER_CONTENT_DISPOSITION		: cerver_log_msg ("Content-Disposition: %s\n", header ? header->str : null); break;
-				case MULTI_PART_HEADER_CONTENT_LENGTH			: cerver_log_msg ("Content-Length: %s\n", header ? header->str : null); break;
-				case MULTI_PART_HEADER_CONTENT_TYPE				: cerver_log_msg ("Content-Type: %s\n", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_DISPOSITION		: cerver_log_msg ("Content-Disposition: %s", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_LENGTH			: cerver_log_msg ("Content-Length: %s", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_TYPE				: cerver_log_msg ("Content-Type: %s", header ? header->str : null); break;
 
 				default: break;
 			}

--- a/src/cerver/http/multipart.c
+++ b/src/cerver/http/multipart.c
@@ -66,9 +66,11 @@ void http_multi_part_headers_print (MultiPart *mpart) {
 			header = mpart->headers[i];
 
 			switch (i) {
-				case MULTI_PART_HEADER_CONTENT_DISPOSITION		: printf ("Content-Disposition: %s\n", header ? header->str : null); break;
-				case MULTI_PART_HEADER_CONTENT_LENGTH			: printf ("Content-Length: %s\n", header ? header->str : null); break;
-				case MULTI_PART_HEADER_CONTENT_TYPE				: printf ("Content-Type: %s\n", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_DISPOSITION		: cerver_log_msg ("Content-Disposition: %s\n", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_LENGTH			: cerver_log_msg ("Content-Length: %s\n", header ? header->str : null); break;
+				case MULTI_PART_HEADER_CONTENT_TYPE				: cerver_log_msg ("Content-Type: %s\n", header ? header->str : null); break;
+
+				default: break;
 			}
 		}
 	}
@@ -164,13 +166,13 @@ multipart_parser *multipart_parser_init (const char *boundary, const multipart_p
 
 }
 
-void multipart_parser_free (multipart_parser *p) { if (p) free(p); }
+void multipart_parser_free (multipart_parser *p) { if (p) free (p); }
 
-size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len) {
+size_t multipart_parser_execute (multipart_parser *p, const char *buf, size_t len) {
 
 	size_t i = 0;
 	size_t mark = 0;
-	char c, cl;
+	char c = 0, cl = 0;
 	int is_last = 0;
 
 	while (i < len) {

--- a/src/cerver/http/request.c
+++ b/src/cerver/http/request.c
@@ -108,40 +108,40 @@ void http_request_headers_print (HttpRequest *http_request) {
 			header = http_request->headers[i];
 
 			switch (i) {
-				case REQUEST_HEADER_ACCEPT							: cerver_log_msg ("Accept: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_CHARSET					: cerver_log_msg ("Accept-Charset: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_ENCODING					: cerver_log_msg ("Accept-Encoding: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_LANGUAGE					: cerver_log_msg ("Accept-Language: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT							: cerver_log_msg ("Accept: %s", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_CHARSET					: cerver_log_msg ("Accept-Charset: %s", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_ENCODING					: cerver_log_msg ("Accept-Encoding: %s", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_LANGUAGE					: cerver_log_msg ("Accept-Language: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_ACCESS_CONTROL_REQUEST_HEADERS	: cerver_log_msg ("Access-Control-Request-Headers: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCESS_CONTROL_REQUEST_HEADERS	: cerver_log_msg ("Access-Control-Request-Headers: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_AUTHORIZATION					: cerver_log_msg ("Authorization: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_AUTHORIZATION					: cerver_log_msg ("Authorization: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CACHE_CONTROL					: cerver_log_msg ("Cache-Control: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CACHE_CONTROL					: cerver_log_msg ("Cache-Control: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CONNECTION						: cerver_log_msg ("Connection: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CONNECTION						: cerver_log_msg ("Connection: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CONTENT_LENGTH					: cerver_log_msg ("Content-Length: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_CONTENT_TYPE					: cerver_log_msg ("Content-Type: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CONTENT_LENGTH					: cerver_log_msg ("Content-Length: %s", header ? header->str : null); break;
+				case REQUEST_HEADER_CONTENT_TYPE					: cerver_log_msg ("Content-Type: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_COOKIE							: cerver_log_msg ("Cookie: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_COOKIE							: cerver_log_msg ("Cookie: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_DATE							: cerver_log_msg ("Date: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_DATE							: cerver_log_msg ("Date: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_EXPECT							: cerver_log_msg ("Expect: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_EXPECT							: cerver_log_msg ("Expect: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_HOST							: cerver_log_msg ("Host: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_HOST							: cerver_log_msg ("Host: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_ORIGIN							: cerver_log_msg ("Origin: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ORIGIN							: cerver_log_msg ("Origin: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_PROXY_AUTHORIZATION				: cerver_log_msg ("Proxy-Authorization: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_PROXY_AUTHORIZATION				: cerver_log_msg ("Proxy-Authorization: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_UPGRADE							: cerver_log_msg ("Upgrade: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_UPGRADE							: cerver_log_msg ("Upgrade: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_USER_AGENT						: cerver_log_msg ("User-Agent: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_USER_AGENT						: cerver_log_msg ("User-Agent: %s", header ? header->str : null); break;
 
-				case REQUEST_HEADER_WEB_SOCKET_KEY					: cerver_log_msg ("Sec-WebSocket-Key: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_WEB_SOCKET_VERSION				: cerver_log_msg ("Sec-WebSocket-Version: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_WEB_SOCKET_KEY					: cerver_log_msg ("Sec-WebSocket-Key: %s", header ? header->str : null); break;
+				case REQUEST_HEADER_WEB_SOCKET_VERSION				: cerver_log_msg ("Sec-WebSocket-Version: %s", header ? header->str : null); break;
 
 				default: break;
 			}

--- a/src/cerver/http/request.c
+++ b/src/cerver/http/request.c
@@ -108,40 +108,42 @@ void http_request_headers_print (HttpRequest *http_request) {
 			header = http_request->headers[i];
 
 			switch (i) {
-				case REQUEST_HEADER_ACCEPT							: printf ("Accept: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_CHARSET					: printf ("Accept-Charset: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_ENCODING					: printf ("Accept-Encoding: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_ACCEPT_LANGUAGE					: printf ("Accept-Language: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT							: cerver_log_msg ("Accept: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_CHARSET					: cerver_log_msg ("Accept-Charset: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_ENCODING					: cerver_log_msg ("Accept-Encoding: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCEPT_LANGUAGE					: cerver_log_msg ("Accept-Language: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_ACCESS_CONTROL_REQUEST_HEADERS	: printf ("Access-Control-Request-Headers: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ACCESS_CONTROL_REQUEST_HEADERS	: cerver_log_msg ("Access-Control-Request-Headers: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_AUTHORIZATION					: printf ("Authorization: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_AUTHORIZATION					: cerver_log_msg ("Authorization: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CACHE_CONTROL					: printf ("Cache-Control: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CACHE_CONTROL					: cerver_log_msg ("Cache-Control: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CONNECTION						: printf ("Connection: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CONNECTION						: cerver_log_msg ("Connection: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_CONTENT_LENGTH					: printf ("Content-Length: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_CONTENT_TYPE					: printf ("Content-Type: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CONTENT_LENGTH					: cerver_log_msg ("Content-Length: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_CONTENT_TYPE					: cerver_log_msg ("Content-Type: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_COOKIE							: printf ("Cookie: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_COOKIE							: cerver_log_msg ("Cookie: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_DATE							: printf ("Date: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_DATE							: cerver_log_msg ("Date: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_EXPECT							: printf ("Expect: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_EXPECT							: cerver_log_msg ("Expect: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_HOST							: printf ("Host: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_HOST							: cerver_log_msg ("Host: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_ORIGIN							: printf ("Origin: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_ORIGIN							: cerver_log_msg ("Origin: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_PROXY_AUTHORIZATION				: printf ("Proxy-Authorization: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_PROXY_AUTHORIZATION				: cerver_log_msg ("Proxy-Authorization: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_UPGRADE							: printf ("Upgrade: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_UPGRADE							: cerver_log_msg ("Upgrade: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_USER_AGENT						: printf ("User-Agent: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_USER_AGENT						: cerver_log_msg ("User-Agent: %s\n", header ? header->str : null); break;
 
-				case REQUEST_HEADER_WEB_SOCKET_KEY					: printf ("Sec-WebSocket-Key: %s\n", header ? header->str : null); break;
-				case REQUEST_HEADER_WEB_SOCKET_VERSION				: printf ("Sec-WebSocket-Version: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_WEB_SOCKET_KEY					: cerver_log_msg ("Sec-WebSocket-Key: %s\n", header ? header->str : null); break;
+				case REQUEST_HEADER_WEB_SOCKET_VERSION				: cerver_log_msg ("Sec-WebSocket-Version: %s\n", header ? header->str : null); break;
+
+				default: break;
 			}
 		}
 	}


### PR DESCRIPTION
## General
- Added more http definitions to print additional debug logs

## Handler
- Refactor cerver_receive_threads () to allocate receive buffer only once
- Refactor cerver_receive_http () to only allocate the receive buffer once

## HTTP
- More work in web sockets receive & send related methods
- Closing connection on failed sock_set_timeout () when upgrading to ws
- Refactor request & multipart print headers methods to use cerver_log_msg

## Examples
- Small fix in echo_handler_on_message () in sockets example
- Sending a bigger message to test web sockets