### PR TITLE
HTTP Beta 2.0b-12

### DIFF
--- a/examples/web/web.c
+++ b/examples/web/web.c
@@ -131,6 +131,23 @@ void custom_handler (CerverReceive *cr, HttpRequest *request) {
 
 }
 
+// GET /reference
+void reference_handler (CerverReceive *cr, HttpRequest *request) {
+
+	char *json = (char *) calloc (256, sizeof (char));
+	if (json) {
+		strncpy (json, "{\"oki\": \"doki\"}", 256);
+
+		(void) http_response_json_custom_reference_send (
+			cr,
+			(http_status) 200, json, strlen (json)
+		);
+
+		free (json);
+	}
+
+}
+
 #pragma endregion
 
 #pragma region start
@@ -194,6 +211,10 @@ int main (int argc, char **argv) {
 		// GET /custom
 		HttpRoute *custom_route = http_route_create (REQUEST_METHOD_GET, "custom", custom_handler);
 		http_cerver_route_register (http_cerver, custom_route);
+
+		// GET /reference
+		HttpRoute *reference_route = http_route_create (REQUEST_METHOD_GET, "reference", reference_handler);
+		http_cerver_route_register (http_cerver, reference_route);
 
 		if (cerver_start (web_cerver)) {
 			cerver_log_error (

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -100,6 +100,10 @@ extern int dlist_insert_after (DoubleList *dlist, ListElement *element, const vo
 // returns 0 on success, 1 on error
 extern int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos);
 
+// inserts at the end of the dlist, after the last element
+// returns 0 on success, 1 on error
+extern int dlist_insert_at_end (DoubleList *dlist, const void *data);
+
 /*** remove ***/
 
 // finds the data using the query and the list comparator and the removes it from the list
@@ -147,7 +151,9 @@ extern ListElement *dlist_get_element (
 );
 
 // traverses the dlist and returns the list element at the specified index
-extern ListElement *dlist_get_element_at (const DoubleList *dlist, const unsigned int idx);
+extern ListElement *dlist_get_element_at (
+	const DoubleList *dlist, const unsigned int idx
+);
 
 // traverses the dlist and returns the data of the list element at the specified index
 extern void *dlist_get_at (const DoubleList *dlist, const unsigned int idx);
@@ -157,7 +163,9 @@ extern void *dlist_get_at (const DoubleList *dlist, const unsigned int idx);
 // uses merge sort to sort the list using the comparator
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
 // return 0 on succes 1 on error
-extern int dlist_sort (DoubleList *dlist, int (*compare)(const void *one, const void *two));
+extern int dlist_sort (
+	DoubleList *dlist, int (*compare)(const void *one, const void *two)
+);
 
 /*** Other ***/
 
@@ -177,7 +185,9 @@ extern DoubleList *dlist_copy (const DoubleList *dlist);
 	// and should return the same structure type as the original method that can be safely deleted
 	// with the dlist's delete method
 // the new dlist's delete and comparator methods are set from the original
-extern DoubleList *dlist_clone (const DoubleList *dlist, void *(*clone) (const void *original));
+extern DoubleList *dlist_clone (
+	const DoubleList *dlist, void *(*clone) (const void *original)
+);
 
 // splits the original dlist into two halfs
 // if dlist->size is odd, extra element will be left in the first half (dlist)

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -100,6 +100,10 @@ extern int dlist_insert_after (DoubleList *dlist, ListElement *element, const vo
 // returns 0 on success, 1 on error
 extern int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos);
 
+// inserts at the start of the dlist, before the first element
+// returns 0 on success, 1 on error
+extern int dlist_insert_at_start (DoubleList *dlist, const void *data);
+
 // inserts at the end of the dlist, after the last element
 // returns 0 on success, 1 on error
 extern int dlist_insert_at_end (DoubleList *dlist, const void *data);

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -90,10 +90,24 @@ extern void dlist_clear_or_delete (void *dlist_ptr);
 // returns 0 on success, 1 on error
 extern int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *data);
 
+// works as dlist_insert_before ()
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+extern int dlist_insert_before_unsafe (
+	DoubleList *dlist, ListElement *element, const void *data
+);
+
 // inserts the data in the double list AFTER the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
 extern int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *data);
+
+// works as dlist_insert_after ()
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+extern int dlist_insert_after_unsafe (
+	DoubleList *dlist, ListElement *element, const void *data
+);
 
 // inserts the data in the double list in the specified pos (0 indexed)
 // if the pos is greater than the current size, it will be added at the end
@@ -104,9 +118,19 @@ extern int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned 
 // returns 0 on success, 1 on error
 extern int dlist_insert_at_start (DoubleList *dlist, const void *data);
 
+// inserts at the start of the dlist, before the first element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+extern int dlist_insert_at_start_unsafe (DoubleList *dlist, const void *data);
+
 // inserts at the end of the dlist, after the last element
 // returns 0 on success, 1 on error
 extern int dlist_insert_at_end (DoubleList *dlist, const void *data);
+
+// inserts at the end of the dlist, after the last element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+extern int dlist_insert_at_end_unsafe (DoubleList *dlist, const void *data);
 
 /*** remove ***/
 

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -146,6 +146,26 @@ extern void *dlist_remove (
 // NULL for the start of the list
 extern void *dlist_remove_element (DoubleList *dlist, ListElement *element);
 
+// works as dlist_remove_element ()
+// this method is NOT thread safe
+extern void *dlist_remove_element_unsafe (DoubleList *dlist, ListElement *element);
+
+// removes the element at the start of the dlist
+// returns the element's data
+extern void *dlist_remove_start (DoubleList *dlist);
+
+// works as dlist_remove_start ()
+// this method is NOT thread safe
+extern void *dlist_remove_start_unsafe (DoubleList *dlist);
+
+// removes the element at the end of the dlist
+// returns the element's data
+extern void *dlist_remove_end (DoubleList *dlist);
+
+// works as dlist_remove_end ()
+// this method is NOT thread safe
+extern void *dlist_remove_end_unsafe (DoubleList *dlist);
+
 // removes the dlist element from the dlist at the specified index 
 // returns the data or NULL if index was invalid
 extern void *dlist_remove_at (DoubleList *dlist, const unsigned int idx);

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -27,8 +27,6 @@ typedef struct DoubleList {
 
 } DoubleList;
 
-// #define dlist_size(list) ((list)->size)
-
 #define dlist_start(list) ((list)->start)
 #define dlist_end(list) ((list)->end)
 
@@ -37,7 +35,10 @@ typedef struct DoubleList {
 
 // sets a list compare function
 // compare must return -1 if one < two, must return 0 if they are equal, and must return 1 if one > two
-extern void dlist_set_compare (DoubleList *list, int (*compare)(const void *one, const void *two));
+extern void dlist_set_compare (
+	DoubleList *list,
+	int (*compare)(const void *one, const void *two)
+);
 
 // sets list destroy function
 extern void dlist_set_destroy (DoubleList *list, void (*destroy)(void *data));
@@ -62,8 +63,10 @@ extern int dlist_delete_if_not_empty (void *dlist_ptr);
 // creates a new double list (double linked list)
 // destroy is the method used to free up the data, NULL to use the default free
 // compare must return -1 if one < two, must return 0 if they are equal, and must return 1 if one > two
-extern DoubleList *dlist_init (void (*destroy)(void *data),
-	int (*compare)(const void *one, const void *two));
+extern DoubleList *dlist_init (
+	void (*destroy)(void *data),
+	int (*compare)(const void *one, const void *two)
+);
 
 // destroys all of the dlist's elements and their data but keeps the dlist
 extern void dlist_reset (DoubleList *dlist);
@@ -102,7 +105,10 @@ extern int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned 
 // finds the data using the query and the list comparator and the removes it from the list
 // and returns the list element's data
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
-extern void *dlist_remove (DoubleList *dlist, const void *query, int (*compare)(const void *one, const void *two));
+extern void *dlist_remove (
+	DoubleList *dlist, 
+	const void *query, int (*compare)(const void *one, const void *two)
+);
 
 // removes the dlist element from the dlist and returns the data
 // NULL for the start of the list
@@ -117,18 +123,28 @@ extern void *dlist_remove_at (DoubleList *dlist, const unsigned int idx);
 // traverses the dlist and for each element, calls the method by passing the list element data and the method args as both arguments
 // this method is thread safe
 // returns 0 on success, 1 on error
-extern int dlist_traverse (const DoubleList *dlist, 
-	void (*method)(void *list_element_data, void *method_args), void *method_args);
+extern int dlist_traverse (
+	const DoubleList *dlist, 
+	void (*method)(void *list_element_data, void *method_args),
+	void *method_args
+);
 
 // uses the list comparator to search using the data as the query
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
 // returns the double list's element data
-extern void *dlist_search (const DoubleList *dlist, const void *data, int (*compare)(const void *one, const void *two));
+extern void *dlist_search (
+	const DoubleList *dlist,
+	const void *data,
+	int (*compare)(const void *one, const void *two)
+);
 
 // searches the dlist and returns the dlist element associated with the data
 // option to pass a custom compare method for searching
-extern ListElement *dlist_get_element (const DoubleList *dlist, const void *data, 
-	int (*compare)(const void *one, const void *two));
+extern ListElement *dlist_get_element (
+	const DoubleList *dlist,
+	const void *data, 
+	int (*compare)(const void *one, const void *two)
+);
 
 // traverses the dlist and returns the list element at the specified index
 extern ListElement *dlist_get_element_at (const DoubleList *dlist, const unsigned int idx);

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -33,6 +33,9 @@ typedef struct DoubleList {
 #define dlist_element_data(element) ((element)->data)
 #define dlist_element_next(element) ((element)->next)
 
+#define dlist_for_each(dlist, le)					\
+	for (le = dlist->start; le; le = le->next)
+
 // sets a list compare function
 // compare must return -1 if one < two, must return 0 if they are equal, and must return 1 if one > two
 extern void dlist_set_compare (

--- a/include/cerver/http/response.h
+++ b/include/cerver/http/response.h
@@ -172,6 +172,21 @@ CERVER_EXPORT u8 http_response_json_custom_send (
 	unsigned int status, const char *json
 );
 
+// creates a http response with the defined status code
+// and the body with a reference to a custom json
+CERVER_EXPORT HttpResponse *http_response_json_custom_reference (
+	http_status status,
+	const char *json, const size_t json_len
+);
+
+// creates and sends a http custom json reference response with the defined status code
+// returns 0 on success, 1 on error
+CERVER_EXPORT u8 http_response_json_custom_reference_send (
+	CerverReceive *cr,
+	unsigned int status,
+	const char *json, const size_t json_len
+);
+
 #pragma endregion
 
 #endif

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-11"
-#define CERVER_VERSION_NAME             "Beta 2.0b-11"
-#define CERVER_VERSION_DATE			    "07/11/2020"
-#define CERVER_VERSION_TIME			    "17:25 CST"
+#define CERVER_VERSION                  "2.0b-12"
+#define CERVER_VERSION_NAME             "Beta 2.0b-12"
+#define CERVER_VERSION_DATE			    "08/11/2020"
+#define CERVER_VERSION_TIME			    "16:35 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -440,7 +440,10 @@ int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos
 // finds the data using the query and the list comparator and the removes it from the list
 // and returns the list element's data
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
-void *dlist_remove (DoubleList *dlist, const void *query, int (*compare)(const void *one, const void *two)) {
+void *dlist_remove (
+	DoubleList *dlist,
+	const void *query, int (*compare)(const void *one, const void *two)
+) {
 
 	void *retval = NULL;
 
@@ -543,7 +546,10 @@ void *dlist_remove_at (DoubleList *dlist, const unsigned int idx) {
 // traverses the dlist and for each element, calls the method by passing the list element data and the method args as both arguments
 // this method is thread safe
 // returns 0 on success, 1 on error
-int dlist_traverse (const DoubleList *dlist, void (*method)(void *list_element_data, void *method_args), void *method_args) {
+int dlist_traverse (
+	const DoubleList *dlist,
+	void (*method)(void *list_element_data, void *method_args), void *method_args
+) {
 
 	int retval = 1;
 
@@ -566,7 +572,11 @@ int dlist_traverse (const DoubleList *dlist, void (*method)(void *list_element_d
 // uses the list comparator to search using the data as the query
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
 // returns the double list's element data
-void *dlist_search (const DoubleList *dlist, const void *data, int (*compare)(const void *one, const void *two)) {
+void *dlist_search (
+	const DoubleList *dlist,
+	const void *data,
+	int (*compare)(const void *one, const void *two)
+) {
 
 	if (dlist && data) {
 		int (*comp)(const void *one, const void *two) = compare ? compare : dlist->compare;
@@ -587,8 +597,10 @@ void *dlist_search (const DoubleList *dlist, const void *data, int (*compare)(co
 
 // searches the dlist and returns the dlist element associated with the data
 // option to pass a custom compare method for searching, if NULL, dlist's compare method will be used
-ListElement *dlist_get_element (const DoubleList *dlist, const void *data, 
-	int (*compare)(const void *one, const void *two)) {
+ListElement *dlist_get_element (
+	const DoubleList *dlist, const void *data, 
+	int (*compare)(const void *one, const void *two)
+) {
 
 	if (dlist && data) {
 		int (*comp)(const void *one, const void *two) = compare ? compare : dlist->compare;
@@ -660,8 +672,10 @@ static ListElement *dllist_split (ListElement *head) {
 }  
 
 // Function to merge two linked lists 
-static ListElement *dllist_merge (int (*compare)(const void *one, const void *two), 
-	ListElement *first, ListElement *second)  { 
+static ListElement *dllist_merge (
+	int (*compare)(const void *one, const void *two), 
+	ListElement *first, ListElement *second
+) {
 
 	// If first linked dlist is empty 
 	if (!first) return second; 
@@ -687,8 +701,10 @@ static ListElement *dllist_merge (int (*compare)(const void *one, const void *tw
 } 
 
 // merge sort
-static ListElement *dlist_merge_sort (ListElement *head, 
-	int (*compare)(const void *one, const void *two)) {
+static ListElement *dlist_merge_sort (
+	ListElement *head, 
+	int (*compare)(const void *one, const void *two)
+) {
 
 	if (!head || !head->next) return head;
 
@@ -791,7 +807,9 @@ DoubleList *dlist_copy (const DoubleList *dlist) {
 	// and should return the same structure type as the original method that can be safely deleted
 	// with the dlist's delete method
 // the new dlist's delete and comparator methods are set from the original
-DoubleList *dlist_clone (const DoubleList *dlist, void *(*clone) (const void *original)) {
+DoubleList *dlist_clone (
+	const DoubleList *dlist, void *(*clone) (const void *original)
+) {
 
 	DoubleList *dlist_clone = NULL;
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -100,7 +100,6 @@ static void dlist_internal_delete (DoubleList *dlist) {
 		data = dlist_internal_remove_element (dlist, NULL);
 		if (data) {
 			if (dlist->destroy) dlist->destroy (data);
-			else free (data);
 		}
 	}
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -42,74 +42,65 @@ static DoubleList *dlist_new (void) {
 
 static void *dlist_internal_remove_element (DoubleList *dlist, ListElement *element) {
 
-	if (dlist) {
-		void *data = NULL;
-		if (dlist->size > 0) {
-			ListElement *old;
+	void *data = NULL;
+	if (dlist->size > 0) {
+		ListElement *old = NULL;
 
-			if (element == NULL) {
-				data = dlist->start->data;
-				old = dlist->start;
-				dlist->start = dlist->start->next;
-				if (dlist->start != NULL) dlist->start->prev = NULL;
+		if (element == NULL) {
+			data = dlist->start->data;
+			old = dlist->start;
+			dlist->start = dlist->start->next;
+			if (dlist->start != NULL) dlist->start->prev = NULL;
+		}
+
+		else {
+			data = element->data;
+			old = element;
+
+			ListElement *prevElement = element->prev;
+			ListElement *nextElement = element->next;
+
+			if (prevElement != NULL && nextElement != NULL) {
+				prevElement->next = nextElement;
+				nextElement->prev = prevElement;
 			}
 
 			else {
-				data = element->data;
-				old = element;
-
-				ListElement *prevElement = element->prev;
-				ListElement *nextElement = element->next;
-
-				if (prevElement != NULL && nextElement != NULL) {
-					prevElement->next = nextElement;
-					nextElement->prev = prevElement;
+				// we are at the start of the dlist
+				if (prevElement == NULL) {
+					if (nextElement != NULL) nextElement->prev = NULL;
+					dlist->start = nextElement;
 				}
 
-				else {
-					// we are at the start of the dlist
-					if (prevElement == NULL) {
-						if (nextElement != NULL) nextElement->prev = NULL;
-						dlist->start = nextElement;
-					}
-
-					// we are at the end of the dlist
-					if (nextElement == NULL) {
-						if (prevElement != NULL) prevElement->next = NULL;
-						dlist->end = prevElement;
-					}
+				// we are at the end of the dlist
+				if (nextElement == NULL) {
+					if (prevElement != NULL) prevElement->next = NULL;
+					dlist->end = prevElement;
 				}
-			}
-
-			list_element_delete (old);
-			dlist->size--;
-
-			if (dlist->size == 0) {
-				dlist->start = NULL;
-				dlist->end = NULL;
 			}
 		}
 
-		return data;
+		list_element_delete (old);
+		dlist->size--;
+
+		if (dlist->size == 0) {
+			dlist->start = NULL;
+			dlist->end = NULL;
+		}
 	}
 
-	return NULL;
+	return data;
 
 }
 
 static void dlist_internal_delete (DoubleList *dlist) {
 
-	if (dlist) {
-		if (dlist->size > 0) {
-			void *data = NULL;
-
-			while (dlist->size > 0) {
-				data = dlist_internal_remove_element (dlist, NULL);
-				if (data) {
-					if (dlist->destroy) dlist->destroy (data);
-					else free (data);
-				}
-			}
+	void *data = NULL;
+	while (dlist->size > 0) {
+		data = dlist_internal_remove_element (dlist, NULL);
+		if (data) {
+			if (dlist->destroy) dlist->destroy (data);
+			else free (data);
 		}
 	}
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -409,6 +409,19 @@ int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *da
 
 }
 
+// works as dlist_insert_before ()
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_before_unsafe (
+	DoubleList *dlist, ListElement *element, const void *data
+) {
+
+	return (dlist && data) ? dlist_internal_insert_before (
+		dlist, element, data
+	) : 1;
+
+}
+
 // inserts the data in the double list AFTER the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
@@ -427,6 +440,19 @@ int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *dat
 	}
 
 	return retval;
+
+}
+
+// works as dlist_insert_after ()
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_after_unsafe (
+	DoubleList *dlist, ListElement *element, const void *data
+) {
+
+	return (dlist && data) ? dlist_internal_insert_after (
+		dlist, element, data
+	) : 1;
 
 }
 
@@ -450,6 +476,17 @@ int dlist_insert_at_start (DoubleList *dlist, const void *data) {
 
 }
 
+// inserts at the start of the dlist, before the first element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_at_start_unsafe (DoubleList *dlist, const void *data) {
+
+	return (dlist && data) ? dlist_internal_insert_before (
+		dlist, dlist->start, data
+	) : 1;
+
+}
+
 // inserts at the end of the dlist, after the last element
 // returns 0 on success, 1 on error
 int dlist_insert_at_end (DoubleList *dlist, const void *data) {
@@ -467,6 +504,17 @@ int dlist_insert_at_end (DoubleList *dlist, const void *data) {
 	}
 
 	return retval;
+
+}
+
+// inserts at the end of the dlist, after the last element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_at_end_unsafe (DoubleList *dlist, const void *data) {
+
+	return (dlist && data) ? dlist_internal_insert_after (
+		dlist, dlist->end, data
+	) : 1;
 
 }
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -604,17 +604,77 @@ void *dlist_remove (
 // NULL for the start of the list
 void *dlist_remove_element (DoubleList *dlist, ListElement *element) {
 
+	void *data = NULL;
+
 	if (dlist) {
 		pthread_mutex_lock (dlist->mutex);
 
-		void *data = dlist_internal_remove_element (dlist, element);
+		data = dlist_internal_remove_element (dlist, element);
 
 		pthread_mutex_unlock (dlist->mutex);
-
-		return data;
 	}
 
-	return NULL;
+	return data;
+
+}
+
+// works as dlist_remove_element ()
+// this method is NOT thread safe
+void *dlist_remove_element_unsafe (DoubleList *dlist, ListElement *element) {
+
+	return dlist ? dlist_internal_remove_element (dlist, element) : NULL;
+
+}
+
+// removes the element at the start of the dlist
+// returns the element's data
+void *dlist_remove_start (DoubleList *dlist) {
+
+	void *data = NULL;
+
+	if (dlist) {
+		pthread_mutex_lock (dlist->mutex);
+
+		data = dlist_internal_remove_element (dlist, NULL);
+
+		pthread_mutex_unlock (dlist->mutex);
+	}
+
+	return data;
+
+}
+
+// works as dlist_remove_start ()
+// this method is NOT thread safe
+void *dlist_remove_start_unsafe (DoubleList *dlist) {
+
+	return dlist ? dlist_internal_remove_element (dlist, NULL) : NULL;
+
+}
+
+// removes the element at the end of the dlist
+// returns the element's data
+void *dlist_remove_end (DoubleList *dlist) {
+
+	void *data = NULL;
+
+	if (dlist) {
+		pthread_mutex_lock (dlist->mutex);
+
+		data = dlist_internal_remove_element (dlist, dlist->end);
+
+		pthread_mutex_unlock (dlist->mutex);
+	}
+
+	return data;
+
+}
+
+// works as dlist_remove_end ()
+// this method is NOT thread safe
+void *dlist_remove_end_unsafe (DoubleList *dlist) {
+
+	return dlist ? dlist_internal_remove_element (dlist, dlist->end) : NULL;
 
 }
 

--- a/src/cerver/http/json/json.c
+++ b/src/cerver/http/json/json.c
@@ -3020,7 +3020,7 @@ int json_unpack(json_t *root, const char *fmt, ...) {
 
 #pragma region print
 
-static void print_json_aux (json_t *element, int indent);
+static void print_json_aux (json_t *element, int indent, const char *key);
 
 static void print_json_indent (int indent) {
 
@@ -3034,83 +3034,90 @@ static const char *json_plural (int count) { return count == 1 ? "" : "s"; }
 
 static void print_json_object (json_t *element, int indent) {
 
-    size_t size = 0;
+    print_json_indent (indent);
+
     const char *key = NULL;
     json_t *value = NULL;
+    size_t size = json_object_size (element);
+    printf ("JSON Object of %ld pair%s:\n", size, json_plural (size));
+    json_object_foreach (element, key, value) {
+        print_json_indent (indent + 2);
+        print_json_aux (value, indent + 2, key);
+    }
+
+}
+
+static void print_json_array (json_t *element, int indent, const char *key) {
 
     print_json_indent (indent);
-    size = json_object_size (element);
 
-    printf("JSON Object of %ld pair%s:\n", size, json_plural(size));
-    json_object_foreach(element, key, value) {
-        print_json_indent(indent + 2);
-        printf("JSON Key: \"%s\"\n", key);
-        print_json_aux(value, indent + 2);
-    }
-
-}
-
-static void print_json_array(json_t *element, int indent) {
-
-    size_t size = json_array_size(element);
-    print_json_indent(indent);
-
-    printf("JSON Array of %ld element%s:\n", size, json_plural(size));
+    size_t size = json_array_size (element);
+    printf("JSON Array of %ld element%s:\n", size, json_plural (size));
     for (size_t i = 0; i < size; i++) {
-        print_json_aux(json_array_get(element, i), indent + 2);
+        print_json_aux (json_array_get (element, i), indent + 2, key);
     }
+
 }
 
-static void print_json_string(json_t *element, int indent) {
+static void print_json_string (json_t *element, int indent, const char *key) {
+
     print_json_indent(indent);
-    printf("JSON String: \"%s\"\n", json_string_value(element));
+    printf ("[String] %s: \"%s\"\n", key, json_string_value (element));
+
 }
 
-static void print_json_integer(json_t *element, int indent) {
-    print_json_indent(indent);
-    printf("JSON Integer: \"%" JSON_INTEGER_FORMAT "\"\n", json_integer_value(element));
+static void print_json_integer (json_t *element, int indent, const char *key) {
+
+    print_json_indent (indent);
+    printf ("[Integer] %s: \"%" JSON_INTEGER_FORMAT "\"\n", key, json_integer_value(element));
+
 }
 
-static void print_json_real(json_t *element, int indent) {
-    print_json_indent(indent);
-    printf("JSON Real: %f\n", json_real_value(element));
+static void print_json_real (json_t *element, int indent, const char *key) {
+
+    print_json_indent (indent);
+    printf ("[Real] %s: %f\n", key, json_real_value (element));
+
 }
 
-static void print_json_true(json_t *element, int indent) {
-    (void)element;
-    print_json_indent(indent);
-    printf("JSON True\n");
+static void print_json_true (json_t *element, int indent, const char *key) {
+
+    print_json_indent (indent);
+    printf ("%s: True\n", key);
+
 }
 
-static void print_json_false(json_t *element, int indent) {
-    (void)element;
-    print_json_indent(indent);
-    printf("JSON False\n");
+static void print_json_false (json_t *element, int indent, const char *key) {
+    
+    print_json_indent (indent);
+    printf ("%s: False\n", key);
+
 }
 
-static void print_json_null(json_t *element, int indent) {
-    (void)element;
-    print_json_indent(indent);
-    printf("JSON Null\n");
+static void print_json_null (json_t *element, int indent, const char *key) {
+
+    print_json_indent (indent);
+    printf ("%s: NULL\n", key);
+
 }
 
-static void print_json_aux (json_t *element, int indent) {
+static void print_json_aux (json_t *element, int indent, const char *key) {
 
     switch (json_typeof (element)) {
         case JSON_OBJECT: print_json_object (element, indent); break;
-        case JSON_ARRAY: print_json_array (element, indent); break;
-        case JSON_STRING: print_json_string (element, indent); break;
-        case JSON_INTEGER: print_json_integer (element, indent); break;
-        case JSON_REAL: print_json_real (element, indent); break;
-        case JSON_TRUE: print_json_true (element, indent); break;
-        case JSON_FALSE: print_json_false (element, indent); break;
-        case JSON_NULL: print_json_null (element, indent); break;
+        case JSON_ARRAY: print_json_array (element, indent, key); break;
+        case JSON_STRING: print_json_string (element, indent, key); break;
+        case JSON_INTEGER: print_json_integer (element, indent, key); break;
+        case JSON_REAL: print_json_real (element, indent, key); break;
+        case JSON_TRUE: print_json_true (element, indent, key); break;
+        case JSON_FALSE: print_json_false (element, indent, key); break;
+        case JSON_NULL: print_json_null (element, indent, key); break;
 
         default: fprintf (stderr, "unrecognized JSON type %d\n", json_typeof (element)); break;
     }
 
 }
 
-void json_print (json_t *root) { print_json_aux (root, 0); }
+void json_print (json_t *root) { print_json_aux (root, 0, NULL); }
 
 #pragma endregion


### PR DESCRIPTION
## General
- Added http_response_json_custom_reference () related methods. This method will avoid a copy of custom json values in http responses
- Refactored http_response_json_custom () related methods
- Refactored json print methods

## Collections
- Removed extra checks from dlist internal methods
- If a destroy method is not set on a dlist free wont be used anymore
- Added more dlist insert & remove methods
- Added dlist_for_each macro

## Examples
- Added routes in web example to test custom json references responses