### PR TITLE
HTTP Beta 2.0b-16

### DIFF
--- a/examples/admin.c
+++ b/examples/admin.c
@@ -370,13 +370,24 @@ int main (void) {
 	cerver_log_debug ("Cerver with admin capabilities");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Admin Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		/*** cerver auth configuration ***/
 		// authentication needs to be enabled to handle admins

--- a/examples/advanced.c
+++ b/examples/advanced.c
@@ -198,13 +198,24 @@ int main (void) {
 	cerver_log_debug ("Cerver example with multiple featues enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Advanced Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (my_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -318,13 +318,24 @@ int main (void) {
 	cerver_log_debug ("Cerver with auth options enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Auth Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (handler);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/client/auth.c
+++ b/examples/client/auth.c
@@ -391,7 +391,15 @@ int main (void) {
 	cerver_log_debug ("Cerver creates a new client that will authenticate with a cerver & then, perform requests");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Auth Example");
 
@@ -399,8 +407,10 @@ int main (void) {
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
 
+		cerver_set_handler_type (client_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (client_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (client_cerver, app_handler, NULL);
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -336,13 +336,24 @@ int main (void) {
 	cerver_log_debug ("Cerver creates a new client that will use to make requests to another cerver");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+	
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
+
+		cerver_set_handler_type (client_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (client_cerver, 2000);
 
 		Handler *app_handler = handler_create (cerver_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/client/files.c
+++ b/examples/client/files.c
@@ -212,7 +212,15 @@ int main (void) {
 	cerver_log_debug ("Cerver creates a new client that will use to make files requests to another cerver");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Files Example");
 

--- a/examples/files.c
+++ b/examples/files.c
@@ -168,15 +168,24 @@ int main (void) {
 	cerver_log_debug ("Cerver is configured to accept & handle files requests");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_FILES, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_FILES,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple file cerver example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
+		// cerver_set_thpool_n_threads (my_cerver, 4);
+		
 		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
 		cerver_set_handle_detachable_threads (my_cerver, true);
-		// cerver_set_thpool_n_threads (my_cerver, 4);
 
 		Handler *app_handler = handler_create (handler);
 		// 27/05/2020 - needed for this example!

--- a/examples/game.c
+++ b/examples/game.c
@@ -89,13 +89,24 @@ int main (void) {
 	printf ("\n");
 
 	if (!my_game_init ()) {
-		my_cerver = cerver_create (CERVER_TYPE_GAME, "game-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+		my_cerver = cerver_create (
+			CERVER_TYPE_GAME,
+			"game-cerver",
+			7000,
+			PROTOCOL_TCP,
+			false,
+			2
+		);
+
 		if (my_cerver) {
 			cerver_set_welcome_msg (my_cerver, "Welcome - Simple Game Cerver Example");
 
 			/*** cerver configuration ***/
 			cerver_set_receive_buffer_size (my_cerver, 4096);
 			cerver_set_thpool_n_threads (my_cerver, 4);
+
+			cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+			cerver_set_poll_time_out (my_cerver, 2000);
 
 			Handler *app_handler = handler_create (my_game_packet_handler);
 			// 27/05/2020 - needed for this example!

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -241,12 +241,23 @@ static void on_client_close_connection (void *event_data_ptr) {
 
 static void start (HandlersType type) {
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - App & Custom Handlers Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = NULL;
 		Handler *app_error_handler = NULL;

--- a/examples/logs.c
+++ b/examples/logs.c
@@ -148,7 +148,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Simple test cerver with custom logs configuartions");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple Test Message Example");
 
@@ -156,8 +164,10 @@ int main (int argc, char **argv) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -332,14 +332,24 @@ int main (void) {
 	cerver_log_debug ("Multiple app handlers example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Multiple app handlers example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
-		// cerver_set_app_handlers (my_cerver, handler, NULL);
+		
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		cerver_set_multiple_handlers (my_cerver, 4);
 

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -239,7 +239,15 @@ int main (void) {
 	cerver_log_debug ("We should always receive the same message no matter the method the client is using to send it");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Packets Example");
 
@@ -247,8 +255,10 @@ int main (void) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -208,13 +208,24 @@ int main (void) {
 	cerver_log_debug ("Requests Example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Requests Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		app_data = app_data_create (0, "Hello there!");
 

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -338,13 +338,24 @@ int main (void) {
 	cerver_log_debug ("Cerver with auth & sesions options enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Sessions Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (handler);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/test.c
+++ b/examples/test.c
@@ -197,7 +197,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Single app handler with direct handle option enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", get_port (argc, argv), PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		get_port (argc, argv),
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple Test Message Example");
 
@@ -205,8 +213,10 @@ int main (int argc, char **argv) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -137,18 +137,26 @@ int main (void) {
 	cerver_log_debug ("Handling each connection in a dedicated thread");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Dedicated threads for each conenction");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
-		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
-		cerver_set_handle_detachable_threads (my_cerver, true);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
+		cerver_set_handle_detachable_threads (my_cerver, true);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/web/api.c
+++ b/examples/web/api.c
@@ -392,7 +392,15 @@ int main (int argc, char **argv) {
 
 	users = dlist_init (user_delete, user_comparator);
 
-	api_cerver = cerver_create (CERVER_TYPE_WEB, "api-cerver", 8080, PROTOCOL_TCP, false, 2, 1000);
+	api_cerver = cerver_create (
+		CERVER_TYPE_WEB,
+		"api-cerver",
+		8080,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+	
 	if (api_cerver) {
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (api_cerver, 4096);

--- a/examples/web/sockets.c
+++ b/examples/web/sockets.c
@@ -144,7 +144,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Simple Web Cerver Example");
 	printf ("\n");
 
-	web_cerver = cerver_create (CERVER_TYPE_WEB, "web-cerver", 8080, PROTOCOL_TCP, false, 2, 1000);
+	web_cerver = cerver_create (
+		CERVER_TYPE_WEB,
+		"web-cerver",
+		8080,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (web_cerver) {
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (web_cerver, 4096);

--- a/examples/web/upload.c
+++ b/examples/web/upload.c
@@ -183,7 +183,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Uploads Web Cerver Example");
 	printf ("\n");
 
-	web_cerver = cerver_create (CERVER_TYPE_WEB, "web-cerver", 8080, PROTOCOL_TCP, false, 2, 1000);
+	web_cerver = cerver_create (
+		CERVER_TYPE_WEB,
+		"web-cerver",
+		8080,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (web_cerver) {
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (web_cerver, 4096);

--- a/examples/web/web.c
+++ b/examples/web/web.c
@@ -195,7 +195,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Simple Web Cerver Example");
 	printf ("\n");
 
-	web_cerver = cerver_create (CERVER_TYPE_WEB, "web-cerver", 8080, PROTOCOL_TCP, false, 2, 1000);
+	web_cerver = cerver_create (
+		CERVER_TYPE_WEB,
+		"web-cerver",
+		8080,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (web_cerver) {
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (web_cerver, 4096);

--- a/examples/welcome.c
+++ b/examples/welcome.c
@@ -42,9 +42,20 @@ int main (void) {
 	cerver_log_debug ("Welcome Example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome to cerver!");
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -23,6 +23,18 @@ struct _Packet;
 
 struct _AdminCerver;
 
+#define ADMIN_CERVER_DEFAULT_MAX_ADMINS					1
+#define ADMIN_CERVER_DEFAULT_MAX_ADMIN_CONNECTIONS		2
+#define ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS			4
+
+#define ADMIN_CERVER_DEFAULT_POLL_FDS					4
+#define ADMIN_CERVER_DEFAULT_POLL_TIMEOUT				2000
+
+#define ADMIN_CERVER_DEFAULT_CHECK_PACKETS				false
+
+#define ADMIN_CERVER_DEFAULT_UPDATE_TICKS				30
+#define ADMIN_CERVER_DEFAULT_UPDATE_INTERVAL_SECS		1
+
 #pragma region stats
 
 struct _AdminCerverStats {
@@ -113,14 +125,6 @@ CERVER_PUBLIC u8 admin_send_packet_pieces (Admin *admin, struct _Packet *packet,
 #pragma endregion
 
 #pragma region main
-
-#define DEFAULT_MAX_ADMINS							1
-#define DEFAULT_MAX_ADMIN_CONNECTIONS				1
-
-#define DEFAULT_N_BAD_PACKETS_LIMIT					5
-
-#define DEFAULT_ADMIN_MAX_N_FDS						10
-#define DEFAULT_ADMIN_POLL_TIMEOUT					2000
 
 struct _AdminCerver {
 

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -11,9 +11,6 @@
 #include "cerver/client.h"
 #include "cerver/packets.h"
 
-#define DEFAULT_AUTH_TRIES                  3
-#define DEFAULT_ON_HOLD_MAX_BAD_PACKETS     3
-
 struct _Cerver;
 struct _Connection;
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -491,7 +491,7 @@ CERVER_EXPORT unsigned int cerver_get_n_handlers_working (Cerver *cerver);
 CERVER_EXPORT Cerver *cerver_create (
 	const CerverType type, const char *name,
 	const u16 port, const Protocol protocol, bool use_ipv6,
-	u16 connection_queue, u32 poll_timeout
+	u16 connection_queue
 );
 
 #pragma endregion

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -24,23 +24,40 @@
 
 #include "cerver/game/game.h"
 
-#define DEFAULT_CONNECTION_QUEUE            7
+#define MAX_PORT_NUM								65535
+#define MAX_UDP_PACKET_SIZE							65515
 
-#define DEFAULT_TH_POOL_INIT                4
+#define CERVER_DEFAULT_PORT							7000
+#define CERVER_DEFAULT_PROTOCOL						PROTOCOL_TCP
+#define CERVER_DEFAULT_USE_IPV6						false
+#define CERVER_DEFAULT_CONNECTION_QUEUE				10
+#define CERVER_DEFAULT_RECEIVE_BUFFER_SIZE			4096
+#define CERVER_DEFAULT_POOL_THREADS					4
 
-#define MAX_PORT_NUM                        65535
-#define MAX_UDP_PACKET_SIZE                 65515
+#define CERVER_DEFAULT_SOCKETS_INIT					10
 
-#define DEFAULT_POLL_TIMEOUT                2000
-#define poll_n_fds                          100         // n of fds for the pollfd array
+#define CERVER_DEFAULT_POLL_FDS						128
+#define CERVER_DEFAULT_POLL_TIMEOUT					2000
 
-#define DEFAULT_SOCKETS_INIT                10
+#define CERVER_DEFAULT_MAX_INACTIVE_TIME			60
+#define CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL		30
 
-#define DEFAULT_MAX_INACTIVE_TIME           60
-#define DEFAULT_CHECK_INACTIVE_INTERVAL     30
+#define CERVER_DEFAULT_AUTH_REQUIRED				false
+#define CERVER_DEFAULT_MAX_AUTH_TRIES				2
 
-#define DEFAULT_UPDATE_TICKS                15
-#define DEFAULT_UPDATE_INTERVAL_SECS        1
+#define CERVER_DEFAULT_ON_HOLD_POLL_FDS				64
+#define CERVER_DEFAULT_ON_HOLD_TIMEOUT				2000
+#define CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS		4
+#define CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS		false
+
+#define CERVER_DEFAULT_USE_SESSIONS					false
+
+#define CERVER_DEFAULT_MULTIPLE_HANDLERS			false
+
+#define CERVER_DEFAULT_CHECK_PACKETS				false
+
+#define CERVER_DEFAULT_UPDATE_TICKS					30
+#define CERVER_DEFAULT_UPDATE_INTERVAL_SECS			1
 
 struct _Cerver;
 struct _AdminCerver;
@@ -246,7 +263,7 @@ struct _Cerver {
 	u32 on_hold_poll_timeout;
 	u32 max_on_hold_connections;
 	u16 current_on_hold_nfds;
-	pthread_t on_hold_poll_id;
+	pthread_t on_hold_poll_thread_id;
 	pthread_mutex_t *on_hold_poll_lock;
 	u8 on_hold_max_bad_packets;
 	bool on_hold_check_packets;

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -94,9 +94,13 @@ typedef enum CerverHandlerType {
 
 } CerverHandlerType;
 
-CERVER_EXPORT const char *cerver_handler_type_to_string (CerverHandlerType type);
+CERVER_EXPORT const char *cerver_handler_type_to_string (
+	CerverHandlerType type
+);
 
-CERVER_EXPORT const char *cerver_handler_type_description (CerverHandlerType type);
+CERVER_EXPORT const char *cerver_handler_type_description (
+	CerverHandlerType type
+);
 
 #pragma endregion
 
@@ -115,12 +119,16 @@ typedef struct CerverInfo {
 
 // sets the cerver msg to be sent when a client connects
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_welcome_msg (struct _Cerver *cerver, const char *msg);
+CERVER_EXPORT u8 cerver_set_welcome_msg (
+	struct _Cerver *cerver, const char *msg
+);
 
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
-CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
-	struct _Client *client, struct _Connection *connection);
+CERVER_PUBLIC u8 cerver_info_send_info_packet (
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection
+);
 
 #pragma endregion
 
@@ -159,10 +167,14 @@ typedef struct CerverStats {
 } CerverStats;
 
 // sets the cerver stats threshold time (how often the stats get reset)
-CERVER_EXPORT void cerver_stats_set_threshold_time (struct _Cerver *cerver, time_t threshold_time);
+CERVER_EXPORT void cerver_stats_set_threshold_time (
+	struct _Cerver *cerver, time_t threshold_time
+);
 
 // prints the cerver stats
-CERVER_EXPORT void cerver_stats_print (struct _Cerver *cerver, bool received, bool sent);
+CERVER_EXPORT void cerver_stats_print (
+	struct _Cerver *cerver, bool received, bool sent
+);
 
 #pragma endregion
 
@@ -309,13 +321,19 @@ CERVER_EXPORT void cerver_set_network_values (
 );
 
 // sets the cerver connection queue (how many connections to queue for accept)
-CERVER_EXPORT void cerver_set_connection_queue (Cerver *cerver, const u16 connection_queue);
+CERVER_EXPORT void cerver_set_connection_queue (
+	Cerver *cerver, const u16 connection_queue
+);
 
 // sets the cerver's receive buffer size used in recv method
-CERVER_EXPORT void cerver_set_receive_buffer_size (Cerver *cerver, const u32 size);
+CERVER_EXPORT void cerver_set_receive_buffer_size (
+	Cerver *cerver, const u32 size
+);
 
 // sets the cerver's data and a way to free it
-CERVER_EXPORT void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data);
+CERVER_EXPORT void cerver_set_cerver_data (
+	Cerver *cerver, void *data, Action delete_data
+);
 
 // sets the cerver's thpool number of threads
 // this will enable the cerver's ability to handle received packets using multiple threads
@@ -323,11 +341,15 @@ CERVER_EXPORT void cerver_set_cerver_data (Cerver *cerver, void *data, Action de
 // but we aware that you need to make your structures and data thread safe, as they might be accessed
 // from multiple threads at the same time
 // by default, all received packets will be handle only in one thread
-CERVER_EXPORT void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads);
+CERVER_EXPORT void cerver_set_thpool_n_threads (
+	Cerver *cerver, u16 n_threads
+);
 
 // sets the initial number of sockets to be created in the cerver's sockets pool
 // the defauult value is 10
-CERVER_EXPORT void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets);
+CERVER_EXPORT void cerver_set_sockets_pool_init (
+	Cerver *cerver, unsigned int n_sockets
+);
 
 // 17/06/2020
 // enables the ability to check for inactive clients - clients that have not been sent or received from a packet in x time
@@ -342,16 +364,22 @@ CERVER_EXPORT void cerver_set_inactive_clients (
 // sets the cerver handler type
 // the default type is to handle connections using the poll () which requires only one thread
 // if threads type is selected, a new thread will be created for each new connection
-CERVER_EXPORT void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type);
+CERVER_EXPORT void cerver_set_handler_type (
+	Cerver *cerver, CerverHandlerType handler_type
+);
 
 // set the ability to handle new connections if cerver handler type is CERVER_HANDLER_TYPE_THREADS
 // by only creating new detachable threads for each connection
 // by default, this option is turned off to also use the thpool
 // if cerver is of type CERVER_TYPE_WEB, the thpool will be used more often as connections have a shorter life
-CERVER_EXPORT void cerver_set_handle_detachable_threads (Cerver *cerver, bool active);
+CERVER_EXPORT void cerver_set_handle_detachable_threads (
+	Cerver *cerver, bool active
+);
 
 // sets the cerver poll timeout in ms
-CERVER_EXPORT void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout);
+CERVER_EXPORT void cerver_set_poll_time_out (
+	Cerver *cerver, const u32 poll_timeout
+);
 
 // enables cerver's built in authentication methods
 // cerver requires client authentication upon new client connections
@@ -359,27 +387,40 @@ CERVER_EXPORT void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_time
 // authenticate is a user defined method that takes an AuthMethod ptr that should NOT be free
 // and must return 0 on a success authentication & 1 on any error
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_auth (Cerver *cerver, u8 max_auth_tries, delegate authenticate);
+CERVER_EXPORT u8 cerver_set_auth (
+	Cerver *cerver,
+	u8 max_auth_tries, delegate authenticate
+);
 
 // sets the max auth tries a new connection is allowed to have before it is dropped due to failure
-CERVER_EXPORT void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries);
+CERVER_EXPORT void cerver_set_auth_max_tries (
+	Cerver *cerver, u8 max_auth_tries
+);
 
 // sets the method to be used for client authentication
 // must return 0 on success authentication
-CERVER_EXPORT void cerver_set_auth_method (Cerver *cerver, delegate authenticate);
+CERVER_EXPORT void cerver_set_auth_method (
+	Cerver *cerver, delegate authenticate
+);
 
 // sets the cerver on poll timeout in ms
-CERVER_EXPORT void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout);
+CERVER_EXPORT void cerver_set_on_hold_poll_timeout (
+	Cerver *cerver, u32 on_hold_poll_timeout
+);
 
 // sets the max number of bad packets to tolerate from an ON HOLD connection before being dropped,
 // the default is DEFAULT_ON_HOLD_MAX_BAD_PACKETS
 // a bad packet is anyone which can't be handle by the cerver because there is no handle,
 // or because it failed the packet_check () method
-CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_packets);
+CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (
+	Cerver *cerver, u8 on_hold_max_bad_packets
+);
 
 // sets whether to check for packets using the packet_check () method in ON HOLD handler or NOT
 // any packet that fails the check will be considered as a bad packet
-CERVER_EXPORT void cerver_set_on_hold_check_packets (Cerver *cerver, bool check);
+CERVER_EXPORT void cerver_set_on_hold_check_packets (
+	Cerver *cerver, bool check
+);
 
 // configures the cerver to use client sessions
 // This will allow for multiple connections from the same client,
@@ -388,10 +429,14 @@ CERVER_EXPORT void cerver_set_on_hold_check_packets (Cerver *cerver, bool check)
 // and must return a char * representing the session id (token) for the client
 // or use the default one
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const void *));
+CERVER_EXPORT u8 cerver_set_sessions (
+	Cerver *cerver, void *(*session_id_generator) (const void *)
+);
 
 // sets a custom method to handle the raw received buffer from the socket
-CERVER_EXPORT void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer);
+CERVER_EXPORT void cerver_set_handle_recieved_buffer (
+	Cerver *cerver, Action handle_received_buffer
+);
 
 // 27/05/2020 - changed form Action to Handler
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
@@ -403,32 +448,44 @@ CERVER_EXPORT void cerver_set_app_handlers (
 // sets option to automatically delete PACKET_TYPE_APP packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_app_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_app_error_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_app_error_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // 27/05/2020 - changed form Action to Handler
 // sets a PACKET_TYPE_CUSTOM packet type handler
-CERVER_EXPORT void cerver_set_custom_handler (Cerver *cerver, struct _Handler *custom_handler);
+CERVER_EXPORT void cerver_set_custom_handler (
+	Cerver *cerver, struct _Handler *custom_handler
+);
 
 // sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_custom_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // enables the ability of the cerver to have multiple app handlers
 // returns 0 on success, 1 on error
-CERVER_EXPORT int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers);
+CERVER_EXPORT int cerver_set_multiple_handlers (
+	Cerver *cerver, unsigned int n_handlers
+);
 
 // set whether to check or not incoming packets
 // check packet's header protocol id & version compatibility
 // if packets do not pass the checks, won't be handled and will be inmediately destroyed
 // packets size must be cheked in individual methods (handlers)
 // by default, this option is turned off
-CERVER_EXPORT void cerver_set_check_packets (Cerver *cerver, bool check_packets);
+CERVER_EXPORT void cerver_set_check_packets (
+	Cerver *cerver, bool check_packets
+);
 
 // sets a custom cerver update function to be executed every n ticks
 // a new thread will be created that will call your method each tick
@@ -458,7 +515,9 @@ CERVER_EXPORT u8 cerver_set_admin_enable (Cerver *cerver);
 
 #pragma region sockets
 
-CERVER_PRIVATE int cerver_sockets_pool_push (Cerver *cerver, struct _Socket *socket);
+CERVER_PRIVATE int cerver_sockets_pool_push (
+	Cerver *cerver, struct _Socket *socket
+);
 
 CERVER_PRIVATE struct _Socket *cerver_sockets_pool_pop (Cerver *cerver);
 
@@ -472,7 +531,9 @@ CERVER_EXPORT void cerver_handlers_print_info (Cerver *cerver);
 // adds a new handler to the cerver handlers array
 // is the responsability of the user to provide a unique handler id, which must be < cerver->n_handlers
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_handlers_add (Cerver *cerver, struct _Handler *handler);
+CERVER_EXPORT u8 cerver_handlers_add (
+	Cerver *cerver, struct _Handler *handler
+);
 
 // returns the current number of app handlers (multiple handlers option)
 CERVER_EXPORT unsigned int cerver_get_n_handlers (Cerver *cerver);

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -36,6 +36,9 @@ typedef struct DoubleList {
 #define dlist_for_each(dlist, le)					\
 	for (le = dlist->start; le; le = le->next)
 
+#define dlist_for_each_backwards(dlist, le)			\
+	for (le = dlist->end; le; le = le->prev)
+
 // sets a list compare function
 // compare must return -1 if one < two, must return 0 if they are equal, and must return 1 if one > two
 extern void dlist_set_compare (
@@ -264,10 +267,29 @@ extern DoubleList *dlist_split_half (DoubleList *dlist);
 // elements are removed from the original list and inserted directly into the new one
 // if no matches, dlist will be returned with size of 0
 // comparator must return TRUE on match (item will be moved to new dlist)
-// this methods is thread safe
+// this method is thread safe
 // returns a newly allocated dlist with the same detsroy comprator methods
 extern DoubleList *dlist_split_by_condition (
 	DoubleList *dlist,
+	bool (*compare)(const void *one, const void *two),
+	const void *match
+);
+
+// merges two dlists into a newly created one
+// moves list elements from both dlist into a new dlist
+// first the elements of one and then all the elements of two
+// both dlists can be safely deleted after this operation
+// returns a newly allocated dlist with size = one->size + two->size
+extern DoubleList *dlist_merge_two (
+	DoubleList *one, DoubleList *two
+);
+
+// creates a new dlist with all the elements from both dlists
+// that match the specified confition
+// elements from original dlists are moved directly to the new list
+// returns a newly allocated dlist with all the matches
+extern DoubleList *dlist_merge_two_by_condition (
+	DoubleList *one, DoubleList *two,
 	bool (*compare)(const void *one, const void *two),
 	const void *match
 );

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -47,7 +47,10 @@ extern void dlist_set_compare (
 );
 
 // sets list destroy function
-extern void dlist_set_destroy (DoubleList *list, void (*destroy)(void *data));
+extern void dlist_set_destroy (
+	DoubleList *list,
+	void (*destroy)(void *data)
+);
 
 // thread safe method to get the dlist's size
 extern size_t dlist_size (const DoubleList *dlist);
@@ -94,54 +97,75 @@ extern void dlist_clear_or_delete (void *dlist_ptr);
 // inserts the data in the double list BEFORE the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
-extern int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *data);
+extern int dlist_insert_before (
+	DoubleList *dlist,
+	ListElement *element, const void *data
+);
 
 // works as dlist_insert_before ()
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
 extern int dlist_insert_before_unsafe (
-	DoubleList *dlist, ListElement *element, const void *data
+	DoubleList *dlist,
+	ListElement *element, const void *data
 );
 
 // inserts the data in the double list AFTER the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
-extern int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *data);
+extern int dlist_insert_after (
+	DoubleList *dlist,
+	ListElement *element, const void *data
+);
 
 // works as dlist_insert_after ()
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
 extern int dlist_insert_after_unsafe (
-	DoubleList *dlist, ListElement *element, const void *data
+	DoubleList *dlist,
+	ListElement *element, const void *data
 );
 
 // inserts the data in the double list in the specified pos (0 indexed)
 // if the pos is greater than the current size, it will be added at the end
 // returns 0 on success, 1 on error
-extern int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos);
+extern int dlist_insert_at (
+	DoubleList *dlist,
+	const void *data, const unsigned int pos
+);
 
 // inserts at the start of the dlist, before the first element
 // returns 0 on success, 1 on error
-extern int dlist_insert_at_start (DoubleList *dlist, const void *data);
+extern int dlist_insert_at_start (
+	DoubleList *dlist, const void *data
+);
 
 // inserts at the start of the dlist, before the first element
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
-extern int dlist_insert_at_start_unsafe (DoubleList *dlist, const void *data);
+extern int dlist_insert_at_start_unsafe (
+	DoubleList *dlist, const void *data
+);
 
 // inserts at the end of the dlist, after the last element
 // returns 0 on success, 1 on error
-extern int dlist_insert_at_end (DoubleList *dlist, const void *data);
+extern int dlist_insert_at_end (
+	DoubleList *dlist, const void *data
+);
 
 // inserts at the end of the dlist, after the last element
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
-extern int dlist_insert_at_end_unsafe (DoubleList *dlist, const void *data);
+extern int dlist_insert_at_end_unsafe (
+	DoubleList *dlist, const void *data
+);
 
 // uses de dlist's comparator method to insert new data in the correct position
 // this method is thread safe
 // returns 0 on success, 1 on error
-extern int dlist_insert_in_order (DoubleList *dlist, const void *data);
+extern int dlist_insert_in_order (
+	DoubleList *dlist, const void *data
+);
 
 /*** remove ***/
 
@@ -155,11 +179,15 @@ extern void *dlist_remove (
 
 // removes the dlist element from the dlist and returns the data
 // NULL for the start of the list
-extern void *dlist_remove_element (DoubleList *dlist, ListElement *element);
+extern void *dlist_remove_element (
+	DoubleList *dlist, ListElement *element
+);
 
 // works as dlist_remove_element ()
 // this method is NOT thread safe
-extern void *dlist_remove_element_unsafe (DoubleList *dlist, ListElement *element);
+extern void *dlist_remove_element_unsafe (
+	DoubleList *dlist, ListElement *element
+);
 
 // removes the element at the start of the dlist
 // returns the element's data
@@ -179,7 +207,9 @@ extern void *dlist_remove_end_unsafe (DoubleList *dlist);
 
 // removes the dlist element from the dlist at the specified index 
 // returns the data or NULL if index was invalid
-extern void *dlist_remove_at (DoubleList *dlist, const unsigned int idx);
+extern void *dlist_remove_at (
+	DoubleList *dlist, const unsigned int idx
+);
 
 // removes all the elements that match the query using the comparator method
 // option to delete removed elements data when delete_data is set to TRUE
@@ -244,7 +274,9 @@ extern int dlist_sort (
 
 // returns a newly allocated array with the list elements inside it
 // data will not be copied, only the pointers, so the list will keep the original elements
-extern void **dlist_to_array (const DoubleList *dlist, size_t *count);
+extern void **dlist_to_array (
+	const DoubleList *dlist, size_t *count
+);
 
 // returns a exact copy of the dlist
 // creates the dlist's elements using the same data pointers as in the original dlist

--- a/include/cerver/collections/dlist.h
+++ b/include/cerver/collections/dlist.h
@@ -138,6 +138,11 @@ extern int dlist_insert_at_end (DoubleList *dlist, const void *data);
 // returns 0 on success, 1 on error
 extern int dlist_insert_at_end_unsafe (DoubleList *dlist, const void *data);
 
+// uses de dlist's comparator method to insert new data in the correct position
+// this method is thread safe
+// returns 0 on success, 1 on error
+extern int dlist_insert_in_order (DoubleList *dlist, const void *data);
+
 /*** remove ***/
 
 // finds the data using the query and the list comparator and the removes it from the list

--- a/include/cerver/connection.h
+++ b/include/cerver/connection.h
@@ -15,11 +15,20 @@
 
 #include "cerver/threads/thread.h"
 
-// used for connection with exponential backoff (secs)
-#define DEFAULT_CONNECTION_MAX_SLEEP                60
-#define DEFAULT_CONNECTION_PROTOCOL                 PROTOCOL_TCP
+#define CONNECTION_DEFAULT_PROTOCOL					PROTOCOL_TCP
+#define CONNECTION_DEFAULT_USE_IPV6					false
 
-#define DEFAULT_CONNECTION_TIMEOUT					2
+// used for connection with exponential backoff (secs)
+#define CONNECTION_DEFAULT_MAX_SLEEP				60
+
+#define CONNECTION_DEFAULT_MAX_AUTH_TRIES			2
+#define CONNECTION_DEFAULT_BAD_PACKETS				4
+
+#define CONNECTION_DEFAULT_RECEIVE_BUFFER_SIZE		4096
+
+#define CONNECTION_DEFAULT_UPDATE_TIMEOUT			2
+
+#define CONNECTION_DEFAULT_RECEIVE_PACKETS			true
 
 struct _Socket;
 struct _Cerver;
@@ -77,8 +86,8 @@ struct _Connection {
 	u8 auth_tries;                          // remaining attempts to authenticate
 	u8 bad_packets;                         // number of bad packets before being disconnected
 
-	u32 receive_packet_buffer_size;         // 01/01/2020 - read packets into a buffer of this size in client_receive ()
-	struct _SockReceive *sock_receive;      // 01/01/2020 - used for inter-cerver communications
+	u32 receive_packet_buffer_size;         // read packets into a buffer of this size in client_receive ()
+	struct _SockReceive *sock_receive;      // used for inter-cerver communications
 
 	pthread_t update_thread_id;
 	u32 update_timeout;
@@ -91,7 +100,7 @@ struct _Connection {
 	size_t received_data_size;
 	Action received_data_delete;
 
-	bool receive_packets;                   		// set if the connection will receive packets or not (default true)
+	bool receive_packets;                   // set if the connection will receive packets or not (default true)
 	
 	// custom receive method to handle incomming packets in the connection
 	u8 (*custom_receive) (

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -15,8 +15,6 @@
 
 #include "cerver/game/lobby.h"
 
-#define RECEIVE_PACKET_BUFFER_SIZE      8192
-
 struct _Socket;
 struct _Cerver;
 struct _Client;

--- a/include/cerver/http/route.h
+++ b/include/cerver/http/route.h
@@ -272,4 +272,6 @@ CERVER_EXPORT void http_route_set_ws_on_error (
 	void (*ws_on_error)(struct _Cerver *, enum _HttpWebSocketError)
 );
 
+CERVER_EXPORT void http_route_print (HttpRoute *route);
+
 #endif

--- a/include/cerver/http/route.h
+++ b/include/cerver/http/route.h
@@ -18,22 +18,38 @@
 struct _HttpRoute;
 struct _HttpReceive;
 
+#define HTTP_ROUTE_MODIFIER_MAP(XX)															\
+	XX(0,	NONE, 			None,			Undefined)										\
+	XX(1,	MULTI_PART, 	Multi-Part,		Enables multi-part requests on the route)		\
+	XX(2,	WEB_SOCKET, 	WebSocket,		Enables websocket connections on the route)
+
 typedef enum HttpRouteModifier {
 
-	HTTP_ROUTE_MODIFIER_NONE		= 0,
-
-	HTTP_ROUTE_MODIFIER_MULTI_PART	= 1,	// enables multi part requests on this route
-	HTTP_ROUTE_MODIFIER_WEB_SOCKET	= 2,	// enables web socket connections on this route
+	#define XX(num, name, string, description) HTTP_ROUTE_MODIFIER_##name = num,
+	HTTP_ROUTE_MODIFIER_MAP (XX)
+	#undef XX
 
 } HttpRouteModifier;
 
+CERVER_PUBLIC const char *http_route_modifier_to_string (HttpRouteModifier modifier);
+
+CERVER_PUBLIC const char *http_route_modifier_description (HttpRouteModifier modifier);
+
+#define HTTP_ROUTE_AUTH_TYPE_MAP(XX)																\
+	XX(0,	NONE, 			None,		Undefined)													\
+	XX(1,	BEARER, 		Bearer,		A bearer token is expected in the authorization header)
+
 typedef enum HttpRouteAuthType {
 
-	HTTP_ROUTE_AUTH_TYPE_NONE		= 0,
-
-	HTTP_ROUTE_AUTH_TYPE_BEARER		= 1,	// we expect a bearer token in the authorization header
+	#define XX(num, name, string, description) HTTP_ROUTE_AUTH_TYPE_##name = num,
+	HTTP_ROUTE_AUTH_TYPE_MAP (XX)
+	#undef XX
 
 } HttpRouteAuthType;
+
+CERVER_PUBLIC const char *http_route_auth_type_to_string (HttpRouteAuthType type);
+
+CERVER_PUBLIC const char *http_route_auth_type_description (HttpRouteAuthType type);
 
 struct _HttpRoutesTokens {
 

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "2.0b-15"
-#define CERVER_VERSION_NAME             "Beta 2.0b-15"
-#define CERVER_VERSION_DATE			    "26/11/2020"
-#define CERVER_VERSION_TIME			    "11:10 CST"
+#define CERVER_VERSION                  "2.0b-16"
+#define CERVER_VERSION_NAME             "Beta 2.0b-16"
+#define CERVER_VERSION_DATE			    "28/11/2020"
+#define CERVER_VERSION_TIME			    "11:55 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -476,15 +476,16 @@ AdminCerver *admin_cerver_new (void) {
 
 		admin_cerver->authenticate = NULL;
 
-		admin_cerver->max_admins = DEFAULT_MAX_ADMINS;
-		admin_cerver->max_admin_connections = DEFAULT_MAX_ADMIN_CONNECTIONS;
+		admin_cerver->max_admins = ADMIN_CERVER_DEFAULT_MAX_ADMINS;
+		admin_cerver->max_admin_connections = ADMIN_CERVER_DEFAULT_MAX_ADMIN_CONNECTIONS;
 
-		admin_cerver->n_bad_packets_limit = DEFAULT_N_BAD_PACKETS_LIMIT;
+		admin_cerver->n_bad_packets_limit = ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS;
 
 		admin_cerver->fds = NULL;
-		admin_cerver->max_n_fds = DEFAULT_ADMIN_MAX_N_FDS;
+		admin_cerver->max_n_fds = ADMIN_CERVER_DEFAULT_POLL_FDS;
 		admin_cerver->current_n_fds = 0;
-		admin_cerver->poll_timeout = DEFAULT_ADMIN_POLL_TIMEOUT;
+		admin_cerver->poll_timeout = ADMIN_CERVER_DEFAULT_POLL_TIMEOUT;
+		admin_cerver->poll_lock = NULL;
 
 		admin_cerver->app_packet_handler = NULL;
 		admin_cerver->app_error_packet_handler = NULL;
@@ -498,17 +499,19 @@ AdminCerver *admin_cerver_new (void) {
 		admin_cerver->app_error_packet_handler_delete_packet = true;
 		admin_cerver->custom_packet_handler_delete_packet = true;
 
+		admin_cerver->check_packets = ADMIN_CERVER_DEFAULT_CHECK_PACKETS;
+
 		admin_cerver->update_thread_id = 0;
 		admin_cerver->update = NULL;
 		admin_cerver->update_args = NULL;
 		admin_cerver->delete_update_args = NULL;
-		admin_cerver->update_ticks = DEFAULT_UPDATE_TICKS;
+		admin_cerver->update_ticks = ADMIN_CERVER_DEFAULT_UPDATE_TICKS;
 
 		admin_cerver->update_interval_thread_id = 0;
 		admin_cerver->update_interval = NULL;
 		admin_cerver->update_interval_args = NULL;
 		admin_cerver->delete_update_interval_args = NULL;
-		admin_cerver->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
+		admin_cerver->update_interval_secs = ADMIN_CERVER_DEFAULT_UPDATE_INTERVAL_SECS;
 
 		admin_cerver->stats = NULL;
 	}
@@ -587,7 +590,8 @@ void admin_cerver_set_max_admin_connections (AdminCerver *admin_cerver, u8 max_a
 void admin_cerver_set_bad_packets_limit (AdminCerver *admin_cerver, i32 n_bad_packets_limit) {
 
 	if (admin_cerver) {
-		admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ? n_bad_packets_limit : DEFAULT_N_BAD_PACKETS_LIMIT;
+		admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ?
+			n_bad_packets_limit : ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS;
 	}
 
 }

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -284,96 +284,113 @@ void cerver_stats_print (Cerver *cerver, bool received, bool sent) {
 
 Cerver *cerver_new (void) {
 
-	Cerver *c = (Cerver *) malloc (sizeof (Cerver));
-	if (c) {
-		memset (c, 0, sizeof (Cerver));
+	Cerver *cerver = (Cerver *) malloc (sizeof (Cerver));
+	if (cerver) {
+		cerver->type = CERVER_TYPE_NONE;
 
-		c->sock = -1;
+		cerver->sock = -1;
+		(void) memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
 
-		c->protocol = PROTOCOL_TCP;         // default protocol
-		c->use_ipv6 = false;
-		c->connection_queue = DEFAULT_CONNECTION_QUEUE;
-		c->receive_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
+		cerver->port = CERVER_DEFAULT_PORT;
+		cerver->protocol = CERVER_DEFAULT_PROTOCOL;         // default protocol
+		cerver->use_ipv6 = CERVER_DEFAULT_USE_IPV6;
+		cerver->connection_queue = CERVER_DEFAULT_CONNECTION_QUEUE;
+		cerver->receive_buffer_size = CERVER_DEFAULT_RECEIVE_BUFFER_SIZE;
 
-		c->isRunning = false;
-		c->blocking = true;
+		cerver->isRunning = false;
+		cerver->blocking = true;
 
-		c->cerver_data = NULL;
-		c->delete_cerver_data = NULL;
+		cerver->cerver_data = NULL;
+		cerver->delete_cerver_data = NULL;
 
-		c->n_thpool_threads = 0;
-		c->thpool = NULL;
+		cerver->n_thpool_threads = CERVER_DEFAULT_POOL_THREADS;
+		cerver->thpool = NULL;
 
-		c->sockets_pool_init = DEFAULT_SOCKETS_INIT;
-		c->sockets_pool = NULL;
+		cerver->sockets_pool_init = CERVER_DEFAULT_SOCKETS_INIT;
+		cerver->sockets_pool = NULL;
 
-		c->clients = NULL;
-		c->client_sock_fd_map = NULL;
+		cerver->clients = NULL;
+		cerver->client_sock_fd_map = NULL;
 
-		c->inactive_clients = false;
+		cerver->inactive_clients = false;
+		cerver->max_inactive_time = CERVER_DEFAULT_MAX_INACTIVE_TIME;
+		cerver->check_inactive_interval = CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL;
+		cerver->inactive_thread_id = 0;
 
-		c->handler_type = CERVER_HANDLER_TYPE_NONE;
+		cerver->handler_type = CERVER_HANDLER_TYPE_NONE;
 
-		c->handle_detachable_threads = false;
+		cerver->handle_detachable_threads = false;
 
-		c->fds = NULL;
-		c->poll_timeout = DEFAULT_POLL_TIMEOUT;
-		c->poll_lock = NULL;
+		cerver->fds = NULL;
+		cerver->max_n_fds = CERVER_DEFAULT_POLL_FDS;
+		cerver->current_n_fds = 0;
+		cerver->poll_timeout = CERVER_DEFAULT_POLL_TIMEOUT;
+		cerver->poll_lock = NULL;
 
-		c->auth_required = false;
-		c->auth_packet = NULL;
-		c->max_auth_tries = DEFAULT_AUTH_TRIES;
-		c->authenticate = NULL;
+		cerver->auth_required = CERVER_DEFAULT_AUTH_REQUIRED;
+		cerver->auth_packet = NULL;
+		cerver->max_auth_tries = CERVER_DEFAULT_MAX_AUTH_TRIES;
+		cerver->authenticate = NULL;
 
-		c->on_hold_connections = NULL;
-		c->on_hold_connection_sock_fd_map = NULL;
-		c->hold_fds = NULL;
-		c->on_hold_poll_timeout = DEFAULT_POLL_TIMEOUT;
-		c->on_hold_poll_lock = NULL;
-		c->on_hold_max_bad_packets = DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
-		c->on_hold_check_packets = false;
+		cerver->on_hold_connections = NULL;
+		cerver->on_hold_connection_sock_fd_map = NULL;
+		cerver->hold_fds = NULL;
+		cerver->on_hold_poll_timeout = CERVER_DEFAULT_ON_HOLD_TIMEOUT;
+		cerver->max_on_hold_connections = CERVER_DEFAULT_ON_HOLD_POLL_FDS;
+		cerver->current_on_hold_nfds = 0;
+		cerver->on_hold_poll_thread_id = 0;
+		cerver->on_hold_poll_lock = NULL;
+		cerver->on_hold_max_bad_packets = CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
+		cerver->on_hold_check_packets = CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS;
 
-		c->use_sessions = false;
-		c->session_id_generator = NULL;
+		cerver->use_sessions = CERVER_DEFAULT_USE_SESSIONS;
+		cerver->session_id_generator = NULL;
 
-		c->handle_received_buffer = NULL;
+		cerver->handle_received_buffer = NULL;
 
-		c->app_packet_handler = NULL;
-		c->app_error_packet_handler = NULL;
-		c->custom_packet_handler = NULL;
+		cerver->app_packet_handler = NULL;
+		cerver->app_error_packet_handler = NULL;
+		cerver->custom_packet_handler = NULL;
 
-		c->app_packet_handler_delete_packet = true;
-		c->app_error_packet_handler_delete_packet = true;
-		c->custom_packet_handler_delete_packet = true;
+		cerver->app_packet_handler_delete_packet = true;
+		cerver->app_error_packet_handler_delete_packet = true;
+		cerver->custom_packet_handler_delete_packet = true;
 
-		c->handlers = NULL;
-		c->handlers_lock = NULL;
+		cerver->multiple_handlers = CERVER_DEFAULT_MULTIPLE_HANDLERS;
+		cerver->handlers = NULL;
+		cerver->n_handlers = 0;
+		cerver->num_handlers_alive = 0;
+		cerver->num_handlers_working = 0;
+		cerver->handlers_lock = NULL;
 
-		c->check_packets = false;
+		cerver->check_packets = CERVER_DEFAULT_CHECK_PACKETS;
 
-		c->update = NULL;
-		c->update_args = NULL;
-		c->delete_update_args = NULL;
-		c->update_ticks = DEFAULT_UPDATE_TICKS;
+		cerver->update_thread_id = 0;
+		cerver->update = NULL;
+		cerver->update_args = NULL;
+		cerver->delete_update_args = NULL;
+		cerver->update_ticks = CERVER_DEFAULT_UPDATE_TICKS;
 
-		c->update_interval = NULL;
-		c->update_interval_args = NULL;
-		c->delete_update_interval_args = NULL;
-		c->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
+		cerver->update_interval_thread_id = 0;
+		cerver->update_interval = NULL;
+		cerver->update_interval_args = NULL;
+		cerver->delete_update_interval_args = NULL;
+		cerver->update_interval_secs = CERVER_DEFAULT_UPDATE_INTERVAL_SECS;
 
-		c->admin = NULL;
+		cerver->admin = NULL;
+		cerver->admin_thread_id = 0;
 
 		for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
-			c->events[i] = NULL;
+			cerver->events[i] = NULL;
 
 		for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
-			c->errors[i] = NULL;
+			cerver->errors[i] = NULL;
 
-		c->info = NULL;
-		c->stats = NULL;
+		cerver->info = NULL;
+		cerver->stats = NULL;
 	}
 
-	return c;
+	return cerver;
 
 }
 
@@ -518,8 +535,8 @@ void cerver_set_inactive_clients (
 
 	if (cerver) {
 		cerver->inactive_clients = true;
-		cerver->max_inactive_time = max_inactive_time ? max_inactive_time : DEFAULT_MAX_INACTIVE_TIME;
-		cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : DEFAULT_CHECK_INACTIVE_INTERVAL;
+		cerver->max_inactive_time = max_inactive_time ? max_inactive_time : CERVER_DEFAULT_MAX_INACTIVE_TIME;
+		cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL;
 	}
 
 }
@@ -1297,13 +1314,13 @@ static u8 cerver_init_poll_fds (Cerver *cerver) {
 
 	u8 retval = 1;
 
-	cerver->fds = (struct pollfd *) calloc (poll_n_fds, sizeof (struct pollfd));
+	cerver->fds = (struct pollfd *) calloc (CERVER_DEFAULT_POLL_FDS, sizeof (struct pollfd));
 	if (cerver->fds) {
-		memset (cerver->fds, 0, sizeof (struct pollfd) * poll_n_fds);
+		memset (cerver->fds, 0, sizeof (struct pollfd) * CERVER_DEFAULT_POLL_FDS);
 		// set all fds as available spaces
-		for (u32 i = 0; i < poll_n_fds; i++) cerver->fds[i].fd = -1;
+		for (u32 i = 0; i < CERVER_DEFAULT_POLL_FDS; i++) cerver->fds[i].fd = -1;
 
-		cerver->max_n_fds = poll_n_fds;
+		cerver->max_n_fds = CERVER_DEFAULT_POLL_FDS;
 		cerver->current_n_fds = 0;
 
 		retval = 0;     // success!!
@@ -1333,7 +1350,7 @@ static u8 cerver_init_data_structures (Cerver *cerver) {
 		);
 
 		if (cerver->clients) {
-			cerver->client_sock_fd_map = htab_create (poll_n_fds, NULL, NULL);
+			cerver->client_sock_fd_map = htab_create (CERVER_DEFAULT_POLL_FDS, NULL, NULL);
 			if (cerver->client_sock_fd_map) {
 				u8 errors = 0;
 
@@ -1559,7 +1576,7 @@ static u8 cerver_auth_start (Cerver *cerver) {
 	if (cerver) {
 		cerver->auth_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_REQUEST_AUTH, NULL, 0);
 
-		cerver->max_on_hold_connections = poll_n_fds / 2;
+		cerver->max_on_hold_connections = CERVER_DEFAULT_ON_HOLD_POLL_FDS;
 		cerver->on_hold_connections = avl_init (connection_comparator, connection_delete);
 		cerver->on_hold_connection_sock_fd_map = htab_create (cerver->max_on_hold_connections / 4, NULL, NULL);
 		if (cerver->on_hold_connections && cerver->on_hold_connection_sock_fd_map) {
@@ -1575,7 +1592,7 @@ static u8 cerver_auth_start (Cerver *cerver) {
 				cerver->on_hold_poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
 				pthread_mutex_init (cerver->on_hold_poll_lock, NULL);
 
-				if (!thread_create_detachable (&cerver->on_hold_poll_id, on_hold_poll, cerver)) {
+				if (!thread_create_detachable (&cerver->on_hold_poll_thread_id, on_hold_poll, cerver)) {
 					retval = 0;
 				}
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1098,7 +1098,7 @@ static u8 cerver_handlers_destroy (Cerver *cerver) {
 Cerver *cerver_create (
 	const CerverType type, const char *name,
 	const u16 port, const Protocol protocol, bool use_ipv6,
-	u16 connection_queue, u32 poll_timeout
+	u16 connection_queue
 ) {
 
 	Cerver *cerver = NULL;
@@ -1131,10 +1131,6 @@ Cerver *cerver_create (
 
 				default: break;
 			}
-
-			cerver->handler_type = CERVER_HANDLER_TYPE_POLL;
-
-			cerver_set_poll_time_out (cerver, poll_timeout);
 
 			cerver_set_handle_recieved_buffer (cerver, cerver_receive_handle_buffer);
 
@@ -1976,7 +1972,13 @@ static u8 cerver_start_tcp (Cerver *cerver) {
 	u8 retval = 1;
 
 	switch (cerver->handler_type) {
-		case CERVER_HANDLER_TYPE_NONE: break;
+		case CERVER_HANDLER_TYPE_NONE: {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver's %s handler type has NOT been configured!",
+				cerver->info->name->str
+			);
+		} break;
 
 		case CERVER_HANDLER_TYPE_POLL: {
 			if (!cerver->blocking) {
@@ -2053,7 +2055,13 @@ static u8 cerver_start_tcp (Cerver *cerver) {
 			}
 		} break;
 
-		default: break;
+		default: {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver's %s handler type is invalid!",
+				cerver->info->name->str
+			);
+		} break;
 	}
 
 	return retval;

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -145,7 +145,10 @@ u8 cerver_set_welcome_msg (Cerver *cerver, const char *msg) {
 
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
-u8 cerver_info_send_info_packet (Cerver *cerver, Client *client, Connection *connection) {
+u8 cerver_info_send_info_packet (
+	Cerver *cerver,
+	Client *client, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -508,7 +511,10 @@ void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets) {
 // will be automatically dropped from the cerver
 // max_inactive_time - max secs allowed for a client to be inactive, 0 for default
 // check_inactive_interval - how often to check for inactive clients in secs, 0 for default
-void cerver_set_inactive_clients (Cerver *cerver, u32 max_inactive_time, u32 check_inactive_interval) {
+void cerver_set_inactive_clients (
+	Cerver *cerver,
+	u32 max_inactive_time, u32 check_inactive_interval
+) {
 
 	if (cerver) {
 		cerver->inactive_clients = true;
@@ -605,7 +611,9 @@ void cerver_set_on_hold_check_packets (Cerver *cerver, bool check) {
 
 // configures the cerver to use client sessions
 // retuns 0 on success, 1 on error
-u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const void *)) {
+u8 cerver_set_sessions (
+	Cerver *cerver, void *(*session_id_generator) (const void *)
+) {
 
 	u8 retval = 1;
 
@@ -623,7 +631,9 @@ u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const voi
 }
 
 // sets a custom method to handle the raw received buffer from the socker
-void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer) {
+void cerver_set_handle_recieved_buffer (
+	Cerver *cerver, Action handle_received_buffer
+) {
 
 	if (cerver) cerver->handle_received_buffer = handle_received_buffer;
 
@@ -1875,7 +1885,9 @@ static u8 cerver_update_interval_start (Cerver *cerver) {
 
 }
 
-static void cerver_inactive_check (AVLNode *node, Cerver *cerver, time_t current_time) {
+static void cerver_inactive_check (
+	AVLNode *node, Cerver *cerver, time_t current_time
+) {
 
 	cerver_inactive_check (node->right, cerver, current_time);
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -259,20 +259,32 @@ static void dlist_internal_delete (DoubleList *dlist) {
 
 #pragma endregion
 
-void dlist_set_compare (DoubleList *dlist, int (*compare)(const void *one, const void *two)) { if (dlist) dlist->compare = compare; }
+void dlist_set_compare (
+	DoubleList *dlist, int (*compare)(const void *one, const void *two)
+) { 
+	
+	if (dlist) dlist->compare = compare;
+	
+}
 
-void dlist_set_destroy (DoubleList *dlist, void (*destroy)(void *data)) { if (dlist) dlist->destroy = destroy; }
+void dlist_set_destroy (
+	DoubleList *dlist, void (*destroy)(void *data)
+) { 
+	
+	if (dlist) dlist->destroy = destroy;
+	
+}
 
 size_t dlist_size (const DoubleList *dlist) {
 
 	size_t retval = 0;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = dlist->size;
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -284,11 +296,11 @@ bool dlist_is_empty (const DoubleList *dlist) {
 	bool retval = true;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = (dlist->size == 0);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -300,11 +312,11 @@ bool dlist_is_not_empty (const DoubleList *dlist) {
 	bool retval = false;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = (dlist->size > 0);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -316,11 +328,11 @@ void dlist_delete (void *dlist_ptr) {
 	if (dlist_ptr) {
 		DoubleList *dlist = (DoubleList *) dlist_ptr;
 
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		dlist_internal_delete (dlist);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 		pthread_mutex_destroy (dlist->mutex);
 		free (dlist->mutex);
 
@@ -340,7 +352,7 @@ int dlist_delete_if_empty (void *dlist_ptr) {
 
 		DoubleList *dlist = (DoubleList *) dlist_ptr;
 
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		if (dlist->size == 0) {
 			dlist_internal_delete (dlist);
@@ -348,7 +360,7 @@ int dlist_delete_if_empty (void *dlist_ptr) {
 			retval = 0;
 		}
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 		pthread_mutex_destroy (dlist->mutex);
 		free (dlist->mutex);
 
@@ -370,7 +382,7 @@ int dlist_delete_if_not_empty (void *dlist_ptr) {
 
 		DoubleList *dlist = (DoubleList *) dlist_ptr;
 
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		if (dlist->size > 0) {
 			dlist_internal_delete (dlist);
@@ -378,7 +390,7 @@ int dlist_delete_if_not_empty (void *dlist_ptr) {
 			retval = 0;
 		}
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 		pthread_mutex_destroy (dlist->mutex);
 		free (dlist->mutex);
 
@@ -409,7 +421,7 @@ DoubleList *dlist_init (void (*destroy)(void *data), int (*compare)(const void *
 void dlist_reset (DoubleList *dlist) {
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		if (dlist->size > 0) {
 			void *data = NULL;
@@ -423,7 +435,7 @@ void dlist_reset (DoubleList *dlist) {
 		dlist->end = NULL;
 		dlist->size = 0;
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 }
@@ -435,12 +447,12 @@ void dlist_clear (void *dlist_ptr) {
 	if (dlist_ptr) {
 		DoubleList *dlist = (DoubleList *) dlist_ptr;
 
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		while (dlist->size > 0) 
 			(void) dlist_internal_remove_element (dlist, NULL);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 }
@@ -477,13 +489,13 @@ int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *da
 	int retval = 1;
 
 	if (dlist && data) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = dlist_internal_insert_before (
 			dlist, element, data
 		);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -511,13 +523,13 @@ int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *dat
 	int retval = 1;
 
 	if (dlist && data) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = dlist_internal_insert_after (
 			dlist, element, data
 		);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -544,13 +556,13 @@ int dlist_insert_at_start (DoubleList *dlist, const void *data) {
 	int retval = 1;
 
 	if (dlist && data) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = dlist_internal_insert_before (
 			dlist, NULL, data
 		);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -575,13 +587,13 @@ int dlist_insert_at_end (DoubleList *dlist, const void *data) {
 	int retval = 1;
 
 	if (dlist && data) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		retval = dlist_internal_insert_after (
 			dlist, dlist->end, data
 		);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return retval;
@@ -648,7 +660,7 @@ void *dlist_remove (
 		int (*comp)(const void *one, const void *two) = compare ? compare : dlist->compare;
 
 		if (comp) {
-			pthread_mutex_lock (dlist->mutex);
+			(void) pthread_mutex_lock (dlist->mutex);
 
 			ListElement *ptr = dlist_start (dlist);
 
@@ -673,7 +685,7 @@ void *dlist_remove (
 				first = false;
 			}
 
-			pthread_mutex_unlock (dlist->mutex);
+			(void) pthread_mutex_unlock (dlist->mutex);
 		}
 	}
 
@@ -688,11 +700,11 @@ void *dlist_remove_element (DoubleList *dlist, ListElement *element) {
 	void *data = NULL;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		data = dlist_internal_remove_element (dlist, element);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return data;
@@ -714,11 +726,11 @@ void *dlist_remove_start (DoubleList *dlist) {
 	void *data = NULL;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		data = dlist_internal_remove_element (dlist, NULL);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return data;
@@ -740,11 +752,11 @@ void *dlist_remove_end (DoubleList *dlist) {
 	void *data = NULL;
 
 	if (dlist) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		data = dlist_internal_remove_element (dlist, dlist->end);
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return data;
@@ -767,7 +779,7 @@ void *dlist_remove_at (DoubleList *dlist, const unsigned int idx) {
 
 	if (dlist) {
 		if (idx < dlist->size) {
-			pthread_mutex_lock (dlist->mutex);
+			(void) pthread_mutex_lock (dlist->mutex);
 
 			bool first = true;
 			unsigned int i = 0;
@@ -790,7 +802,7 @@ void *dlist_remove_at (DoubleList *dlist, const unsigned int idx) {
 				i++;
 			}
 
-			pthread_mutex_unlock (dlist->mutex);
+			(void) pthread_mutex_unlock (dlist->mutex);
 		}
 	}
 
@@ -813,7 +825,7 @@ unsigned int dlist_remove_by_condition (
 	unsigned int matches = 0;
 
 	if (dlist && compare) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		size_t original_size = dlist->size;
 		size_t count = 0;
@@ -838,7 +850,7 @@ unsigned int dlist_remove_by_condition (
 			count += 1;
 		}
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 	}
 
 	return matches;
@@ -858,13 +870,13 @@ int dlist_traverse (
 	int retval = 1;
 
 	if (dlist && method) {
-		pthread_mutex_lock (dlist->mutex);
+		(void) pthread_mutex_lock (dlist->mutex);
 
 		for (ListElement *le = dlist_start (dlist); le; le = le->next) {
 			method (le->data, method_args);
 		}
 
-		pthread_mutex_unlock (dlist->mutex);
+		(void) pthread_mutex_unlock (dlist->mutex);
 
 		retval = 0;
 	}
@@ -1037,12 +1049,12 @@ int dlist_sort (
 			int (*comp)(const void *one, const void *two) = compare ? compare : dlist->compare;
 
 			if (comp) {
-				pthread_mutex_lock (dlist->mutex);
+				(void) pthread_mutex_lock (dlist->mutex);
 
 				dlist->start = dlist_merge_sort (dlist->start, comp);
 				retval = 0;
 
-				pthread_mutex_unlock (dlist->mutex);
+				(void) pthread_mutex_unlock (dlist->mutex);
 			}
 		}
 
@@ -1147,7 +1159,7 @@ DoubleList *dlist_split_half (DoubleList *dlist) {
 		if (dlist->size > 1) {
 			half = dlist_init (dlist->destroy, dlist->compare);
 
-			pthread_mutex_lock (dlist->mutex);
+			(void) pthread_mutex_lock (dlist->mutex);
 
 			size_t carry = dlist->size % 2;
 			size_t half_count = dlist->size / 2;
@@ -1169,7 +1181,7 @@ DoubleList *dlist_split_half (DoubleList *dlist) {
 				count++;
 			}
 
-			pthread_mutex_unlock (dlist->mutex);
+			(void) pthread_mutex_unlock (dlist->mutex);
 		}
 	}
 
@@ -1194,7 +1206,7 @@ DoubleList *dlist_split_by_condition (
 	if (dlist && compare) {
 		matches = dlist_init (dlist->destroy, dlist->compare);
 		if (matches) {
-			pthread_mutex_lock (dlist->mutex);
+			(void) pthread_mutex_lock (dlist->mutex);
 
 			dlist_internal_move_matches (
 				dlist, matches,
@@ -1202,7 +1214,7 @@ DoubleList *dlist_split_by_condition (
 				match
 			);
 
-			pthread_mutex_unlock (dlist->mutex);
+			(void) pthread_mutex_unlock (dlist->mutex);
 		}
 	}
 

--- a/src/cerver/collections/dlist.c
+++ b/src/cerver/collections/dlist.c
@@ -401,7 +401,10 @@ int dlist_delete_if_not_empty (void *dlist_ptr) {
 
 }
 
-DoubleList *dlist_init (void (*destroy)(void *data), int (*compare)(const void *one, const void *two)) {
+DoubleList *dlist_init (
+	void (*destroy)(void *data),
+	int (*compare)(const void *one, const void *two)
+) {
 
 	DoubleList *dlist = dlist_new ();
 
@@ -484,7 +487,10 @@ void dlist_clear_or_delete (void *dlist_ptr) {
 // inserts the data in the double list BEFORE the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
-int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *data) {
+int dlist_insert_before (
+	DoubleList *dlist,
+	ListElement *element, const void *data
+) {
 
 	int retval = 1;
 
@@ -506,7 +512,8 @@ int dlist_insert_before (DoubleList *dlist, ListElement *element, const void *da
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
 int dlist_insert_before_unsafe (
-	DoubleList *dlist, ListElement *element, const void *data
+	DoubleList *dlist,
+	ListElement *element, const void *data
 ) {
 
 	return (dlist && data) ? dlist_internal_insert_before (
@@ -518,7 +525,10 @@ int dlist_insert_before_unsafe (
 // inserts the data in the double list AFTER the specified element
 // if element == NULL, data will be inserted at the start of the list
 // returns 0 on success, 1 on error
-int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *data) {
+int dlist_insert_after (
+	DoubleList *dlist,
+	ListElement *element, const void *data
+) {
 
 	int retval = 1;
 
@@ -540,7 +550,8 @@ int dlist_insert_after (DoubleList *dlist, ListElement *element, const void *dat
 // this method is NOT thread safe
 // returns 0 on success, 1 on error
 int dlist_insert_after_unsafe (
-	DoubleList *dlist, ListElement *element, const void *data
+	DoubleList *dlist,
+	ListElement *element, const void *data
 ) {
 
 	return (dlist && data) ? dlist_internal_insert_after (
@@ -549,72 +560,13 @@ int dlist_insert_after_unsafe (
 
 }
 
-// inserts at the start of the dlist, before the first element
-// returns 0 on success, 1 on error
-int dlist_insert_at_start (DoubleList *dlist, const void *data) {
-
-	int retval = 1;
-
-	if (dlist && data) {
-		(void) pthread_mutex_lock (dlist->mutex);
-
-		retval = dlist_internal_insert_before (
-			dlist, NULL, data
-		);
-
-		(void) pthread_mutex_unlock (dlist->mutex);
-	}
-
-	return retval;
-
-}
-
-// inserts at the start of the dlist, before the first element
-// this method is NOT thread safe
-// returns 0 on success, 1 on error
-int dlist_insert_at_start_unsafe (DoubleList *dlist, const void *data) {
-
-	return (dlist && data) ? dlist_internal_insert_before (
-		dlist, NULL, data
-	) : 1;
-
-}
-
-// inserts at the end of the dlist, after the last element
-// returns 0 on success, 1 on error
-int dlist_insert_at_end (DoubleList *dlist, const void *data) {
-
-	int retval = 1;
-
-	if (dlist && data) {
-		(void) pthread_mutex_lock (dlist->mutex);
-
-		retval = dlist_internal_insert_after (
-			dlist, dlist->end, data
-		);
-
-		(void) pthread_mutex_unlock (dlist->mutex);
-	}
-
-	return retval;
-
-}
-
-// inserts at the end of the dlist, after the last element
-// this method is NOT thread safe
-// returns 0 on success, 1 on error
-int dlist_insert_at_end_unsafe (DoubleList *dlist, const void *data) {
-
-	return (dlist && data) ? dlist_internal_insert_after (
-		dlist, dlist->end, data
-	) : 1;
-
-}
-
 // inserts the data in the double list in the specified pos (0 indexed)
 // if the pos is greater than the current size, it will be added at the end
 // returns 0 on success, 1 on error
-int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos) {
+int dlist_insert_at (
+	DoubleList *dlist,
+	const void *data, const unsigned int pos
+) {
 
 	int retval = 1;
 
@@ -641,6 +593,76 @@ int dlist_insert_at (DoubleList *dlist, const void *data, const unsigned int pos
 	}
 
 	return retval;
+
+}
+
+// inserts at the start of the dlist, before the first element
+// returns 0 on success, 1 on error
+int dlist_insert_at_start (
+	DoubleList *dlist, const void *data
+) {
+
+	int retval = 1;
+
+	if (dlist && data) {
+		(void) pthread_mutex_lock (dlist->mutex);
+
+		retval = dlist_internal_insert_before (
+			dlist, NULL, data
+		);
+
+		(void) pthread_mutex_unlock (dlist->mutex);
+	}
+
+	return retval;
+
+}
+
+// inserts at the start of the dlist, before the first element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_at_start_unsafe (
+	DoubleList *dlist, const void *data
+) {
+
+	return (dlist && data) ? dlist_internal_insert_before (
+		dlist, NULL, data
+	) : 1;
+
+}
+
+// inserts at the end of the dlist, after the last element
+// returns 0 on success, 1 on error
+int dlist_insert_at_end (
+	DoubleList *dlist, const void *data
+) {
+
+	int retval = 1;
+
+	if (dlist && data) {
+		(void) pthread_mutex_lock (dlist->mutex);
+
+		retval = dlist_internal_insert_after (
+			dlist, dlist->end, data
+		);
+
+		(void) pthread_mutex_unlock (dlist->mutex);
+	}
+
+	return retval;
+
+}
+
+// inserts at the end of the dlist, after the last element
+// this method is NOT thread safe
+// returns 0 on success, 1 on error
+int dlist_insert_at_end_unsafe (
+	DoubleList *dlist, const void *data
+) {
+
+	return (dlist && data) ? dlist_internal_insert_after (
+		dlist, dlist->end, data
+	) : 1;
 
 }
 
@@ -676,7 +698,9 @@ static inline int dlist_insert_in_order_actual (
 // uses de dlist's comparator method to insert new data in the correct position
 // this method is thread safe
 // returns 0 on success, 1 on error
-int dlist_insert_in_order (DoubleList *dlist, const void *data) {
+int dlist_insert_in_order (
+	DoubleList *dlist, const void *data
+) {
 	
 	int retval = 1;
 

--- a/src/cerver/connection.c
+++ b/src/cerver/connection.c
@@ -104,28 +104,28 @@ Connection *connection_new (void) {
 
 		connection->socket = NULL;
 		connection->port = 0;
-		connection->protocol = DEFAULT_CONNECTION_PROTOCOL;
-		connection->use_ipv6 = false;
+		connection->protocol = CONNECTION_DEFAULT_PROTOCOL;
+		connection->use_ipv6 = CONNECTION_DEFAULT_USE_IPV6;
 
 		connection->ip = NULL;
-		memset (&connection->address, 0, sizeof (struct sockaddr_storage));
+		(void) memset (&connection->address, 0, sizeof (struct sockaddr_storage));
 
 		connection->connected_timestamp = 0;
 
 		connection->cerver_report = NULL;
 
-		connection->max_sleep = DEFAULT_CONNECTION_MAX_SLEEP;
+		connection->max_sleep = CONNECTION_DEFAULT_MAX_SLEEP;
 		connection->active = false;
 		connection->updating = false;
 
-		connection->auth_tries = DEFAULT_AUTH_TRIES;
+		connection->auth_tries = CONNECTION_DEFAULT_MAX_AUTH_TRIES;
 		connection->bad_packets = 0;
 
-		connection->receive_packet_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
+		connection->receive_packet_buffer_size = CONNECTION_DEFAULT_RECEIVE_BUFFER_SIZE;
 		connection->sock_receive = NULL;
 
 		connection->update_thread_id = 0;
-		connection->update_timeout = DEFAULT_CONNECTION_TIMEOUT;
+		connection->update_timeout = CONNECTION_DEFAULT_UPDATE_TIMEOUT;
 
 		connection->full_packet = false;
 
@@ -133,7 +133,8 @@ Connection *connection_new (void) {
 		connection->received_data_size = 0;
 		connection->received_data_delete = NULL;
 
-		connection->receive_packets = true;
+		connection->receive_packets = CONNECTION_DEFAULT_RECEIVE_PACKETS;
+
 		connection->custom_receive = NULL;
 		connection->custom_receive_args = NULL;
 		connection->custom_receive_args_delete = NULL;

--- a/src/cerver/http/http.c
+++ b/src/cerver/http/http.c
@@ -339,10 +339,12 @@ static unsigned int http_cerver_init_load_jwt_keys (HttpCerver *http_cerver) {
 	unsigned int errors = 0 ;
 
 	if (http_cerver->jwt_opt_key_name) {
+		cerver_log_msg ("Loading jwt PRIVATE key...");
 		errors |= http_cerver_init_load_jwt_private_key (http_cerver);
 	}
 
 	if (http_cerver->jwt_opt_pub_key_name) {
+		cerver_log_msg ("Loading jwt PUBLIC key...");
 		errors |= http_cerver_init_load_jwt_public_key (http_cerver);
 	}
 
@@ -353,13 +355,21 @@ static unsigned int http_cerver_init_load_jwt_keys (HttpCerver *http_cerver) {
 void http_cerver_init (HttpCerver *http_cerver) {
 
 	if (http_cerver) {
+		cerver_log_msg ("Loading HTTP routes...");
+
 		// init top level routes
+		HttpRoute *route = NULL;
 		for (ListElement *le = dlist_start (http_cerver->routes); le; le = le->next) {
-			http_route_init ((HttpRoute *) le->data);
+			route = (HttpRoute *) le->data;
+			
+			http_route_init (route);
+			http_route_print (route);
 		}
 
 		// load jwt keys
 		(void) http_cerver_init_load_jwt_keys (http_cerver);
+
+		cerver_log_success ("Done loading HTTP routes!");
 	}
 
 }

--- a/src/cerver/http/route.c
+++ b/src/cerver/http/route.c
@@ -584,4 +584,65 @@ void http_route_set_ws_on_error (
 	
 }
 
+static void http_route_get_methods_string (
+	HttpRoute *route, const char *route_methods_str
+) {
+
+	char *end = (char *) route_methods_str;
+	char *method_name = NULL;
+	size_t method_name_len = 0;
+	for (u8 i = 0; i < HTTP_HANDLERS_COUNT; i++) {
+		if (route->handlers[i]) {
+			method_name = (char *) http_request_method_str ((RequestMethod) i);
+			method_name_len = strlen (method_name);
+			(void) memcpy (end, method_name, method_name_len);
+			end += method_name_len += 1;
+		}
+	}
+
+	*end = '\0';
+
+}
+
+static void http_route_print_child (HttpRoute *child) {
+
+	cerver_log_msg ("\t\tRoute: %s", child->route->str);
+
+	char route_methods_str[128] = { 0 };
+	http_route_get_methods_string (child, route_methods_str);
+
+	cerver_log_msg ("\t\tMethods: %s", route_methods_str);
+
+	cerver_log_msg ("\t\tModifier: %s", http_route_modifier_to_string (child->modifier));
+	cerver_log_msg ("\t\tAuth: %s", http_route_auth_type_to_string (child->auth_type));
+
+}
+
+void http_route_print (HttpRoute *route) {
+
+	if (route) {
+		cerver_log_msg ("Route: %s", route->route->str);
+
+		char route_methods_str[128] = { 0 };
+		http_route_get_methods_string (route, route_methods_str);
+
+		cerver_log_msg ("\tMethods: %s", route_methods_str);
+
+		cerver_log_msg ("\tModifier: %s", http_route_modifier_to_string (route->modifier));
+		cerver_log_msg ("\tAuth: %s", http_route_auth_type_to_string (route->auth_type));
+
+		if (route->children->size) {
+			cerver_log_msg ("\tChildren (%ld):", route->children->size);
+			for (ListElement *le = dlist_start (route->children); le; le = le->next) {
+				http_route_print_child ((HttpRoute *) le->data);
+			}
+		}
+
+		else {
+			cerver_log_msg ("\tNo children");
+		}
+	}
+
+}
+
 #pragma endregion

--- a/src/cerver/http/route.c
+++ b/src/cerver/http/route.c
@@ -16,6 +16,54 @@
 
 #include "cerver/utils/utils.h"
 
+const char *http_route_modifier_to_string (HttpRouteModifier modifier) {
+
+	switch (modifier) {
+		#define XX(num, name, string, description) case HTTP_ROUTE_MODIFIER_##name: return #string;
+		HTTP_ROUTE_MODIFIER_MAP(XX)
+		#undef XX
+	}
+
+	return http_route_modifier_to_string (HTTP_ROUTE_MODIFIER_NONE);
+
+}
+
+const char *http_route_modifier_description (HttpRouteModifier modifier) {
+
+	switch (modifier) {
+		#define XX(num, name, string, description) case HTTP_ROUTE_MODIFIER_##name: return #description;
+		HTTP_ROUTE_MODIFIER_MAP(XX)
+		#undef XX
+	}
+
+	return http_route_modifier_description (HTTP_ROUTE_MODIFIER_NONE);
+
+}
+
+const char *http_route_auth_type_to_string (HttpRouteAuthType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case HTTP_ROUTE_AUTH_TYPE_##name: return #string;
+		HTTP_ROUTE_AUTH_TYPE_MAP(XX)
+		#undef XX
+	}
+
+	return http_route_auth_type_to_string (HTTP_ROUTE_AUTH_TYPE_NONE);
+
+}
+
+const char *http_route_auth_type_description (HttpRouteAuthType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case HTTP_ROUTE_AUTH_TYPE_##name: return #description;
+		HTTP_ROUTE_AUTH_TYPE_MAP(XX)
+		#undef XX
+	}
+
+	return http_route_auth_type_description (HTTP_ROUTE_AUTH_TYPE_NONE);
+
+}
+
 #pragma region tokens
 
 static HttpRoutesTokens *http_routes_tokens_new (void) {


### PR DESCRIPTION
## General
- Removed poll type as the default handler when creating a new cerver. Cerver's handle type must be manually specified before calling cerver_start ()
- Refactored main cerver methods definitions structure
- Updated cerver default definitions in main cerver header
- Refactored cerver_new () & cerver init methods to use new default values
- Refactored admin cerver & connections default values definitions

## HTTP
- Refactored http route's modifiers & auth types definitions
- Logging created http routes when initializing http cerver

## Collections
- Refactored dlist methods organization
- Added dlist_for_each_backwards macro
- Added dlist_merge_two () & dlist_merge _two_by_condition ()
- Added dlist_insert_in_order ()

## Examples
- Updated examples to manually specify their handler type