### PR TITLE
Beta 1.6.3b-3

### DIFF
--- a/examples/admin.c
+++ b/examples/admin.c
@@ -370,13 +370,24 @@ int main (void) {
 	cerver_log_debug ("Cerver with admin capabilities");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Admin Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		/*** cerver auth configuration ***/
 		// authentication needs to be enabled to handle admins

--- a/examples/advanced.c
+++ b/examples/advanced.c
@@ -198,13 +198,24 @@ int main (void) {
 	cerver_log_debug ("Cerver example with multiple featues enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Advanced Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (my_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -318,7 +318,15 @@ int main (void) {
 	cerver_log_debug ("Cerver with auth options enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Auth Example");
 

--- a/examples/client/auth.c
+++ b/examples/client/auth.c
@@ -391,7 +391,15 @@ int main (void) {
 	cerver_log_debug ("Cerver creates a new client that will authenticate with a cerver & then, perform requests");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Auth Example");
 
@@ -399,8 +407,10 @@ int main (void) {
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
 
+		cerver_set_handler_type (client_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (client_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (client_cerver, app_handler, NULL);
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -336,13 +336,24 @@ int main (void) {
 	cerver_log_debug ("Cerver creates a new client that will use to make requests to another cerver");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+	
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
+
+		cerver_set_handler_type (client_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (client_cerver, 2000);
 
 		Handler *app_handler = handler_create (cerver_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/client/files.c
+++ b/examples/client/files.c
@@ -240,13 +240,24 @@ static void start (void) {
 	cerver_log_debug ("Cerver creates a new client that will use to make files requests to another cerver");
 	printf ("\n");
 
-	client_cerver = cerver_create (CERVER_TYPE_CUSTOM, "client-cerver", 7001, PROTOCOL_TCP, false, 2, 2000);
+	client_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"client-cerver",
+		7001,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (client_cerver) {
 		cerver_set_welcome_msg (client_cerver, "Welcome - Cerver Client Files Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (client_cerver, 4096);
 		cerver_set_thpool_n_threads (client_cerver, 4);
+
+		cerver_set_handler_type (client_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (client_cerver, 2000);
 
 		Handler *app_handler = handler_create (cerver_app_handler_direct);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/files.c
+++ b/examples/files.c
@@ -168,15 +168,24 @@ int main (void) {
 	cerver_log_debug ("Cerver is configured to accept & handle files requests");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_FILES, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_FILES,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple file cerver example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
+		// cerver_set_thpool_n_threads (my_cerver, 4);
+		
 		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
 		cerver_set_handle_detachable_threads (my_cerver, true);
-		// cerver_set_thpool_n_threads (my_cerver, 4);
 
 		Handler *app_handler = handler_create (handler);
 		// 27/05/2020 - needed for this example!
@@ -230,7 +239,7 @@ int main (void) {
 	}
 
 	else {
-        cerver_log_error ("Failed to create cerver!");
+		cerver_log_error ("Failed to create cerver!");
 
 		cerver_delete (my_cerver);
 	}

--- a/examples/game.c
+++ b/examples/game.c
@@ -89,13 +89,24 @@ int main (void) {
 	printf ("\n");
 
 	if (!my_game_init ()) {
-		my_cerver = cerver_create (CERVER_TYPE_GAME, "game-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+		my_cerver = cerver_create (
+			CERVER_TYPE_GAME,
+			"game-cerver",
+			7000,
+			PROTOCOL_TCP,
+			false,
+			2
+		);
+
 		if (my_cerver) {
 			cerver_set_welcome_msg (my_cerver, "Welcome - Simple Game Cerver Example");
 
 			/*** cerver configuration ***/
 			cerver_set_receive_buffer_size (my_cerver, 4096);
 			cerver_set_thpool_n_threads (my_cerver, 4);
+
+			cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+			cerver_set_poll_time_out (my_cerver, 2000);
 
 			Handler *app_handler = handler_create (my_game_packet_handler);
 			// 27/05/2020 - needed for this example!

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -241,12 +241,23 @@ static void on_client_close_connection (void *event_data_ptr) {
 
 static void start (HandlersType type) {
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - App & Custom Handlers Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = NULL;
 		Handler *app_error_handler = NULL;

--- a/examples/logs.c
+++ b/examples/logs.c
@@ -148,7 +148,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Simple test cerver with custom logs configuartions");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple Test Message Example");
 
@@ -156,8 +164,10 @@ int main (int argc, char **argv) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/makefile
+++ b/examples/makefile
@@ -2,7 +2,6 @@ TARGET      := cerver
 
 PTHREAD 	:= -l pthread
 MATH		:= -lm
-CMONGO 		:= `pkg-config --libs --cflags libmongoc-1.0`
 
 # print additional information
 DEFINES = -D CERVER_DEBUG -D CERVER_STATS
@@ -36,7 +35,8 @@ directories:
 	@mkdir -p $(BUILDDIR)
 
 clean:
-	@$(RM) -rf $(BUILDDIR) @$(RM) -rf $(TARGETDIR)
+	@$(RM) -rf $(BUILDDIR)
+	@$(RM) -rf $(TARGETDIR)
 
 # pull in dependency info for *existing* .o files
 -include $(OBJECTS:.$(OBJEXT)=.$(DEPEXT))
@@ -55,5 +55,4 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(BUILDDIR)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(BUILDDIR)/$*.$(DEPEXT)
 	@rm -f $(BUILDDIR)/$*.$(DEPEXT).tmp
 
-
-.PHONY: all clean examples
+.PHONY: all clean

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -332,14 +332,24 @@ int main (void) {
 	cerver_log_debug ("Multiple app handlers example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Multiple app handlers example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
-		// cerver_set_app_handlers (my_cerver, handler, NULL);
+		
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		cerver_set_multiple_handlers (my_cerver, 4);
 

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -239,7 +239,15 @@ int main (void) {
 	cerver_log_debug ("We should always receive the same message no matter the method the client is using to send it");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Packets Example");
 
@@ -247,8 +255,10 @@ int main (void) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -208,13 +208,24 @@ int main (void) {
 	cerver_log_debug ("Requests Example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Requests Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		app_data = app_data_create (0, "Hello there!");
 

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -338,13 +338,24 @@ int main (void) {
 	cerver_log_debug ("Cerver with auth & sesions options enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Sessions Example");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (handler);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/test.c
+++ b/examples/test.c
@@ -197,7 +197,15 @@ int main (int argc, char **argv) {
 	cerver_log_debug ("Single app handler with direct handle option enabled");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", get_port (argc, argv), PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		get_port (argc, argv),
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Simple Test Message Example");
 
@@ -205,8 +213,10 @@ int main (int argc, char **argv) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -137,18 +137,26 @@ int main (void) {
 	cerver_log_debug ("Handling each connection in a dedicated thread");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome - Dedicated threads for each conenction");
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);
-		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
-		cerver_set_handle_detachable_threads (my_cerver, true);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
+		cerver_set_handle_detachable_threads (my_cerver, true);
+
 		Handler *app_handler = handler_create (handler);
-		// 27/05/2020 - needed for this example!
 		handler_set_direct_handle (app_handler, true);
 		cerver_set_app_handlers (my_cerver, app_handler, NULL);
 

--- a/examples/welcome.c
+++ b/examples/welcome.c
@@ -42,9 +42,20 @@ int main (void) {
 	cerver_log_debug ("Welcome Example");
 	printf ("\n");
 
-	my_cerver = cerver_create (CERVER_TYPE_CUSTOM, "my-cerver", 7000, PROTOCOL_TCP, false, 2, 2000);
+	my_cerver = cerver_create (
+		CERVER_TYPE_CUSTOM,
+		"my-cerver",
+		7000,
+		PROTOCOL_TCP,
+		false,
+		2
+	);
+
 	if (my_cerver) {
 		cerver_set_welcome_msg (my_cerver, "Welcome to cerver!");
+
+		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		cerver_set_poll_time_out (my_cerver, 2000);
 
 		/*** cerver configuration ***/
 		cerver_set_receive_buffer_size (my_cerver, 4096);

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -11,9 +11,6 @@
 #include "cerver/client.h"
 #include "cerver/packets.h"
 
-#define DEFAULT_AUTH_TRIES                  3
-#define DEFAULT_ON_HOLD_MAX_BAD_PACKETS     3
-
 struct _Cerver;
 struct _Connection;
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -491,7 +491,7 @@ CERVER_EXPORT unsigned int cerver_get_n_handlers_working (Cerver *cerver);
 CERVER_EXPORT Cerver *cerver_create (
 	const CerverType type, const char *name,
 	const u16 port, const Protocol protocol, bool use_ipv6,
-	u16 connection_queue, u32 poll_timeout
+	u16 connection_queue
 );
 
 #pragma endregion

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -94,9 +94,13 @@ typedef enum CerverHandlerType {
 
 } CerverHandlerType;
 
-CERVER_EXPORT const char *cerver_handler_type_to_string (CerverHandlerType type);
+CERVER_EXPORT const char *cerver_handler_type_to_string (
+	CerverHandlerType type
+);
 
-CERVER_EXPORT const char *cerver_handler_type_description (CerverHandlerType type);
+CERVER_EXPORT const char *cerver_handler_type_description (
+	CerverHandlerType type
+);
 
 #pragma endregion
 
@@ -115,12 +119,16 @@ typedef struct CerverInfo {
 
 // sets the cerver msg to be sent when a client connects
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_welcome_msg (struct _Cerver *cerver, const char *msg);
+CERVER_EXPORT u8 cerver_set_welcome_msg (
+	struct _Cerver *cerver, const char *msg
+);
 
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
-CERVER_PUBLIC u8 cerver_info_send_info_packet (struct _Cerver *cerver,
-	struct _Client *client, struct _Connection *connection);
+CERVER_PUBLIC u8 cerver_info_send_info_packet (
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection
+);
 
 #pragma endregion
 
@@ -159,10 +167,14 @@ typedef struct CerverStats {
 } CerverStats;
 
 // sets the cerver stats threshold time (how often the stats get reset)
-CERVER_EXPORT void cerver_stats_set_threshold_time (struct _Cerver *cerver, time_t threshold_time);
+CERVER_EXPORT void cerver_stats_set_threshold_time (
+	struct _Cerver *cerver, time_t threshold_time
+);
 
 // prints the cerver stats
-CERVER_EXPORT void cerver_stats_print (struct _Cerver *cerver, bool received, bool sent);
+CERVER_EXPORT void cerver_stats_print (
+	struct _Cerver *cerver, bool received, bool sent
+);
 
 #pragma endregion
 
@@ -309,13 +321,19 @@ CERVER_EXPORT void cerver_set_network_values (
 );
 
 // sets the cerver connection queue (how many connections to queue for accept)
-CERVER_EXPORT void cerver_set_connection_queue (Cerver *cerver, const u16 connection_queue);
+CERVER_EXPORT void cerver_set_connection_queue (
+	Cerver *cerver, const u16 connection_queue
+);
 
 // sets the cerver's receive buffer size used in recv method
-CERVER_EXPORT void cerver_set_receive_buffer_size (Cerver *cerver, const u32 size);
+CERVER_EXPORT void cerver_set_receive_buffer_size (
+	Cerver *cerver, const u32 size
+);
 
 // sets the cerver's data and a way to free it
-CERVER_EXPORT void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data);
+CERVER_EXPORT void cerver_set_cerver_data (
+	Cerver *cerver, void *data, Action delete_data
+);
 
 // sets the cerver's thpool number of threads
 // this will enable the cerver's ability to handle received packets using multiple threads
@@ -323,11 +341,15 @@ CERVER_EXPORT void cerver_set_cerver_data (Cerver *cerver, void *data, Action de
 // but we aware that you need to make your structures and data thread safe, as they might be accessed
 // from multiple threads at the same time
 // by default, all received packets will be handle only in one thread
-CERVER_EXPORT void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads);
+CERVER_EXPORT void cerver_set_thpool_n_threads (
+	Cerver *cerver, u16 n_threads
+);
 
 // sets the initial number of sockets to be created in the cerver's sockets pool
 // the defauult value is 10
-CERVER_EXPORT void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets);
+CERVER_EXPORT void cerver_set_sockets_pool_init (
+	Cerver *cerver, unsigned int n_sockets
+);
 
 // 17/06/2020
 // enables the ability to check for inactive clients - clients that have not been sent or received from a packet in x time
@@ -342,16 +364,22 @@ CERVER_EXPORT void cerver_set_inactive_clients (
 // sets the cerver handler type
 // the default type is to handle connections using the poll () which requires only one thread
 // if threads type is selected, a new thread will be created for each new connection
-CERVER_EXPORT void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type);
+CERVER_EXPORT void cerver_set_handler_type (
+	Cerver *cerver, CerverHandlerType handler_type
+);
 
 // set the ability to handle new connections if cerver handler type is CERVER_HANDLER_TYPE_THREADS
 // by only creating new detachable threads for each connection
 // by default, this option is turned off to also use the thpool
 // if cerver is of type CERVER_TYPE_WEB, the thpool will be used more often as connections have a shorter life
-CERVER_EXPORT void cerver_set_handle_detachable_threads (Cerver *cerver, bool active);
+CERVER_EXPORT void cerver_set_handle_detachable_threads (
+	Cerver *cerver, bool active
+);
 
 // sets the cerver poll timeout in ms
-CERVER_EXPORT void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout);
+CERVER_EXPORT void cerver_set_poll_time_out (
+	Cerver *cerver, const u32 poll_timeout
+);
 
 // enables cerver's built in authentication methods
 // cerver requires client authentication upon new client connections
@@ -359,27 +387,40 @@ CERVER_EXPORT void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_time
 // authenticate is a user defined method that takes an AuthMethod ptr that should NOT be free
 // and must return 0 on a success authentication & 1 on any error
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_auth (Cerver *cerver, u8 max_auth_tries, delegate authenticate);
+CERVER_EXPORT u8 cerver_set_auth (
+	Cerver *cerver,
+	u8 max_auth_tries, delegate authenticate
+);
 
 // sets the max auth tries a new connection is allowed to have before it is dropped due to failure
-CERVER_EXPORT void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries);
+CERVER_EXPORT void cerver_set_auth_max_tries (
+	Cerver *cerver, u8 max_auth_tries
+);
 
 // sets the method to be used for client authentication
 // must return 0 on success authentication
-CERVER_EXPORT void cerver_set_auth_method (Cerver *cerver, delegate authenticate);
+CERVER_EXPORT void cerver_set_auth_method (
+	Cerver *cerver, delegate authenticate
+);
 
 // sets the cerver on poll timeout in ms
-CERVER_EXPORT void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout);
+CERVER_EXPORT void cerver_set_on_hold_poll_timeout (
+	Cerver *cerver, u32 on_hold_poll_timeout
+);
 
 // sets the max number of bad packets to tolerate from an ON HOLD connection before being dropped,
 // the default is DEFAULT_ON_HOLD_MAX_BAD_PACKETS
 // a bad packet is anyone which can't be handle by the cerver because there is no handle,
 // or because it failed the packet_check () method
-CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_packets);
+CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (
+	Cerver *cerver, u8 on_hold_max_bad_packets
+);
 
 // sets whether to check for packets using the packet_check () method in ON HOLD handler or NOT
 // any packet that fails the check will be considered as a bad packet
-CERVER_EXPORT void cerver_set_on_hold_check_packets (Cerver *cerver, bool check);
+CERVER_EXPORT void cerver_set_on_hold_check_packets (
+	Cerver *cerver, bool check
+);
 
 // configures the cerver to use client sessions
 // This will allow for multiple connections from the same client,
@@ -388,47 +429,64 @@ CERVER_EXPORT void cerver_set_on_hold_check_packets (Cerver *cerver, bool check)
 // and must return a char * representing the session id (token) for the client
 // or use the default one
 // retuns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const void *));
+CERVER_EXPORT u8 cerver_set_sessions (
+	Cerver *cerver, void *(*session_id_generator) (const void *)
+);
 
 // sets a custom method to handle the raw received buffer from the socket
-CERVER_EXPORT void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer);
+CERVER_EXPORT void cerver_set_handle_recieved_buffer (
+	Cerver *cerver, Action handle_received_buffer
+);
 
 // 27/05/2020 - changed form Action to Handler
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 CERVER_EXPORT void cerver_set_app_handlers (
 	Cerver *cerver,
-	struct _Handler *app_handler, struct _Handler *app_error_handler
+	struct _Handler *app_handler,
+	struct _Handler *app_error_handler
 );
 
 // sets option to automatically delete PACKET_TYPE_APP packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_app_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_app_error_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_app_error_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // 27/05/2020 - changed form Action to Handler
 // sets a PACKET_TYPE_CUSTOM packet type handler
-CERVER_EXPORT void cerver_set_custom_handler (Cerver *cerver, struct _Handler *custom_handler);
+CERVER_EXPORT void cerver_set_custom_handler (
+	Cerver *cerver, struct _Handler *custom_handler
+);
 
 // sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-CERVER_EXPORT void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet);
+CERVER_EXPORT void cerver_set_custom_handler_delete (
+	Cerver *cerver, bool delete_packet
+);
 
 // enables the ability of the cerver to have multiple app handlers
 // returns 0 on success, 1 on error
-CERVER_EXPORT int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers);
+CERVER_EXPORT int cerver_set_multiple_handlers (
+	Cerver *cerver, unsigned int n_handlers
+);
 
 // set whether to check or not incoming packets
 // check packet's header protocol id & version compatibility
 // if packets do not pass the checks, won't be handled and will be inmediately destroyed
 // packets size must be cheked in individual methods (handlers)
 // by default, this option is turned off
-CERVER_EXPORT void cerver_set_check_packets (Cerver *cerver, bool check_packets);
+CERVER_EXPORT void cerver_set_check_packets (
+	Cerver *cerver, bool check_packets
+);
 
 // sets a custom cerver update function to be executed every n ticks
 // a new thread will be created that will call your method each tick
@@ -436,7 +494,8 @@ CERVER_EXPORT void cerver_set_check_packets (Cerver *cerver, bool check_packets)
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update (
 	Cerver *cerver,
-	Action update, void *update_args, void (*delete_update_args)(void *),
+	Action update,
+	void *update_args, void (*delete_update_args)(void *),
 	const u8 fps
 );
 
@@ -446,7 +505,8 @@ CERVER_EXPORT void cerver_set_update (
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 CERVER_EXPORT void cerver_set_update_interval (
 	Cerver *cerver,
-	Action update, void *update_args, void (*delete_update_args)(void *),
+	Action update,
+	void *update_args, void (*delete_update_args)(void *),
 	const u32 interval
 );
 
@@ -458,9 +518,13 @@ CERVER_EXPORT u8 cerver_set_admin_enable (Cerver *cerver);
 
 #pragma region sockets
 
-CERVER_PRIVATE int cerver_sockets_pool_push (Cerver *cerver, struct _Socket *socket);
+CERVER_PRIVATE int cerver_sockets_pool_push (
+	Cerver *cerver, struct _Socket *socket
+);
 
-CERVER_PRIVATE struct _Socket *cerver_sockets_pool_pop (Cerver *cerver);
+CERVER_PRIVATE struct _Socket *cerver_sockets_pool_pop (
+	Cerver *cerver
+);
 
 #pragma endregion
 
@@ -472,7 +536,9 @@ CERVER_EXPORT void cerver_handlers_print_info (Cerver *cerver);
 // adds a new handler to the cerver handlers array
 // is the responsability of the user to provide a unique handler id, which must be < cerver->n_handlers
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 cerver_handlers_add (Cerver *cerver, struct _Handler *handler);
+CERVER_EXPORT u8 cerver_handlers_add (
+	Cerver *cerver, struct _Handler *handler
+);
 
 // returns the current number of app handlers (multiple handlers option)
 CERVER_EXPORT unsigned int cerver_get_n_handlers (Cerver *cerver);
@@ -518,7 +584,9 @@ struct _CerverUpdate {
 
 typedef struct _CerverUpdate CerverUpdate;
 
-CERVER_PRIVATE CerverUpdate *cerver_update_new (Cerver *cerver, void *args);
+CERVER_PRIVATE CerverUpdate *cerver_update_new (
+	Cerver *cerver, void *args
+);
 
 CERVER_PUBLIC void cerver_update_delete (void *cerver_update_ptr);
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -24,23 +24,40 @@
 
 #include "cerver/game/game.h"
 
-#define DEFAULT_CONNECTION_QUEUE            7
+#define MAX_PORT_NUM								65535
+#define MAX_UDP_PACKET_SIZE							65515
 
-#define DEFAULT_TH_POOL_INIT                4
+#define CERVER_DEFAULT_PORT							7000
+#define CERVER_DEFAULT_PROTOCOL						PROTOCOL_TCP
+#define CERVER_DEFAULT_USE_IPV6						false
+#define CERVER_DEFAULT_CONNECTION_QUEUE				10
+#define CERVER_DEFAULT_RECEIVE_BUFFER_SIZE			4096
+#define CERVER_DEFAULT_POOL_THREADS					4
 
-#define MAX_PORT_NUM                        65535
-#define MAX_UDP_PACKET_SIZE                 65515
+#define CERVER_DEFAULT_SOCKETS_INIT					10
 
-#define DEFAULT_POLL_TIMEOUT                2000
-#define poll_n_fds                          100         // n of fds for the pollfd array
+#define CERVER_DEFAULT_POLL_FDS						128
+#define CERVER_DEFAULT_POLL_TIMEOUT					2000
 
-#define DEFAULT_SOCKETS_INIT                10
+#define CERVER_DEFAULT_MAX_INACTIVE_TIME			60
+#define CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL		30
 
-#define DEFAULT_MAX_INACTIVE_TIME           60
-#define DEFAULT_CHECK_INACTIVE_INTERVAL     30
+#define CERVER_DEFAULT_AUTH_REQUIRED				false
+#define CERVER_DEFAULT_MAX_AUTH_TRIES				2
 
-#define DEFAULT_UPDATE_TICKS                15
-#define DEFAULT_UPDATE_INTERVAL_SECS        1
+#define CERVER_DEFAULT_ON_HOLD_POLL_FDS				64
+#define CERVER_DEFAULT_ON_HOLD_TIMEOUT				2000
+#define CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS		4
+#define CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS		false
+
+#define CERVER_DEFAULT_USE_SESSIONS					false
+
+#define CERVER_DEFAULT_MULTIPLE_HANDLERS			false
+
+#define CERVER_DEFAULT_CHECK_PACKETS				false
+
+#define CERVER_DEFAULT_UPDATE_TICKS					30
+#define CERVER_DEFAULT_UPDATE_INTERVAL_SECS			1
 
 struct _Cerver;
 struct _AdminCerver;
@@ -246,7 +263,7 @@ struct _Cerver {
 	u32 on_hold_poll_timeout;
 	u32 max_on_hold_connections;
 	u16 current_on_hold_nfds;
-	pthread_t on_hold_poll_id;
+	pthread_t on_hold_poll_thread_id;
 	pthread_mutex_t *on_hold_poll_lock;
 	u8 on_hold_max_bad_packets;
 	bool on_hold_check_packets;

--- a/include/cerver/files.h
+++ b/include/cerver/files.h
@@ -80,10 +80,14 @@ CERVER_PRIVATE FileCerver *file_cerver_create (struct _Cerver *cerver);
 
 // adds a new file path to take into account when a client request for a file
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 file_cerver_add_path (FileCerver *file_cerver, const char *path);
+CERVER_EXPORT u8 file_cerver_add_path (
+	FileCerver *file_cerver, const char *path
+);
 
 // sets the default uploads path to be used when a client sends a file
-CERVER_EXPORT void file_cerver_set_uploads_path (FileCerver *file_cerver, const char *uploads_path);
+CERVER_EXPORT void file_cerver_set_uploads_path (
+	FileCerver *file_cerver, const char *uploads_path
+);
 
 // sets a custom method to be used to handle a file upload
 // in this method, file contents must be consumed from the sock fd
@@ -109,14 +113,17 @@ CERVER_EXPORT void file_cerver_set_file_upload_cb (
 
 // search for the requested file in the configured paths
 // returns the actual filename (path + directory) where it was found, NULL on error
-CERVER_PUBLIC String *file_cerver_search_file (FileCerver *file_cerver, const char *filename);
+CERVER_PUBLIC String *file_cerver_search_file (
+	FileCerver *file_cerver, const char *filename
+);
 
 // opens a file and sends the content back to the client
 // first the FileHeader in a regular packet, then the file contents between sockets
 // if the file is not found, a CERVER_ERROR_FILE_NOT_FOUND error packet will be sent
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_cerver_send_file (
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
 	const char *filename
 );
 
@@ -126,9 +133,16 @@ CERVER_EXPORT void file_cerver_stats_print (FileCerver *file_cerver);
 
 #pragma region main
 
+// sanitizes a filename to correctly be used to save a file
+// removes every character & whitespaces except for
+// alphabet, numbers, '-', '_' and  '.'
+CERVER_EXPORT void files_sanitize_filename (char *filename);
+
 // check if a directory already exists, and if not, creates it
 // returns 0 on success, 1 on error
-CERVER_EXPORT unsigned int files_create_dir (const char *dir_path, mode_t mode);
+CERVER_EXPORT unsigned int files_create_dir (
+	const char *dir_path, mode_t mode
+);
 
 // returns an allocated string with the file extension
 // NULL if no file extension
@@ -137,8 +151,11 @@ CERVER_EXPORT char *files_get_file_extension (const char *filename);
 // returns a list of strings containg the names of all the files in the directory
 CERVER_EXPORT DoubleList *files_get_from_dir (const char *dir);
 
-// reads eachone of the file's lines into a newly created string and returns them inside a dlist
-CERVER_EXPORT DoubleList *file_get_lines (const char *filename);
+// reads each one of the file's lines into newly created strings
+// and returns them inside a dlist
+CERVER_EXPORT DoubleList *file_get_lines (
+	const char *filename, const size_t buffer_size
+);
 
 // returns true if the filename exists
 CERVER_EXPORT bool file_exists (const char *filename);
@@ -151,11 +168,15 @@ CERVER_EXPORT FILE *file_open_as_file (
 
 // opens and reads a file into a buffer
 // sets file size to the amount of bytes read
-CERVER_EXPORT char *file_read (const char *filename, size_t *file_size);
+CERVER_EXPORT char *file_read (
+	const char *filename, size_t *file_size
+);
 
 // opens a file with the required flags
 // returns fd on success, -1 on error
-CERVER_EXPORT int file_open_as_fd (const char *filename, struct stat *filestatus, int flags);
+CERVER_EXPORT int file_open_as_fd (
+	const char *filename, struct stat *filestatus, int flags
+);
 
 CERVER_EXPORT json_value *file_json_parse (const char *filename);
 
@@ -176,7 +197,8 @@ typedef struct _FileHeader FileHeader;
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_send (
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
 	const char *filename
 );
 
@@ -184,7 +206,8 @@ CERVER_PUBLIC ssize_t file_send (
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CERVER_PUBLIC ssize_t file_send_by_fd (
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection,
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
 	int file_fd, const char *actual_filename, size_t filelen
 );
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -15,8 +15,6 @@
 
 #include "cerver/game/lobby.h"
 
-#define RECEIVE_PACKET_BUFFER_SIZE      8192
-
 struct _Socket;
 struct _Cerver;
 struct _Client;

--- a/include/cerver/utils/utils.h
+++ b/include/cerver/utils/utils.h
@@ -38,42 +38,65 @@ CERVER_PUBLIC char *itoa (int i, char *b);
 /*** c strings ***/
 
 // copies a c string into another one previuosly allocated
-CERVER_PUBLIC void c_string_copy (char *to, const char *from);
+CERVER_PUBLIC void c_string_copy (
+	char *to, const char *from
+);
 
 // copies n bytes from a c string into another one previuosly allocated
-CERVER_PUBLIC void c_string_n_copy (char *to, const char *from, size_t n);
+CERVER_PUBLIC void c_string_n_copy (
+	char *to, const char *from, size_t n
+);
 
 // concats two c strings into a newly allocated buffer of len s1 + s2
 // returns a newly allocated buffer on success, NULL on any error
-CERVER_PUBLIC char *c_string_concat (const char *s1, const char *s2, size_t *des_size);
+CERVER_PUBLIC char *c_string_concat (
+	const char *s1, const char *s2, size_t *des_size
+);
 
 // concats two strings into the same buffer
 // wont perform operation if result would overflow buffer
 // returns the len of the final string
-CERVER_PUBLIC size_t c_string_concat_safe (const char *s1, const char *s2, const char *des, size_t des_size);
+CERVER_PUBLIC size_t c_string_concat_safe (
+	const char *s1, const char *s2,
+	const char *des, size_t des_size
+);
 
 // creates a new c string with the desired format, as in printf
 CERVER_PUBLIC char *c_string_create (const char *format, ...);
 
+// removes all the spaces in the c string
+CERVER_PUBLIC void c_string_remove_spaces (char *s);
+
+// removes any CRLF characters in a string
+CERVER_PUBLIC void c_string_remove_line_breaks (char *s);
+
 // get how many tokens will be extracted by counting the number of apperances of the delim
 // the original string won't be affected
-CERVER_PUBLIC size_t c_string_count_tokens (const char *original, const char delim);
+CERVER_PUBLIC size_t c_string_count_tokens (
+	const char *original, const char delim
+);
 
 // splits a c string into tokens based on a delimiter
 // the original string won't be affected
 // this method is thread safe as it uses __strtok_r () instead of the regular strtok ()
-CERVER_PUBLIC char **c_string_split (const char *original, const char delim, size_t *n_tokens);
+CERVER_PUBLIC char **c_string_split (
+	const char *original, const char delim, size_t *n_tokens
+);
 
 // revers a c string
 // returns a newly allocated c string
 CERVER_PUBLIC char *c_string_reverse (const char *str);
 
 // removes all ocurrances of a char from a string
-CERVER_PUBLIC void c_string_remove_char (char *string, char garbage);
+CERVER_PUBLIC void c_string_remove_char (
+	char *string, char garbage
+);
 
 // removes the exact sub string from the main one
 // returns a newly allocated copy of the original str but withput the sub
-CERVER_PUBLIC char *c_string_remove_sub (char *str, const char *sub);
+CERVER_PUBLIC char *c_string_remove_sub (
+	char *str, const char *sub
+);
 
 // removes any white space from the string
 CERVER_PUBLIC char *c_string_trim (char *str);
@@ -82,37 +105,50 @@ CERVER_PUBLIC char *c_string_trim (char *str);
 CERVER_PUBLIC char *c_string_strip_quotes (char *str);
 
 // returns true if the string starts with the selected sub string
-CERVER_PUBLIC bool c_string_starts_with (const char *str, const char *substr);
+CERVER_PUBLIC bool c_string_starts_with (
+	const char *str, const char *substr
+);
 
 // creates a newly allocated string using the data between the two pointers of the SAME string
 // returns a new string, NULL on error
-CERVER_PUBLIC char *c_string_create_with_ptrs (char *first, char *last);
+CERVER_PUBLIC char *c_string_create_with_ptrs (
+	char *first, char *last
+);
 
 // removes a substring from a c string that is defined after a token
 // returns a newly allocated string without the sub,
 // and option to retrieve the actual substring
-CERVER_PUBLIC char *c_string_remove_sub_after_token (char *str, const char token, char **sub);
+CERVER_PUBLIC char *c_string_remove_sub_after_token (
+	char *str, const char token, char **sub
+);
 
 // removes a substring from a c string after the idex of the token
 // returns a newly allocated string without the sub,
 // and option to retrieve the actual substring
 // idx set to -1 for the last token match
 // example: /home/ermiry/Documents, token: '/', idx: -1, returns: Documents
-CERVER_PUBLIC char *c_string_remove_sub_after_token_with_idx (char *str, const char token, char **sub, int idx);
+CERVER_PUBLIC char *c_string_remove_sub_after_token_with_idx (
+	char *str, const char token, char **sub, int idx
+);
 
 // removes a substring from a c string delimited by two equal tokens
 // takes the first and last appearance of the token
 // example: test_20191118142101759__TEST__.png - token: '_'
 // result: test.png
 // returns a newly allocated string, and a option to get the substring
-CERVER_PUBLIC char *c_string_remove_sub_simetric_token (char *str, const char token, char **sub);
+CERVER_PUBLIC char *c_string_remove_sub_simetric_token (
+	char *str, const char token, char **sub
+);
 
 // removes a substring from a c string delimitied by two equal tokens
 // and you can select the idx of the token; use -1 for last token
 // example: test_20191118142101759__TEST__.png - token: '_' - idx (first: 1,  last: 3)
 // result: testTEST__.png
 // returns a newly allocated string, and a option to get the substring
-CERVER_PUBLIC char *c_string_remove_sub_range_token (char *str, const char token, unsigned int first, unsigned int last,
-	char **sub);
+CERVER_PUBLIC char *c_string_remove_sub_range_token (
+	char *str,
+	const char token, unsigned int first, unsigned int last,
+	char **sub
+);
 
 #endif

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "1.6.3b-2"
-#define CERVER_VERSION_NAME             "Beta 1.6.3b-2"
-#define CERVER_VERSION_DATE			    "02/12/2020"
-#define CERVER_VERSION_TIME			    "07:08 CST"
+#define CERVER_VERSION                  "1.6.3b-3"
+#define CERVER_VERSION_NAME             "Beta 1.6.3b-3"
+#define CERVER_VERSION_DATE			    "03/12/2020"
+#define CERVER_VERSION_TIME			    "18:43 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -92,7 +92,7 @@ const char *cerver_handler_type_description (CerverHandlerType type) {
 	}
 
 	return cerver_handler_type_description (CERVER_HANDLER_TYPE_NONE);
-	
+
 }
 
 #pragma endregion
@@ -285,96 +285,113 @@ void cerver_stats_print (Cerver *cerver, bool received, bool sent) {
 
 Cerver *cerver_new (void) {
 
-	Cerver *c = (Cerver *) malloc (sizeof (Cerver));
-	if (c) {
-		memset (c, 0, sizeof (Cerver));
+	Cerver *cerver = (Cerver *) malloc (sizeof (Cerver));
+	if (cerver) {
+		cerver->type = CERVER_TYPE_NONE;
 
-		c->sock = -1;
+		cerver->sock = -1;
+		(void) memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
 
-		c->protocol = PROTOCOL_TCP;         // default protocol
-		c->use_ipv6 = false;
-		c->connection_queue = DEFAULT_CONNECTION_QUEUE;
-		c->receive_buffer_size = RECEIVE_PACKET_BUFFER_SIZE;
+		cerver->port = CERVER_DEFAULT_PORT;
+		cerver->protocol = CERVER_DEFAULT_PROTOCOL;         // default protocol
+		cerver->use_ipv6 = CERVER_DEFAULT_USE_IPV6;
+		cerver->connection_queue = CERVER_DEFAULT_CONNECTION_QUEUE;
+		cerver->receive_buffer_size = CERVER_DEFAULT_RECEIVE_BUFFER_SIZE;
 
-		c->isRunning = false;
-		c->blocking = true;
+		cerver->isRunning = false;
+		cerver->blocking = true;
 
-		c->cerver_data = NULL;
-		c->delete_cerver_data = NULL;
+		cerver->cerver_data = NULL;
+		cerver->delete_cerver_data = NULL;
 
-		c->n_thpool_threads = 0;
-		c->thpool = NULL;
+		cerver->n_thpool_threads = CERVER_DEFAULT_POOL_THREADS;
+		cerver->thpool = NULL;
 
-		c->sockets_pool_init = DEFAULT_SOCKETS_INIT;
-		c->sockets_pool = NULL;
+		cerver->sockets_pool_init = CERVER_DEFAULT_SOCKETS_INIT;
+		cerver->sockets_pool = NULL;
 
-		c->clients = NULL;
-		c->client_sock_fd_map = NULL;
+		cerver->clients = NULL;
+		cerver->client_sock_fd_map = NULL;
 
-		c->inactive_clients = false;
+		cerver->inactive_clients = false;
+		cerver->max_inactive_time = CERVER_DEFAULT_MAX_INACTIVE_TIME;
+		cerver->check_inactive_interval = CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL;
+		cerver->inactive_thread_id = 0;
 
-		c->handler_type = CERVER_HANDLER_TYPE_NONE;
+		cerver->handler_type = CERVER_HANDLER_TYPE_NONE;
 
-		c->handle_detachable_threads = false;
+		cerver->handle_detachable_threads = false;
 
-		c->fds = NULL;
-		c->poll_timeout = DEFAULT_POLL_TIMEOUT;
-		c->poll_lock = NULL;
+		cerver->fds = NULL;
+		cerver->max_n_fds = CERVER_DEFAULT_POLL_FDS;
+		cerver->current_n_fds = 0;
+		cerver->poll_timeout = CERVER_DEFAULT_POLL_TIMEOUT;
+		cerver->poll_lock = NULL;
 
-		c->auth_required = false;
-		c->auth_packet = NULL;
-		c->max_auth_tries = DEFAULT_AUTH_TRIES;
-		c->authenticate = NULL;
+		cerver->auth_required = CERVER_DEFAULT_AUTH_REQUIRED;
+		cerver->auth_packet = NULL;
+		cerver->max_auth_tries = CERVER_DEFAULT_MAX_AUTH_TRIES;
+		cerver->authenticate = NULL;
 
-		c->on_hold_connections = NULL;
-		c->on_hold_connection_sock_fd_map = NULL;
-		c->hold_fds = NULL;
-		c->on_hold_poll_timeout = DEFAULT_POLL_TIMEOUT;
-		c->on_hold_poll_lock = NULL;
-		c->on_hold_max_bad_packets = DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
-		c->on_hold_check_packets = false;
+		cerver->on_hold_connections = NULL;
+		cerver->on_hold_connection_sock_fd_map = NULL;
+		cerver->hold_fds = NULL;
+		cerver->on_hold_poll_timeout = CERVER_DEFAULT_ON_HOLD_TIMEOUT;
+		cerver->max_on_hold_connections = CERVER_DEFAULT_ON_HOLD_POLL_FDS;
+		cerver->current_on_hold_nfds = 0;
+		cerver->on_hold_poll_thread_id = 0;
+		cerver->on_hold_poll_lock = NULL;
+		cerver->on_hold_max_bad_packets = CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
+		cerver->on_hold_check_packets = CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS;
 
-		c->use_sessions = false;
-		c->session_id_generator = NULL;
+		cerver->use_sessions = CERVER_DEFAULT_USE_SESSIONS;
+		cerver->session_id_generator = NULL;
 
-		c->handle_received_buffer = NULL;
+		cerver->handle_received_buffer = NULL;
 
-		c->app_packet_handler = NULL;
-		c->app_error_packet_handler = NULL;
-		c->custom_packet_handler = NULL;
+		cerver->app_packet_handler = NULL;
+		cerver->app_error_packet_handler = NULL;
+		cerver->custom_packet_handler = NULL;
 
-		c->app_packet_handler_delete_packet = true;
-		c->app_error_packet_handler_delete_packet = true;
-		c->custom_packet_handler_delete_packet = true;
+		cerver->app_packet_handler_delete_packet = true;
+		cerver->app_error_packet_handler_delete_packet = true;
+		cerver->custom_packet_handler_delete_packet = true;
 
-		c->handlers = NULL;
-		c->handlers_lock = NULL;
+		cerver->multiple_handlers = CERVER_DEFAULT_MULTIPLE_HANDLERS;
+		cerver->handlers = NULL;
+		cerver->n_handlers = 0;
+		cerver->num_handlers_alive = 0;
+		cerver->num_handlers_working = 0;
+		cerver->handlers_lock = NULL;
 
-		c->check_packets = false;
+		cerver->check_packets = CERVER_DEFAULT_CHECK_PACKETS;
 
-		c->update = NULL;
-		c->update_args = NULL;
-		c->delete_update_args = NULL;
-		c->update_ticks = DEFAULT_UPDATE_TICKS;
+		cerver->update_thread_id = 0;
+		cerver->update = NULL;
+		cerver->update_args = NULL;
+		cerver->delete_update_args = NULL;
+		cerver->update_ticks = CERVER_DEFAULT_UPDATE_TICKS;
 
-		c->update_interval = NULL;
-		c->update_interval_args = NULL;
-		c->delete_update_interval_args = NULL;
-		c->update_interval_secs = DEFAULT_UPDATE_INTERVAL_SECS;
+		cerver->update_interval_thread_id = 0;
+		cerver->update_interval = NULL;
+		cerver->update_interval_args = NULL;
+		cerver->delete_update_interval_args = NULL;
+		cerver->update_interval_secs = CERVER_DEFAULT_UPDATE_INTERVAL_SECS;
 
-		c->admin = NULL;
+		cerver->admin = NULL;
+		cerver->admin_thread_id = 0;
 
 		for (unsigned int i = 0; i < CERVER_MAX_EVENTS; i++)
-			c->events[i] = NULL;
+			cerver->events[i] = NULL;
 
 		for (unsigned int i = 0; i < CERVER_MAX_ERRORS; i++)
-			c->errors[i] = NULL;
+			cerver->errors[i] = NULL;
 
-		c->info = NULL;
-		c->stats = NULL;
+		cerver->info = NULL;
+		cerver->stats = NULL;
 	}
 
-	return c;
+	return cerver;
 
 }
 
@@ -529,8 +546,8 @@ void cerver_set_inactive_clients (
 
 	if (cerver) {
 		cerver->inactive_clients = true;
-		cerver->max_inactive_time = max_inactive_time ? max_inactive_time : DEFAULT_MAX_INACTIVE_TIME;
-		cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : DEFAULT_CHECK_INACTIVE_INTERVAL;
+		cerver->max_inactive_time = max_inactive_time ? max_inactive_time : CERVER_DEFAULT_MAX_INACTIVE_TIME;
+		cerver->check_inactive_interval = check_inactive_interval ? check_inactive_interval : CERVER_DEFAULT_CHECK_INACTIVE_INTERVAL;
 	}
 
 }
@@ -1341,13 +1358,13 @@ static u8 cerver_init_poll_fds (Cerver *cerver) {
 
 	u8 retval = 1;
 
-	cerver->fds = (struct pollfd *) calloc (poll_n_fds, sizeof (struct pollfd));
+	cerver->fds = (struct pollfd *) calloc (CERVER_DEFAULT_POLL_FDS, sizeof (struct pollfd));
 	if (cerver->fds) {
-		memset (cerver->fds, 0, sizeof (struct pollfd) * poll_n_fds);
+		memset (cerver->fds, 0, sizeof (struct pollfd) * CERVER_DEFAULT_POLL_FDS);
 		// set all fds as available spaces
-		for (u32 i = 0; i < poll_n_fds; i++) cerver->fds[i].fd = -1;
+		for (u32 i = 0; i < CERVER_DEFAULT_POLL_FDS; i++) cerver->fds[i].fd = -1;
 
-		cerver->max_n_fds = poll_n_fds;
+		cerver->max_n_fds = CERVER_DEFAULT_POLL_FDS;
 		cerver->current_n_fds = 0;
 
 		retval = 0;     // success!!
@@ -1377,7 +1394,7 @@ static u8 cerver_init_data_structures (Cerver *cerver) {
 		);
 
 		if (cerver->clients) {
-			cerver->client_sock_fd_map = htab_create (poll_n_fds, NULL, NULL);
+			cerver->client_sock_fd_map = htab_create (CERVER_DEFAULT_POLL_FDS, NULL, NULL);
 			if (cerver->client_sock_fd_map) {
 				u8 errors = 0;
 
@@ -1603,7 +1620,7 @@ static u8 cerver_auth_start (Cerver *cerver) {
 	if (cerver) {
 		cerver->auth_packet = packet_generate_request (PACKET_TYPE_AUTH, AUTH_PACKET_TYPE_REQUEST_AUTH, NULL, 0);
 
-		cerver->max_on_hold_connections = poll_n_fds / 2;
+		cerver->max_on_hold_connections = CERVER_DEFAULT_POLL_FDS / 2;
 		cerver->on_hold_connections = avl_init (connection_comparator, connection_delete);
 		cerver->on_hold_connection_sock_fd_map = htab_create (cerver->max_on_hold_connections / 4, NULL, NULL);
 		if (cerver->on_hold_connections && cerver->on_hold_connection_sock_fd_map) {
@@ -1619,7 +1636,7 @@ static u8 cerver_auth_start (Cerver *cerver) {
 				cerver->on_hold_poll_lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
 				pthread_mutex_init (cerver->on_hold_poll_lock, NULL);
 
-				if (!thread_create_detachable (&cerver->on_hold_poll_id, on_hold_poll, cerver)) {
+				if (!thread_create_detachable (&cerver->on_hold_poll_thread_id, on_hold_poll, cerver)) {
 					retval = 0;
 				}
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -1098,7 +1098,7 @@ static u8 cerver_handlers_destroy (Cerver *cerver) {
 Cerver *cerver_create (
 	const CerverType type, const char *name,
 	const u16 port, const Protocol protocol, bool use_ipv6,
-	u16 connection_queue, u32 poll_timeout
+	u16 connection_queue
 ) {
 
 	Cerver *cerver = NULL;
@@ -1131,10 +1131,6 @@ Cerver *cerver_create (
 
 				default: break;
 			}
-
-			cerver->handler_type = CERVER_HANDLER_TYPE_POLL;
-
-			cerver_set_poll_time_out (cerver, poll_timeout);
 
 			cerver_set_handle_recieved_buffer (cerver, cerver_receive_handle_buffer);
 
@@ -1976,7 +1972,13 @@ static u8 cerver_start_tcp (Cerver *cerver) {
 	u8 retval = 1;
 
 	switch (cerver->handler_type) {
-		case CERVER_HANDLER_TYPE_NONE: break;
+		case CERVER_HANDLER_TYPE_NONE: {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver's %s handler type has NOT been configured!",
+				cerver->info->name->str
+			);
+		} break;
 
 		case CERVER_HANDLER_TYPE_POLL: {
 			if (!cerver->blocking) {
@@ -2053,7 +2055,13 @@ static u8 cerver_start_tcp (Cerver *cerver) {
 			}
 		} break;
 
-		default: break;
+		default: {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver's %s handler type is invalid!",
+				cerver->info->name->str
+			);
+		} break;
 	}
 
 	return retval;

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -145,7 +145,9 @@ u8 cerver_set_welcome_msg (Cerver *cerver, const char *msg) {
 
 // sends the cerver info packet
 // retuns 0 on success, 1 on error
-u8 cerver_info_send_info_packet (Cerver *cerver, Client *client, Connection *connection) {
+u8 cerver_info_send_info_packet (
+	Cerver *cerver, Client *client, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -204,7 +206,9 @@ static void cerver_stats_delete (CerverStats *cerver_stats) {
 }
 
 // sets the cerver stats threshold time (how often the stats get reset)
-void cerver_stats_set_threshold_time (Cerver *cerver, time_t threshold_time) {
+void cerver_stats_set_threshold_time (
+	Cerver *cerver, time_t threshold_time
+) {
 
 	if (cerver) {
 		if (cerver->stats) cerver->stats->threshold_time = threshold_time;
@@ -460,21 +464,27 @@ void cerver_set_network_values (
 }
 
 // sets the cerver connection queue (how many connections to queue for accept)
-void cerver_set_connection_queue (Cerver *cerver, const u16 connection_queue) {
+void cerver_set_connection_queue (
+	Cerver *cerver, const u16 connection_queue
+) {
 
 	if (cerver) cerver->connection_queue = connection_queue;
 
 }
 
 // sets the cerver's receive buffer size used in recv method
-void cerver_set_receive_buffer_size (Cerver *cerver, const u32 size) {
+void cerver_set_receive_buffer_size (
+	Cerver *cerver, const u32 size
+) {
 
 	if (cerver) cerver->receive_buffer_size = size;
 
 }
 
 // sets the cerver's data and a way to free it
-void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data) {
+void cerver_set_cerver_data (
+	Cerver *cerver, void *data, Action delete_data
+) {
 
 	if (cerver) {
 		cerver->cerver_data = data;
@@ -489,7 +499,9 @@ void cerver_set_cerver_data (Cerver *cerver, void *data, Action delete_data) {
 // but we aware that you need to make your structures and data thread safe, as they might be accessed
 // from multiple threads at the same time
 // by default, all received packets will be handle only in one thread
-void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads) {
+void cerver_set_thpool_n_threads (
+	Cerver *cerver, u16 n_threads
+) {
 
 	if (cerver) cerver->n_thpool_threads = n_threads;
 
@@ -497,7 +509,9 @@ void cerver_set_thpool_n_threads (Cerver *cerver, u16 n_threads) {
 
 // sets the initial number of sockets to be created in the cerver's sockets pool
 // the defauult value is 10
-void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets) {
+void cerver_set_sockets_pool_init (
+	Cerver *cerver, unsigned int n_sockets
+) {
 
 	if (cerver) cerver->sockets_pool_init = n_sockets;
 
@@ -508,7 +522,10 @@ void cerver_set_sockets_pool_init (Cerver *cerver, unsigned int n_sockets) {
 // will be automatically dropped from the cerver
 // max_inactive_time - max secs allowed for a client to be inactive, 0 for default
 // check_inactive_interval - how often to check for inactive clients in secs, 0 for default
-void cerver_set_inactive_clients (Cerver *cerver, u32 max_inactive_time, u32 check_inactive_interval) {
+void cerver_set_inactive_clients (
+	Cerver *cerver,
+	u32 max_inactive_time, u32 check_inactive_interval
+) {
 
 	if (cerver) {
 		cerver->inactive_clients = true;
@@ -521,7 +538,9 @@ void cerver_set_inactive_clients (Cerver *cerver, u32 max_inactive_time, u32 che
 // sets the cerver handler type
 // the default type is to handle connections using the poll () which requires only one thread
 // if threads type is selected, a new thread will be created for each new connection
-void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type) {
+void cerver_set_handler_type (
+	Cerver *cerver, CerverHandlerType handler_type
+) {
 
 	if (cerver) cerver->handler_type = handler_type;
 
@@ -531,14 +550,18 @@ void cerver_set_handler_type (Cerver *cerver, CerverHandlerType handler_type) {
 // by only creating new detachable threads for each connection
 // by default, this option is turned off to also use the thpool
 // if cerver is of type CERVER_TYPE_WEB, the thpool will be used more often as connections have a shorter life
-void cerver_set_handle_detachable_threads (Cerver *cerver, bool active) {
+void cerver_set_handle_detachable_threads (
+	Cerver *cerver, bool active
+) {
 
 	if (cerver) cerver->handle_detachable_threads = active;
 
 }
 
 // sets the cerver poll timeout
-void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout) {
+void cerver_set_poll_time_out (
+	Cerver *cerver, const u32 poll_timeout
+) {
 
 	if (cerver) cerver->poll_timeout = poll_timeout;
 
@@ -547,7 +570,9 @@ void cerver_set_poll_time_out (Cerver *cerver, const u32 poll_timeout) {
 // enables cerver's built in authentication methods
 // cerver requires client authentication upon new client connections
 // retuns 0 on success, 1 on error
-u8 cerver_set_auth (Cerver *cerver, u8 max_auth_tries, delegate authenticate) {
+u8 cerver_set_auth (
+	Cerver *cerver, u8 max_auth_tries, delegate authenticate
+) {
 
 	u8 retval = 1;
 
@@ -563,8 +588,11 @@ u8 cerver_set_auth (Cerver *cerver, u8 max_auth_tries, delegate authenticate) {
 
 }
 
-// sets the max auth tries a new connection is allowed to have before it is dropped due to failure
-void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries) {
+// sets the max auth tries a new connection is allowed to have
+// before it is dropped due to failure
+void cerver_set_auth_max_tries (
+	Cerver *cerver, u8 max_auth_tries
+) {
 
 	if (cerver) cerver->max_auth_tries = max_auth_tries;
 
@@ -572,14 +600,18 @@ void cerver_set_auth_max_tries (Cerver *cerver, u8 max_auth_tries) {
 
 // sets the method to be used for client authentication
 // must return 0 on success authentication
-void cerver_set_auth_method (Cerver *cerver, delegate authenticate) {
+void cerver_set_auth_method (
+	Cerver *cerver, delegate authenticate
+) {
 
 	if (cerver && authenticate) cerver->authenticate = authenticate;
 
 }
 
 // sets the cerver on poll timeout in ms
-void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout) {
+void cerver_set_on_hold_poll_timeout (
+	Cerver *cerver, u32 on_hold_poll_timeout
+) {
 
 	if (cerver) cerver->on_hold_poll_timeout = on_hold_poll_timeout;
 
@@ -589,7 +621,9 @@ void cerver_set_on_hold_poll_timeout (Cerver *cerver, u32 on_hold_poll_timeout) 
 // the default is DEFAULT_ON_HOLD_MAX_BAD_PACKETS
 // a bad packet is anyone which can't be handle by the cerver because there is no handle,
 // or because it failed the packet_check () method
-void cerver_set_on_hold_max_bad_packets (Cerver *cerver, u8 on_hold_max_bad_packets) {
+void cerver_set_on_hold_max_bad_packets (
+	Cerver *cerver, u8 on_hold_max_bad_packets
+) {
 
 	if (cerver) cerver->on_hold_max_bad_packets = on_hold_max_bad_packets;
 
@@ -605,7 +639,9 @@ void cerver_set_on_hold_check_packets (Cerver *cerver, bool check) {
 
 // configures the cerver to use client sessions
 // retuns 0 on success, 1 on error
-u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const void *)) {
+u8 cerver_set_sessions (
+	Cerver *cerver, void *(*session_id_generator) (const void *)
+) {
 
 	u8 retval = 1;
 
@@ -623,14 +659,18 @@ u8 cerver_set_sessions (Cerver *cerver, void *(*session_id_generator) (const voi
 }
 
 // sets a custom method to handle the raw received buffer from the socker
-void cerver_set_handle_recieved_buffer (Cerver *cerver, Action handle_received_buffer) {
+void cerver_set_handle_recieved_buffer (
+	Cerver *cerver, Action handle_received_buffer
+) {
 
 	if (cerver) cerver->handle_received_buffer = handle_received_buffer;
 
 }
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
-void cerver_set_app_handlers (Cerver *cerver, Handler *app_handler, Handler *app_error_handler) {
+void cerver_set_app_handlers (
+	Cerver *cerver, Handler *app_handler, Handler *app_error_handler
+) {
 
 	if (cerver) {
 		cerver->app_packet_handler = app_handler;
@@ -651,7 +691,9 @@ void cerver_set_app_handlers (Cerver *cerver, Handler *app_handler, Handler *app
 // sets option to automatically delete PACKET_TYPE_APP packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet) {
+void cerver_set_app_handler_delete (
+	Cerver *cerver, bool delete_packet
+) {
 
 	if (cerver) cerver->app_packet_handler_delete_packet = delete_packet;
 
@@ -660,14 +702,18 @@ void cerver_set_app_handler_delete (Cerver *cerver, bool delete_packet) {
 // sets option to automatically delete PACKET_TYPE_APP_ERROR packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-void cerver_set_app_error_handler_delete (Cerver *cerver, bool delete_packet) {
+void cerver_set_app_error_handler_delete (
+	Cerver *cerver, bool delete_packet
+) {
 
 	if (cerver) cerver->app_error_packet_handler_delete_packet = delete_packet;
 
 }
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
-void cerver_set_custom_handler (Cerver *cerver, Handler *custom_handler) {
+void cerver_set_custom_handler (
+	Cerver *cerver, Handler *custom_handler
+) {
 
 	if (cerver) {
 		cerver->custom_packet_handler = custom_handler;
@@ -682,7 +728,9 @@ void cerver_set_custom_handler (Cerver *cerver, Handler *custom_handler) {
 // sets option to automatically delete PACKET_TYPE_CUSTOM packets after use
 // if set to false, user must delete the packets manualy
 // by the default, packets are deleted by cerver
-void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet) {
+void cerver_set_custom_handler_delete (
+	Cerver *cerver, bool delete_packet
+) {
 
 	if (cerver) cerver->custom_packet_handler_delete_packet = delete_packet;
 
@@ -690,7 +738,9 @@ void cerver_set_custom_handler_delete (Cerver *cerver, bool delete_packet) {
 
 // enables the ability of the cerver to have multiple app handlers
 // returns 0 on success, 1 on error
-int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers) {
+int cerver_set_multiple_handlers (
+	Cerver *cerver, unsigned int n_handlers
+) {
 
 	int retval = 1;
 
@@ -720,7 +770,9 @@ int cerver_set_multiple_handlers (Cerver *cerver, unsigned int n_handlers) {
 // if packets do not pass the checks, won't be handled and will be inmediately destroyed
 // packets size must be cheked in individual methods (handlers)
 // by default, this option is turned off
-void cerver_set_check_packets (Cerver *cerver, bool check_packets) {
+void cerver_set_check_packets (
+	Cerver *cerver, bool check_packets
+) {
 
 	if (cerver) {
 		cerver->check_packets = check_packets;
@@ -734,7 +786,8 @@ void cerver_set_check_packets (Cerver *cerver, bool check_packets) {
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void cerver_set_update (
 	Cerver *cerver,
-	Action update, void *update_args, void (*delete_update_args)(void *),
+	Action update,
+	void *update_args, void (*delete_update_args)(void *),
 	const u8 fps
 ) {
 
@@ -753,7 +806,8 @@ void cerver_set_update (
 // will only be deleted at cerver teardown if you set the delete_update_args ()
 void cerver_set_update_interval (
 	Cerver *cerver,
-	Action update, void *update_args, void (*delete_update_args)(void *),
+	Action update,
+	void *update_args, void (*delete_update_args)(void *),
 	const u32 interval
 ) {
 

--- a/src/cerver/files.c
+++ b/src/cerver/files.c
@@ -316,9 +316,37 @@ void file_cerver_stats_print (FileCerver *file_cerver) {
 
 #pragma region main
 
+// sanitizes a filename to correctly be used to save a file
+// removes every character & whitespaces except for
+// alphabet, numbers, '-', '_' and  '.'
+void files_sanitize_filename (char *filename) {
+
+	if (filename) {
+		for (int i = 0, j; filename[i] != '\0'; ++i) {
+			while (
+				!(filename[i] >= 'a' && filename[i] <= 'z') && !(filename[i] >= 'A' && filename[i] <= 'Z')	// alphabet
+				&& !(filename[i] >= 48 && filename[i] <= 57)												// numbers
+				&& !(filename[i] == '-') && !(filename[i] == '_') && !(filename[i] == '.')					// clean characters
+				&& !(filename[i] == '\0')
+			) {
+				for (j = i; filename[j] != '\0'; ++j) {
+					filename[j] = filename[j + 1];
+				}
+
+				filename[j] = '\0';
+			}
+		}
+
+		c_string_remove_spaces (filename);
+	}
+
+}
+
 // check if a directory already exists, and if not, creates it
 // returns 0 on success, 1 on error
-unsigned int files_create_dir (const char *dir_path, mode_t mode) {
+unsigned int files_create_dir (
+	const char *dir_path, mode_t mode
+) {
 
 	unsigned int retval = 1;
 

--- a/src/cerver/utils/utils.c
+++ b/src/cerver/utils/utils.c
@@ -117,7 +117,7 @@ void c_string_copy (char *to, const char *from) {
 
 	if (to && from) {
 		while (*from) *to++ = *from++;
-		
+
 		*to = '\0';
 	}
 
@@ -131,7 +131,7 @@ void c_string_n_copy (char *to, const char *from, size_t n) {
 			*to++ = *from++;
 			n--;
 		}
-		
+
 		*to = '\0';
 	}
 
@@ -139,7 +139,9 @@ void c_string_n_copy (char *to, const char *from, size_t n) {
 
 // concats two c strings into a newly allocated buffer of len s1 + s2
 // returns a newly allocated buffer on success, NULL on any error
-char *c_string_concat (const char *s1, const char *s2, size_t *des_size) {
+char *c_string_concat (
+	const char *s1, const char *s2, size_t *des_size
+) {
 
 	char *retval = NULL;
 
@@ -168,7 +170,10 @@ char *c_string_concat (const char *s1, const char *s2, size_t *des_size) {
 // concats two strings into the same buffer
 // wont perform operation if result would overflow buffer
 // returns the len of the final string
-size_t c_string_concat_safe (const char *s1, const char *s2, const char *des, size_t des_size) {
+size_t c_string_concat_safe (
+	const char *s1, const char *s2,
+	const char *des, size_t des_size
+) {
 
 	size_t retval = 0;
 
@@ -194,7 +199,7 @@ size_t c_string_concat_safe (const char *s1, const char *s2, const char *des, si
 // creates a new c string with the desired format, as in printf
 char *c_string_create (const char *format, ...) {
 
-	char *fmt;
+	char *fmt = NULL;
 
 	if (format != NULL) fmt = strdup (format);
 	else fmt = strdup ("");
@@ -219,9 +224,35 @@ char *c_string_create (const char *format, ...) {
 
 }
 
+// removes all the spaces in the c string
+void c_string_remove_spaces (char *s) {
+
+	const char *d = s;
+	do {
+		while (*d == ' ') {
+			++d;
+		}
+	} while ((*s++ = *d++));
+
+}
+
+// removes any CRLF characters in a string
+void c_string_remove_line_breaks (char *s) {
+
+	const char *d = s;
+	do {
+		while (*d == '\r' || *d == '\n') {
+			++d;
+		}
+	} while ((*s++ = *d++));
+
+}
+
 // get how many tokens will be extracted by counting the number of apperances of the delim
 // the original string won't be affected
-size_t c_string_count_tokens (const char *original, const char delim) {
+size_t c_string_count_tokens (
+	const char *original, const char delim
+) {
 
 	size_t count = 0;
 
@@ -256,7 +287,9 @@ size_t c_string_count_tokens (const char *original, const char delim) {
 // splits a c string into tokens based on a delimiter
 // the original string won't be affected
 // this method is thread safe as it uses __strtok_r () instead of the regular strtok ()
-char **c_string_split (const char *original, const char delim, size_t *n_tokens) {
+char **c_string_split (
+	const char *original, const char delim, size_t *n_tokens
+) {
 
 	char **result = NULL;
 
@@ -327,7 +360,7 @@ void c_string_remove_char (char *string, char garbage) {
 		*dst = *src;
 		if (*dst != garbage) dst++;
 	}
-	
+
 	*dst = '\0';
 
 }
@@ -348,7 +381,7 @@ char *c_string_remove_sub (char *str, const char *sub) {
 			size_t new_len = len_str - len_sub;
 			retval = (char *) calloc (new_len + 1, sizeof (char));
 			if (retval) {
-				char *ptr = retval; 
+				char *ptr = retval;
 				ptrdiff_t idx = 0;
 
 				// copy the first part of the string
@@ -370,7 +403,7 @@ char *c_string_remove_sub (char *str, const char *sub) {
 			}
 		}
 	}
-	
+
 	return retval;
 
 }
@@ -412,8 +445,9 @@ char *c_string_strip_quotes (char *str) {
 // returns true if the string starts with the selected sub string
 bool c_string_starts_with (const char *str, const char *substr) {
 
-	return (str && substr) ? strncmp (str, substr, strlen (substr)) == 0 : false;
-	
+	return (str && substr) ?
+		strncmp (str, substr, strlen (substr)) == 0 : false;
+
 }
 
 // creates a newly allocated string using the data between the two pointers of the SAME string
@@ -447,7 +481,9 @@ char *c_string_create_with_ptrs (char *first, char *last) {
 // removes a substring from a c string that is defined after a token
 // returns a newly allocated string without the sub,
 // and option to retrieve the actual substring
-char *c_string_remove_sub_after_token (char *str, const char token, char **sub) {
+char *c_string_remove_sub_after_token (
+	char *str, const char token, char **sub
+) {
 
 	char *retval = NULL;
 
@@ -467,12 +503,12 @@ char *c_string_remove_sub_after_token (char *str, const char token, char **sub) 
 
 		if (sub) {
 			*sub = (char *) calloc (sub_len + 1, sizeof (char));
-			memcpy (*sub, ptr, sub_len);
+			(void) memcpy (*sub, ptr, sub_len);
 			// *sub[sub_len] = '\0';
-		} 
+		}
 
 		retval = (char *) calloc (diff_len + 1, sizeof (char));
-		memcpy (retval, str, diff_len);
+		(void) memcpy (retval, str, diff_len);
 		// retval[diff_len] = '\0';
 	}
 
@@ -485,7 +521,9 @@ char *c_string_remove_sub_after_token (char *str, const char token, char **sub) 
 // and option to retrieve the actual substring
 // idx set to -1 for the last token match
 // example: /home/ermiry/Documents, token: '/', idx: -1, returns: Documents
-char *c_string_remove_sub_after_token_with_idx (char *str, const char token, char **sub, int idx) {
+char *c_string_remove_sub_after_token_with_idx (
+	char *str, const char token, char **sub, int idx
+) {
 
 	char *retval = NULL;
 
@@ -513,12 +551,12 @@ char *c_string_remove_sub_after_token_with_idx (char *str, const char token, cha
 
 		if (sub) {
 			*sub = (char *) calloc (sub_len + 1, sizeof (char));
-			memcpy (*sub, last_ptr, sub_len);
+			(void) memcpy (*sub, last_ptr, sub_len);
 			// *sub[sub_len] = '\0';
-		} 
+		}
 
 		retval = (char *) calloc (diff_len + 1, sizeof (char));
-		memcpy (retval, str, diff_len);
+		(void) memcpy (retval, str, diff_len);
 		// retval[diff_len] = '\0';
 	}
 
@@ -531,7 +569,9 @@ char *c_string_remove_sub_after_token_with_idx (char *str, const char token, cha
 // example: test_20191118142101759__TEST__.png - token: '_'
 // result: test.png
 // returns a newly allocated string, and a option to get the substring
-char *c_string_remove_sub_simetric_token (char *str, const char token, char **sub) {
+char *c_string_remove_sub_simetric_token (
+	char *str, const char token, char **sub
+) {
 
 	char *retval = NULL;
 
@@ -553,12 +593,12 @@ char *c_string_remove_sub_simetric_token (char *str, const char token, char **su
 		if (sub) {
 			*sub = c_string_create_with_ptrs (first, last);
 			sub_ptr = *sub;
-		} 
+		}
 
 		else {
 			sub_ptr = c_string_create_with_ptrs (first, last);
 			out = false;
-		} 
+		}
 
 		// get the substring between the two tokens
 		retval = c_string_remove_sub (str, sub_ptr);
@@ -575,8 +615,11 @@ char *c_string_remove_sub_simetric_token (char *str, const char token, char **su
 // example: test_20191118142101759__TEST__.png - token: '_' - idx (first: 1,  last: 3)
 // result: testTEST__.png
 // returns a newly allocated string, and a option to get the substring
-char *c_string_remove_sub_range_token (char *str, const char token, unsigned int first, unsigned int last,
-	char **sub) {
+char *c_string_remove_sub_range_token (
+	char *str,
+	const char token, unsigned int first, unsigned int last,
+	char **sub
+) {
 
 	char *retval = NULL;
 
@@ -606,12 +649,12 @@ char *c_string_remove_sub_range_token (char *str, const char token, unsigned int
 			if (sub) {
 				*sub = c_string_create_with_ptrs (first_ptr, last_ptr);
 				sub_ptr = *sub;
-			} 
+			}
 
 			else {
 				sub_ptr = c_string_create_with_ptrs (first_ptr, last_ptr);
 				out = false;
-			} 
+			}
 
 			// get the substring between the two tokens
 			retval = c_string_remove_sub (str, sub_ptr);
@@ -628,7 +671,9 @@ char *c_string_remove_sub_range_token (char *str, const char token, unsigned int
 // takes the first appearance of the first token, and the last appearance of the second one
 // example: test_20191118142101759__TEST__.png - first token: '_' - last token: 'T'
 // result: test__.png
-char *c_string_remove_sub_different_token (char *str, const char token_one, const char token_two) {
+char *c_string_remove_sub_different_token (
+	char *str, const char token_one, const char token_two
+) {
 
 	// TODO:
 


### PR DESCRIPTION
## General
- Updated cerver default definitions in main cerver header
- Moved definitions from auth & handler headers to main cerver header
- Refactored cerver_new () & cerver init methods to use new default values
- Refactored main cerver methods definitions structure
- Removed poll type as the default handler when creating a new cerver
- Cerver's handle type must be manually specified before calling cerver_start ()
- Added files_sanitize_filename () method
- Refactored files sources organization & file_get_lines ()
- Refactored utilities sources & added more c string methods

## Examples
- Updated examples to manually specify their handler type
- Refactored makefile example & removed mongo dependency