### PR TITLE
Beta 1.6.3b-5

### DIFF
--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -27,6 +27,8 @@ struct _AdminCerver;
 #define ADMIN_CERVER_DEFAULT_MAX_ADMIN_CONNECTIONS		2
 #define ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS			4
 
+#define ADMIN_CERVER_DEFAULT_RECEIVE_BUFFER_SIZE		4096
+
 #define ADMIN_CERVER_DEFAULT_POLL_FDS					4
 #define ADMIN_CERVER_DEFAULT_POLL_TIMEOUT				2000
 
@@ -160,6 +162,8 @@ struct _AdminCerver {
 	// number of bad packets before ending connection
 	u32 n_bad_packets_limit;
 
+	size_t receive_buffer_size;
+
 	struct pollfd *fds;
 	u32 max_n_fds;                      // current max n fds in pollfd
 	u16 current_n_fds;                  // n of active fds in the pollfd array
@@ -229,6 +233,11 @@ CERVER_EXPORT void admin_cerver_set_max_admin_connections (
 // -1 to use defaults (5 and 20)
 CERVER_EXPORT void admin_cerver_set_bad_packets_limit (
 	AdminCerver *admin_cerver, i32 n_bad_packets_limit
+);
+
+// sets the admin cerver's receive buffer size used for recv ()
+CERVER_EXPORT void cerver_set_receive_buffer_size (
+	AdminCerver *admin_cerver, const size_t buffer_size
 );
 
 // sets the max number of poll fds for the admin cerver

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -71,6 +71,28 @@ CERVER_PUBLIC void admin_cerver_stats_print (
 
 #pragma region admin
 
+#define ADMIN_CONNECTIONS_STATUS_MAP(XX)									\
+	XX(0,	NONE,		None, 		Undefined)								\
+	XX(1,	ERROR,		Error, 		Failed to remove connection)			\
+	XX(2,	ONE,		One,		At least one active connection)			\
+	XX(3,	DROPPED,	Dropped,	Removed due to no connections left)
+
+typedef enum AdminConnectionsStatus {
+
+	#define XX(num, name, string, description) ADMIN_CONNECTIONS_STATUS_##name = num,
+	ADMIN_CONNECTIONS_STATUS_MAP (XX)
+	#undef XX
+
+} AdminConnectionsStatus;
+
+CERVER_PUBLIC const char *admin_connections_status_to_string (
+	const AdminConnectionsStatus status
+);
+
+CERVER_PUBLIC const char *admin_connections_status_description (
+	const AdminConnectionsStatus status
+);
+
 struct _Admin {
 
 	struct _AdminCerver *admin_cerver;
@@ -121,8 +143,9 @@ CERVER_PUBLIC Admin *admin_get_by_session_id (
 // removes the connection from the admin referred to by the sock fd
 // and also checks if there is another active connection in the admin, if not it will be dropped
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 admin_remove_connection_by_sock_fd (
-	struct _AdminCerver *admin_cerver, Admin *admin, const i32 sock_fd
+CERVER_PUBLIC AdminConnectionsStatus admin_remove_connection_by_sock_fd (
+	struct _AdminCerver *admin_cerver,
+	Admin *admin, const i32 sock_fd
 );
 
 // sends a packet to the first connection of the specified admin

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -236,7 +236,7 @@ CERVER_EXPORT void admin_cerver_set_bad_packets_limit (
 );
 
 // sets the admin cerver's receive buffer size used for recv ()
-CERVER_EXPORT void cerver_set_receive_buffer_size (
+CERVER_EXPORT void admin_cerver_set_receive_buffer_size (
 	AdminCerver *admin_cerver, const size_t buffer_size
 );
 

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -384,6 +384,27 @@ CERVER_PRIVATE u8 admin_cerver_end (
 
 #pragma region handler
 
+#define ADMIN_CERVER_HANDLER_ERROR_MAP(XX)										\
+	XX(0,	NONE,			None,				No handler error)				\
+	XX(1,	PACKET,			Bad Packet,			Packet check failed)			\
+	XX(2,	DROPPED,		Dropped Connection, The connection has been ended)
+
+typedef enum AdminCerverHandlerError {
+
+	#define XX(num, name, string, description) ADMIN_CERVER_HANDLER_ERROR_##name = num,
+	ADMIN_CERVER_HANDLER_ERROR_MAP (XX)
+	#undef XX
+
+} AdminCerverHandlerError;
+
+CERVER_PUBLIC const char *admin_cerver_handler_error_to_string (
+	const AdminCerverHandlerError error
+);
+
+CERVER_PUBLIC const char *admin_cerver_handler_error_description (
+	const AdminCerverHandlerError error
+);
+
 // handles a packet from an admin
 // returns 0 if we can / need to handle more packets
 // returns 1 if the connection has been ended

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -368,20 +368,29 @@ CERVER_PRIVATE u8 admin_cerver_drop_admin (
 
 #pragma region start
 
-CERVER_PRIVATE u8 admin_cerver_start (AdminCerver *admin_cerver);
+CERVER_PRIVATE u8 admin_cerver_start (
+	AdminCerver *admin_cerver
+);
 
 #pragma endregion
 
 #pragma region end
 
-CERVER_PRIVATE u8 admin_cerver_end (AdminCerver *admin_cerver);
+CERVER_PRIVATE u8 admin_cerver_end (
+	AdminCerver *admin_cerver
+);
 
 #pragma endregion
 
 #pragma region handler
 
 // handles a packet from an admin
-CERVER_PRIVATE void admin_packet_handler (struct _Packet *packet);
+// returns 0 if we can / need to handle more packets
+// returns 1 if the connection has been ended
+// or removed from admin poll
+CERVER_PRIVATE u8 admin_packet_handler (
+	struct _Packet *packet
+);
 
 #pragma endregion
 

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -88,7 +88,9 @@ typedef struct _AuthMethod AuthMethod;
 
 #pragma region handler
 
-// handles an packet from an on hold connection
+// handles a packet from an on hold connection
+// returns 0 if we can / need to handle more packets
+// returns 1 if the connection has been ended or removed from on hold
 CERVER_PRIVATE u8 on_hold_packet_handler (
 	struct _Packet *packet
 );

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -18,14 +18,14 @@ struct _Packet;
 
 #pragma region errors
 
-#define CERVER_AUTH_ERROR_MAP(XX)														    \
-	XX(0,	NONE, 		        None, 		        No authentication error)				\
-	XX(1,	SUCCESS, 		    Success Auth, 		Authentication has been successful)	    \
-	XX(2,	NO_HANDLER, 	    No Handler, 		The cerver has no auth handler)			\
-	XX(3,	MISSING_VALUES,     Missing Values, 	Bad auth request due to missing values) \
-	XX(4,	FAILED, 	        Failed Auth, 	    Invalid credentials)                    \
-	XX(5,	INVALID_SESSION, 	Bad Session ID, 	Session id is invalid)                  \
-	XX(6,	DROPPED, 	        Dropped Connection, The connection has been ended)
+#define CERVER_AUTH_ERROR_MAP(XX)															\
+	XX(0,	NONE,				None,				No authentication error)				\
+	XX(1,	SUCCESS,			Success Auth,		Authentication has been successful)		\
+	XX(2,	NO_HANDLER,			No Handler,			The cerver has no auth handler)			\
+	XX(3,	MISSING_VALUES,		Missing Values,		Bad auth request due to missing values) \
+	XX(4,	FAILED,				Failed Auth,		Invalid credentials)					\
+	XX(5,	INVALID_SESSION,	Bad Session ID,		Session id is invalid)					\
+	XX(6,	DROPPED,			Dropped Connection, The connection has been ended)
 
 typedef enum CerverAuthError {
 
@@ -36,11 +36,11 @@ typedef enum CerverAuthError {
 } CerverAuthError;
 
 CERVER_PUBLIC const char *cerver_auth_error_to_string (
-    const CerverAuthError error
+	const CerverAuthError error
 );
 
 CERVER_PUBLIC const char *cerver_auth_error_description (
-    const CerverAuthError error
+	const CerverAuthError error
 );
 
 #pragma endregion
@@ -50,17 +50,17 @@ CERVER_PUBLIC const char *cerver_auth_error_description (
 // the auth data stripped from the packet
 struct _AuthData {
 
-    String *token;
+	String *token;
 
-    void *auth_data;
-    size_t auth_data_size;
+	void *auth_data;
+	size_t auth_data_size;
 
-    // recover data used for authentication
-    // after a success auth, it will be added to the client
-    // if not, it should be dispossed by user defined auth method
-    // and set to NULL
-    void *data;                 
-    Action delete_data;         // how to delete the data
+	// recover data used for authentication
+	// after a success auth, it will be added to the client
+	// if not, it should be dispossed by user defined auth method
+	// and set to NULL
+	void *data;
+	Action delete_data;         // how to delete the data
 
 };
 
@@ -73,12 +73,12 @@ typedef struct _AuthData AuthData;
 // auxiliary structure passed to the user defined auth method
 struct _AuthMethod {
 
-    struct _Packet *packet;         // the original packet
-    AuthData *auth_data;            // the stripped auth data from the packet
+	struct _Packet *packet;         // the original packet
+	AuthData *auth_data;            // the stripped auth data from the packet
 
-    // a user message that can be sent to the connection when teh auth has failed
-    // in a generated ERR_FAILED_AUTH packet
-    String *error_message;
+	// a user message that can be sent to the connection when teh auth has failed
+	// in a generated ERR_FAILED_AUTH packet
+	String *error_message;
 
 };
 
@@ -90,7 +90,7 @@ typedef struct _AuthMethod AuthMethod;
 
 // handles an packet from an on hold connection
 CERVER_PRIVATE u8 on_hold_packet_handler (
-    struct _Packet *packet
+	struct _Packet *packet
 );
 
 #pragma endregion
@@ -101,12 +101,12 @@ CERVER_PRIVATE u8 on_hold_packet_handler (
 // until it has a sucess or failed authentication
 // returns 0 on success, 1 on error
 CERVER_PRIVATE u8 on_hold_connection (
-    struct _Cerver *cerver, struct _Connection *connection
+	struct _Cerver *cerver, struct _Connection *connection
 );
 
 // closes the on hold connection and removes it from the cerver
 CERVER_PRIVATE void on_hold_connection_drop (
-    const struct _Cerver *cerver, struct _Connection *connection
+	const struct _Cerver *cerver, struct _Connection *connection
 );
 
 #pragma endregion
@@ -116,7 +116,7 @@ CERVER_PRIVATE void on_hold_connection_drop (
 // removed a sock fd from the cerver's on hold poll array
 // returns 0 on success, 1 on error
 CERVER_PRIVATE u8 on_hold_poll_unregister_sock_fd (
-    struct _Cerver *cerver, const i32 sock_fd
+	struct _Cerver *cerver, const i32 sock_fd
 );
 
 // handles packets from the on hold clients until they authenticate

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -14,6 +14,8 @@
 struct _Cerver;
 struct _Connection;
 
+struct _Packet;
+
 // the auth data stripped from the packet
 struct _AuthData {
 
@@ -50,7 +52,9 @@ typedef struct _AuthMethod AuthMethod;
 #pragma region handler
 
 // handles an packet from an on hold connection
-CERVER_PRIVATE void on_hold_packet_handler (void *packet_ptr);
+CERVER_PRIVATE void on_hold_packet_handler (
+    struct _Packet *packet
+);
 
 #pragma endregion
 
@@ -59,10 +63,14 @@ CERVER_PRIVATE void on_hold_packet_handler (void *packet_ptr);
 // if the cerver requires authentication, we put the connection on hold
 // until it has a sucess or failed authentication
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 on_hold_connection (struct _Cerver *cerver, struct _Connection *connection);
+CERVER_PRIVATE u8 on_hold_connection (
+    struct _Cerver *cerver, struct _Connection *connection
+);
 
 // closes the on hold connection and removes it from the cerver
-CERVER_PRIVATE void on_hold_connection_drop (const struct _Cerver *cerver, struct _Connection *connection);
+CERVER_PRIVATE void on_hold_connection_drop (
+    const struct _Cerver *cerver, struct _Connection *connection
+);
 
 #pragma endregion
 
@@ -70,7 +78,9 @@ CERVER_PRIVATE void on_hold_connection_drop (const struct _Cerver *cerver, struc
 
 // removed a sock fd from the cerver's on hold poll array
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 on_hold_poll_unregister_sock_fd (struct _Cerver *cerver, const i32 sock_fd);
+CERVER_PRIVATE u8 on_hold_poll_unregister_sock_fd (
+    struct _Cerver *cerver, const i32 sock_fd
+);
 
 // handles packets from the on hold clients until they authenticate
 CERVER_PRIVATE void *on_hold_poll (void *cerver_ptr);

--- a/include/cerver/auth.h
+++ b/include/cerver/auth.h
@@ -16,6 +16,37 @@ struct _Connection;
 
 struct _Packet;
 
+#pragma region errors
+
+#define CERVER_AUTH_ERROR_MAP(XX)														    \
+	XX(0,	NONE, 		        None, 		        No authentication error)				\
+	XX(1,	SUCCESS, 		    Success Auth, 		Authentication has been successful)	    \
+	XX(2,	NO_HANDLER, 	    No Handler, 		The cerver has no auth handler)			\
+	XX(3,	MISSING_VALUES,     Missing Values, 	Bad auth request due to missing values) \
+	XX(4,	FAILED, 	        Failed Auth, 	    Invalid credentials)                    \
+	XX(5,	INVALID_SESSION, 	Bad Session ID, 	Session id is invalid)                  \
+	XX(6,	DROPPED, 	        Dropped Connection, The connection has been ended)
+
+typedef enum CerverAuthError {
+
+	#define XX(num, name, string, description) CERVER_AUTH_ERROR_##name = num,
+	CERVER_AUTH_ERROR_MAP (XX)
+	#undef XX
+
+} CerverAuthError;
+
+CERVER_PUBLIC const char *cerver_auth_error_to_string (
+    const CerverAuthError error
+);
+
+CERVER_PUBLIC const char *cerver_auth_error_description (
+    const CerverAuthError error
+);
+
+#pragma endregion
+
+#pragma region data
+
 // the auth data stripped from the packet
 struct _AuthData {
 
@@ -35,6 +66,10 @@ struct _AuthData {
 
 typedef struct _AuthData AuthData;
 
+#pragma endregion
+
+#pragma region method
+
 // auxiliary structure passed to the user defined auth method
 struct _AuthMethod {
 
@@ -49,10 +84,12 @@ struct _AuthMethod {
 
 typedef struct _AuthMethod AuthMethod;
 
+#pragma endregion
+
 #pragma region handler
 
 // handles an packet from an on hold connection
-CERVER_PRIVATE void on_hold_packet_handler (
+CERVER_PRIVATE u8 on_hold_packet_handler (
     struct _Packet *packet
 );
 

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -49,6 +49,7 @@
 #define CERVER_DEFAULT_ON_HOLD_TIMEOUT				2000
 #define CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS		4
 #define CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS		false
+#define CERVER_DEFAULT_ON_HOLD_RECEIVE_BUFFER_SIZE	4096
 
 #define CERVER_DEFAULT_USE_SESSIONS					false
 
@@ -267,6 +268,7 @@ struct _Cerver {
 	pthread_mutex_t *on_hold_poll_lock;
 	u8 on_hold_max_bad_packets;
 	bool on_hold_check_packets;
+	size_t on_hold_receive_buffer_size;
 
 	// allow the clients to use sessions (have multiple connections)
 	bool use_sessions;
@@ -437,6 +439,12 @@ CERVER_EXPORT void cerver_set_on_hold_max_bad_packets (
 // any packet that fails the check will be considered as a bad packet
 CERVER_EXPORT void cerver_set_on_hold_check_packets (
 	Cerver *cerver, bool check
+);
+
+// sets the size of the buffer to be allocated
+// to receive packets from on hold connections
+CERVER_EXPORT void cerver_set_on_hold_receive_buffer_size (
+	Cerver *cerver, const size_t on_hold_receive_buffer_size
 );
 
 // configures the cerver to use client sessions

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -291,9 +291,10 @@ CERVER_EXPORT u8 client_connection_drop (
 // removes the connection from the client referred to by the sock fd by calling client_connection_drop ()
 // and also remove the client & connection from the cerver's structures when needed
 // also checks if there is another active connection in the client, if not it will be dropped
-// returns 0 on success, 1 on error
-CERVER_PUBLIC u8 client_remove_connection_by_sock_fd (
-	struct _Cerver *cerver, Client *client, i32 sock_fd
+// returns the resulting status after the operation
+CERVER_PUBLIC ClientConnectionsStatus client_remove_connection_by_sock_fd (
+	struct _Cerver *cerver,
+	Client *client, const i32 sock_fd
 );
 
 // registers all the active connections from a client to the cerver's structures (like maps)

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -89,6 +89,28 @@ CERVER_PUBLIC void client_file_stats_print (
 #define CLIENT_MAX_EVENTS				32
 #define CLIENT_MAX_ERRORS				32
 
+#define CLIENT_CONNECTIONS_STATUS_MAP(XX)									\
+	XX(0,	NONE,		None, 		Undefined)								\
+	XX(1,	ERROR,		Error, 		Failed to remove connection)			\
+	XX(2,	ONE,		One,		At least one active connection)			\
+	XX(3,	DROPPED,	Dropped,	Removed due to no connections left)
+
+typedef enum ClientConnectionsStatus {
+
+	#define XX(num, name, string, description) CLIENT_CONNECTIONS_STATUS_##name = num,
+	CLIENT_CONNECTIONS_STATUS_MAP (XX)
+	#undef XX
+
+} ClientConnectionsStatus;
+
+CERVER_PUBLIC const char *client_connections_status_to_string (
+	const ClientConnectionsStatus status
+);
+
+CERVER_PUBLIC const char *client_connections_status_description (
+	const ClientConnectionsStatus status
+);
+
 // anyone that connects to the cerver
 struct _Client {
 

--- a/include/cerver/client.h
+++ b/include/cerver/client.h
@@ -2,6 +2,7 @@
 #define _CERVER_CLIENT_H_
 
 #include <stdbool.h>
+
 #include <time.h>
 
 #include "cerver/types/types.h"
@@ -37,15 +38,15 @@ struct _ClientError;
 
 struct _ClientStats {
 
-	time_t threshold_time;                  // every time we want to reset the client's stats
+	time_t threshold_time;			// every time we want to reset the client's stats
 
-	u64 n_receives_done;                    // n calls to recv ()
+	u64 n_receives_done;			// n calls to recv ()
 
-	u64 total_bytes_received;               // total amount of bytes received from this client
-	u64 total_bytes_sent;                   // total amount of bytes that have been sent to the client (all of its connections)
+	u64 total_bytes_received;		// total amount of bytes received from this client
+	u64 total_bytes_sent;			// total amount of bytes that have been sent to the client (all of its connections)
 
-	u64 n_packets_received;                 // total number of packets received from this client (packet header + data)
-	u64 n_packets_sent;                     // total number of packets sent to this client (all connections)
+	u64 n_packets_received;			// total number of packets received from this client (packet header + data)
+	u64 n_packets_sent;				// total number of packets sent to this client (all connections)
 
 	struct _PacketsPerType *received_packets;
 	struct _PacketsPerType *sent_packets;
@@ -54,7 +55,9 @@ struct _ClientStats {
 
 typedef struct _ClientStats ClientStats;
 
-CERVER_PUBLIC void client_stats_print (struct _Client *client);
+CERVER_PUBLIC void client_stats_print (
+	struct _Client *client
+);
 
 struct _ClientFileStats {
 
@@ -75,7 +78,9 @@ struct _ClientFileStats {
 
 typedef struct _ClientFileStats ClientFileStats;
 
-CERVER_PUBLIC void client_file_stats_print (struct _Client *client);
+CERVER_PUBLIC void client_file_stats_print (
+	struct _Client *client
+);
 
 #pragma endregion
 
@@ -91,7 +96,6 @@ struct _Client {
 	u64 id;
 	time_t connected_timestamp;
 
-	// 16/06/2020 - abiility to add a name to a client
 	String *name;
 
 	DoubleList *connections;
@@ -99,9 +103,9 @@ struct _Client {
 	// multiple connections can be associated with the same client using the same session id
 	String *session_id;
 
-	time_t last_activity;   // the last time the client sent / receive data
+	time_t last_activity;	// the last time the client sent / receive data
 
-	bool drop_client;        // client failed to authenticate
+	bool drop_client;		// client failed to authenticate
 
 	void *data;
 	Action delete_data;
@@ -111,7 +115,7 @@ struct _Client {
 	time_t time_started;
 	u64 uptime;
 
-	// 16/06/2020 - custom packet handlers
+	// custom packet handlers
 	unsigned int num_handlers_alive;       // handlers currently alive
 	unsigned int num_handlers_working;     // handlers currently working
 	pthread_mutex_t *handlers_lock;
@@ -121,7 +125,7 @@ struct _Client {
 
 	bool check_packets;              // enable / disbale packet checking
 
-	// 17/06/2020 - general client lock
+	// general client lock
 	pthread_mutex_t *lock;
 
 	struct _ClientEvent *events[CLIENT_MAX_EVENTS];
@@ -159,7 +163,8 @@ CERVER_PUBLIC Client *client_new (void);
 // completely deletes a client and all of its data
 CERVER_PUBLIC void client_delete (void *ptr);
 
-// used in data structures that require a delete function, but the client needs to stay alive
+// used in data structures that require a delete function
+// but the client needs to stay alive
 CERVER_PUBLIC void client_delete_dummy (void *ptr);
 
 // creates a new client and inits its values
@@ -172,22 +177,30 @@ CERVER_PUBLIC Client *client_create_with_connection (
 );
 
 // sets the client's name
-CERVER_EXPORT void client_set_name (Client *client, const char *name);
+CERVER_EXPORT void client_set_name (
+	Client *client, const char *name
+);
 
 // this methods is primarily used for logging
 // returns the client's name directly (if any) & should NOT be deleted, if not
 // returns a newly allocated string with the clients id that should be deleted after use
-CERVER_EXPORT char *client_get_identifier (Client *client, bool *is_name);
+CERVER_EXPORT char *client_get_identifier (
+	Client *client, bool *is_name
+);
 
 // sets the client's session id
-CERVER_PUBLIC u8 client_set_session_id (Client *client, const char *session_id);
+CERVER_PUBLIC u8 client_set_session_id (
+	Client *client, const char *session_id
+);
 
 // returns the client's app data
 CERVER_EXPORT void *client_get_data (Client *client);
 
 // sets client's data and a way to destroy it
 // deletes the previous data of the client
-CERVER_EXPORT void client_set_data (Client *client, void *data, Action delete_data);
+CERVER_EXPORT void client_set_data (
+	Client *client, void *data, Action delete_data
+);
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
 CERVER_EXPORT void client_set_app_handlers (
@@ -196,20 +209,28 @@ CERVER_EXPORT void client_set_app_handlers (
 );
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
-CERVER_EXPORT void client_set_custom_handler (Client *client, struct _Handler *custom_handler);
+CERVER_EXPORT void client_set_custom_handler (
+	Client *client, struct _Handler *custom_handler
+);
 
 // set whether to check or not incoming packets
 // check packet's header protocol id & version compatibility
 // if packets do not pass the checks, won't be handled and will be inmediately destroyed
 // packets size must be cheked in individual methods (handlers)
 // by default, this option is turned off
-CERVER_EXPORT void client_set_check_packets (Client *client, bool check_packets);
+CERVER_EXPORT void client_set_check_packets (
+	Client *client, bool check_packets
+);
 
 // compare clients based on their client ids
-CERVER_PUBLIC int client_comparator_client_id (const void *a, const void *b);
+CERVER_PUBLIC int client_comparator_client_id (
+	const void *a, const void *b
+);
 
 // compare clients based on their session ids
-CERVER_PUBLIC int client_comparator_session_id (const void *a, const void *b);
+CERVER_PUBLIC int client_comparator_session_id (
+	const void *a, const void *b
+);
 
 // closes all client connections
 // returns 0 on success, 1 on error
@@ -220,61 +241,89 @@ CERVER_EXPORT void client_got_disconnected (Client *client);
 
 // drops a client form the cerver
 // unregisters the client from the cerver and the deletes him
-CERVER_EXPORT void client_drop (struct _Cerver *cerver, Client *client);
+CERVER_EXPORT void client_drop (
+	struct _Cerver *cerver, Client *client
+);
 
 // adds a new connection to the end of the client to the client's connection list
 // without adding it to any other structure
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 client_connection_add (Client *client, struct _Connection *connection);
+CERVER_EXPORT u8 client_connection_add (
+	Client *client, struct _Connection *connection
+);
 
 // removes the connection from the client
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 client_connection_remove (Client *client, struct _Connection *connection);
+CERVER_EXPORT u8 client_connection_remove (
+	Client *client, struct _Connection *connection
+);
 
 // closes the connection & then removes it from the client & finally deletes the connection
 // moves the socket to the cerver's socket pool
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 client_connection_drop (struct _Cerver *cerver, Client *client, struct _Connection *connection);
+CERVER_EXPORT u8 client_connection_drop (
+	struct _Cerver *cerver,
+	Client *client, struct _Connection *connection
+);
 
 // removes the connection from the client referred to by the sock fd by calling client_connection_drop ()
 // and also remove the client & connection from the cerver's structures when needed
 // also checks if there is another active connection in the client, if not it will be dropped
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 client_remove_connection_by_sock_fd (struct _Cerver *cerver, Client *client, i32 sock_fd);
+CERVER_PUBLIC u8 client_remove_connection_by_sock_fd (
+	struct _Cerver *cerver, Client *client, i32 sock_fd
+);
 
 // registers all the active connections from a client to the cerver's structures (like maps)
 // returns 0 on success registering at least one, 1 if all connections failed
-CERVER_PRIVATE u8 client_register_connections_to_cerver (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE u8 client_register_connections_to_cerver (
+	struct _Cerver *cerver, Client *client
+);
 
 // unregiters all the active connections from a client from the cerver's structures (like maps)
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
-CERVER_PRIVATE u8 client_unregister_connections_from_cerver (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE u8 client_unregister_connections_from_cerver (
+	struct _Cerver *cerver, Client *client
+);
 
 // registers all the active connections from a client to the cerver's poll
 // returns 0 on success registering at least one, 1 if all connections failed
-CERVER_PRIVATE u8 client_register_connections_to_cerver_poll (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE u8 client_register_connections_to_cerver_poll (
+	struct _Cerver *cerver, Client *client
+);
 
 // unregisters all the active connections from a client from the cerver's poll
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
-CERVER_PRIVATE u8 client_unregister_connections_from_cerver_poll (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE u8 client_unregister_connections_from_cerver_poll (
+	struct _Cerver *cerver, Client *client
+);
 
-// 07/06/2020
 // removes the client from cerver data structures, not taking into account its connections
-CERVER_PRIVATE Client *client_remove_from_cerver (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE Client *client_remove_from_cerver (
+	struct _Cerver *cerver, Client *client
+);
 
 // registers a client to the cerver --> add it to cerver's structures
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 client_register_to_cerver (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE u8 client_register_to_cerver (
+	struct _Cerver *cerver, Client *client
+);
 
 // unregisters a client from a cerver -- removes it from cerver's structures
-CERVER_PRIVATE Client *client_unregister_from_cerver (struct _Cerver *cerver, Client *client);
+CERVER_PRIVATE Client *client_unregister_from_cerver (
+	struct _Cerver *cerver, Client *client
+);
 
 // gets the client associated with a sock fd using the client-sock fd map
-CERVER_PUBLIC Client *client_get_by_sock_fd (struct _Cerver *cerver, i32 sock_fd);
+CERVER_PUBLIC Client *client_get_by_sock_fd (
+	struct _Cerver *cerver, i32 sock_fd
+);
 
 // searches the avl tree to get the client associated with the session id
 // the cerver must support sessions
-CERVER_PUBLIC Client *client_get_by_session_id (struct _Cerver *cerver, const char *session_id);
+CERVER_PUBLIC Client *client_get_by_session_id (
+	struct _Cerver *cerver, const char *session_id
+);
 
 // broadcast a packet to all clients inside an avl structure
 CERVER_PUBLIC void client_broadcast_to_all_avl (
@@ -316,7 +365,9 @@ typedef enum ClientEventType {
 } ClientEventType;
 
 // get the description for the current error type
-CERVER_EXPORT const char *client_event_type_description (ClientEventType type);
+CERVER_EXPORT const char *client_event_type_description (
+	const ClientEventType type
+);
 
 struct _ClientEvent {
 
@@ -353,7 +404,9 @@ CERVER_EXPORT u8 client_event_register (
 // unregister the action associated with an event
 // deletes the action args using the delete_action_args () if NOT NULL
 // returns 0 on success, 1 on error or if event is NOT registered
-CERVER_EXPORT u8 client_event_unregister (struct _Client *client, const ClientEventType event_type);
+CERVER_EXPORT u8 client_event_unregister (
+	struct _Client *client, const ClientEventType event_type
+);
 
 CERVER_PRIVATE void client_event_set_response (
 	struct _Client *client,
@@ -381,7 +434,9 @@ typedef struct ClientEventData {
 
 } ClientEventData;
 
-CERVER_PUBLIC void client_event_data_delete (ClientEventData *event_data);
+CERVER_PUBLIC void client_event_data_delete (
+	ClientEventData *event_data
+);
 
 #pragma endregion
 
@@ -412,7 +467,9 @@ typedef enum ClientErrorType {
 } ClientErrorType;
 
 // get the description for the current error type
-CERVER_EXPORT const char *client_error_type_description (ClientErrorType type);
+CERVER_EXPORT const char *client_error_type_description (
+	const ClientErrorType type
+);
 
 struct _ClientError {
 
@@ -443,7 +500,9 @@ CERVER_EXPORT u8 client_error_register (
 // unregisters the action associated with the error types
 // deletes the action args using the delete_action_args () if NOT NULL
 // returns 0 on success, 1 on error or if error is NOT registered
-CERVER_EXPORT u8 client_error_unregister (struct _Client *client, const ClientErrorType error_type);
+CERVER_EXPORT u8 client_error_unregister (
+	struct _Client *client, const ClientErrorType error_type
+);
 
 // triggers all the actions that are registred to an error
 // returns 0 on success, 1 on error
@@ -465,10 +524,14 @@ typedef struct ClientErrorData {
 
 } ClientErrorData;
 
-CERVER_PUBLIC void client_error_data_delete (ClientErrorData *error_data);
+CERVER_PUBLIC void client_error_data_delete (
+	ClientErrorData *error_data
+);
 
 // creates an error packet ready to be sent
-CERVER_PUBLIC struct _Packet *client_error_packet_generate (const ClientErrorType type, const char *msg);
+CERVER_PUBLIC struct _Packet *client_error_packet_generate (
+	const ClientErrorType type, const char *msg
+);
 
 // creates and send a new error packet
 // returns 0 on success, 1 on error
@@ -491,7 +554,9 @@ typedef struct ClientConnection {
 
 } ClientConnection;
 
-CERVER_PRIVATE void client_connection_aux_delete (ClientConnection *cc);
+CERVER_PRIVATE void client_connection_aux_delete (
+	ClientConnection *cc
+);
 
 // creates a new connection that is ready to connect and registers it to the client
 CERVER_EXPORT struct _Connection *client_connection_create (
@@ -502,14 +567,20 @@ CERVER_EXPORT struct _Connection *client_connection_create (
 
 // registers an existing connection to a client
 // retuns 0 on success, 1 on error
-CERVER_EXPORT int client_connection_register (Client *client, struct _Connection *connection);
+CERVER_EXPORT int client_connection_register (
+	Client *client, struct _Connection *connection
+);
 
 // unregister an exitsing connection from the client
 // returns 0 on success, 1 on error or if the connection does not belong to the client
-CERVER_EXPORT int client_connection_unregister (Client *client, struct _Connection *connection);
+CERVER_EXPORT int client_connection_unregister (
+	Client *client, struct _Connection *connection
+);
 
 // performs a receive in the connection's socket to get a complete packet & handle it
-CERVER_EXPORT void client_connection_get_next_packet (Client *client, struct _Connection *connection);
+CERVER_EXPORT void client_connection_get_next_packet (
+	Client *client, struct _Connection *connection
+);
 
 /*** connect ***/
 
@@ -518,20 +589,26 @@ CERVER_EXPORT void client_connection_get_next_packet (Client *client, struct _Co
 // this is a blocking method, as it will wait until the connection has been successfull or a timeout
 // user must manually handle how he wants to receive / handle incomming packets and also send requests
 // returns 0 when the connection has been established, 1 on error or failed to connect
-CERVER_EXPORT unsigned int client_connect (Client *client, struct _Connection *connection);
+CERVER_EXPORT unsigned int client_connect (
+	Client *client, struct _Connection *connection
+);
 
 // connects a client to the host with the specified values in the connection
 // performs a first read to get the cerver info packet
 // this is a blocking method, and works exactly the same as if only calling client_connect ()
 // returns 0 when the connection has been established, 1 on error or failed to connect
-CERVER_EXPORT unsigned int client_connect_to_cerver (Client *client, struct _Connection *connection);
+CERVER_EXPORT unsigned int client_connect_to_cerver (
+	Client *client, struct _Connection *connection
+);
 
 // connects a client to the host with the specified values in the connection
 // it can be a cerver or not
 // this is NOT a blocking method, a new thread will be created to wait for a connection to be established
 // user must manually handle how he wants to receive / handle incomming packets and also send requests
 // returns 0 on success connection thread creation, 1 on error
-CERVER_EXPORT unsigned int client_connect_async (Client *client, struct _Connection *connection);
+CERVER_EXPORT unsigned int client_connect_async (
+	Client *client, struct _Connection *connection
+);
 
 /*** start ***/
 
@@ -539,18 +616,24 @@ CERVER_EXPORT unsigned int client_connect_async (Client *client, struct _Connect
 // it will start the connection's update thread to enable the connection to
 // receive & handle packets in a dedicated thread
 // returns 0 on success, 1 on error
-CERVER_EXPORT int client_connection_start (Client *client, struct _Connection *connection);
+CERVER_EXPORT int client_connection_start (
+	Client *client, struct _Connection *connection
+);
 
 // connects a client connection to a server
 // and after a success connection, it will start the connection (create update thread for receiving messages)
 // this is a blocking method, returns only after a success or failed connection
 // returns 0 on success, 1 on error
-CERVER_EXPORT int client_connect_and_start (Client *client, struct _Connection *connection);
+CERVER_EXPORT int client_connect_and_start (
+	Client *client, struct _Connection *connection
+);
 
 // connects a client connection to a server in a new thread to avoid blocking the calling thread,
 // and after a success connection, it will start the connection (create update thread for receiving messages)
 // returns 0 on success creating connection thread, 1 on error
-CERVER_EXPORT u8 client_connect_and_start_async (Client *client, struct _Connection *connection);
+CERVER_EXPORT u8 client_connect_and_start_async (
+	Client *client, struct _Connection *connection
+);
 
 /*** requests ***/
 
@@ -561,7 +644,10 @@ CERVER_EXPORT u8 client_connect_and_start_async (Client *client, struct _Connect
 // this method only works if your response consists only of one packet
 // neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
 // retruns 0 when the response has been handled, 1 on error
-CERVER_EXPORT unsigned int client_request_to_cerver (Client *client, struct _Connection *connection, struct _Packet *request);
+CERVER_EXPORT unsigned int client_request_to_cerver (
+	Client *client, struct _Connection *connection,
+	struct _Packet *request
+);
 
 // when a client is already connected to the cerver, a request can be made to the cerver
 // the response will be handled by the client's handlers
@@ -569,16 +655,23 @@ CERVER_EXPORT unsigned int client_request_to_cerver (Client *client, struct _Con
 // this method only works if your response consists only of one packet
 // neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
 // returns 0 on success request, 1 on error
-CERVER_EXPORT unsigned int client_request_to_cerver_async (Client *client, struct _Connection *connection, struct _Packet *request);
+CERVER_EXPORT unsigned int client_request_to_cerver_async (
+	Client *client, struct _Connection *connection,
+	struct _Packet *request
+);
 
 /*** files ***/
 
 // adds a new file path to take into account when getting a request for a file
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 client_files_add_path (Client *client, const char *path);
+CERVER_EXPORT u8 client_files_add_path (
+	Client *client, const char *path
+);
 
 // sets the default uploads path to be used when receiving a file
-CERVER_EXPORT void client_files_set_uploads_path (Client *client, const char *uploads_path);
+CERVER_EXPORT void client_files_set_uploads_path (
+	Client *client, const char *uploads_path
+);
 
 // sets a custom method to be used to handle a file upload (receive)
 // in this method, file contents must be consumed from the sock fd
@@ -604,16 +697,24 @@ CERVER_EXPORT void client_files_set_file_upload_cb (
 
 // search for the requested file in the configured paths
 // returns the actual filename (path + directory) where it was found, NULL on error
-CERVER_PUBLIC String *client_files_search_file (Client *client, const char *filename);
+CERVER_PUBLIC String *client_files_search_file (
+	Client *client, const char *filename
+);
 
 // requests a file from the cerver
 // the client's uploads_path should have been configured before calling this method
 // returns 0 on success sending request, 1 on failed to send request
-CERVER_EXPORT u8 client_file_get (Client *client, struct _Connection *connection, const char *filename);
+CERVER_EXPORT u8 client_file_get (
+	Client *client, struct _Connection *connection,
+	const char *filename
+);
 
 // sends a file to the cerver
 // returns 0 on success sending request, 1 on failed to send request
-CERVER_EXPORT u8 client_file_send (Client *client, struct _Connection *connection, const char *filename);
+CERVER_EXPORT u8 client_file_send (
+	Client *client, struct _Connection *connection,
+	const char *filename
+);
 
 /*** update ***/
 
@@ -628,24 +729,32 @@ CERVER_PRIVATE unsigned int client_receive_internal (
 
 // allocates a new packet buffer to receive incoming data from the connection's socket
 // returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
-CERVER_PUBLIC unsigned int client_receive (Client *client, struct _Connection *connection);
+CERVER_PUBLIC unsigned int client_receive (
+	Client *client, struct _Connection *connection
+);
 
 /*** end ***/
 
 // closes the connection's socket & set it to be inactive
 // does not send a close connection packet to the cerver
 // returns 0 on success, 1 on error
-CERVER_PUBLIC int client_connection_stop (Client *client, Connection *connection);
+CERVER_PUBLIC int client_connection_stop (
+	Client *client, Connection *connection
+);
 
 // terminates the connection & closes the socket
 // but does NOT destroy the current connection
 // returns 0 on success, 1 on error
-CERVER_PUBLIC int client_connection_close (Client *client, struct _Connection *connection);
+CERVER_PUBLIC int client_connection_close (
+	Client *client, struct _Connection *connection
+);
 
 // terminates and destroys a connection registered to a client
 // that is connected to a cerver
 // returns 0 on success, 1 on error
-CERVER_PUBLIC int client_connection_end (Client *client, struct _Connection *connection);
+CERVER_PUBLIC int client_connection_end (
+	Client *client, struct _Connection *connection
+);
 
 // stop any on going connection and process and destroys the client
 // returns 0 on success, 1 on error

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -185,6 +185,7 @@ typedef struct ReceiveHandle {
 
 	char *buffer;
 	size_t buffer_size;
+	size_t received_size;
 
 } ReceiveHandle;
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -82,7 +82,8 @@ struct _Handler {
 	// cons - calling thread will be busy until handler method is done
 	bool direct_handle;
 
-	// the jobs (packets) that are waiting to be handled - passed as args to the handler method
+	// the jobs (packets) that are waiting to be handled
+	// passed as args to the handler method
 	JobQueue *job_queue;
 
 	struct _Cerver *cerver;     // the cerver this handler belongs to
@@ -145,6 +146,27 @@ CERVER_PRIVATE int handler_start (Handler *handler);
 #pragma endregion
 
 #pragma region handlers
+
+#define CERVER_HANDLER_ERROR_MAP(XX)											\
+	XX(0,	NONE,			None,				No handler error)				\
+	XX(1,	PACKET,			Bad Packet,			Packet check failed)			\
+	XX(2,	DROPPED,		Dropped Connection, The connection has been ended)
+
+typedef enum CerverHandlerError {
+
+	#define XX(num, name, string, description) CERVER_HANDLER_ERROR_##name = num,
+	CERVER_HANDLER_ERROR_MAP (XX)
+	#undef XX
+
+} CerverHandlerError;
+
+CERVER_PUBLIC const char *cerver_handler_error_to_string (
+	const CerverHandlerError error
+);
+
+CERVER_PUBLIC const char *cerver_handler_error_description (
+	const CerverHandlerError error
+);
 
 // handles a request from a client to get a file
 CERVER_PRIVATE void cerver_request_get_file (

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -220,6 +220,11 @@ CERVER_PRIVATE CerverReceive *cerver_receive_create_full (
 
 CERVER_PRIVATE void cerver_switch_receive_handle_failed (CerverReceive *cr);
 
+CERVER_PRIVATE void cerver_receive_internal (
+	CerverReceive *cr,
+	char *packet_buffer, const size_t packet_buffer_size
+);
+
 // receive all incoming data from the socket
 CERVER_PRIVATE void cerver_receive (void *ptr);
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -213,7 +213,9 @@ typedef struct ReceiveHandle {
 CERVER_PRIVATE void receive_handle_delete (void *receive_ptr);
 
 // default cerver receive handler
-CERVER_PRIVATE void cerver_receive_handle_buffer (void *receive_ptr);
+CERVER_PRIVATE void cerver_receive_handle_buffer (
+	void *receive_handle_ptr
+);
 
 typedef struct CerverReceive {
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -225,9 +225,6 @@ CERVER_PRIVATE void cerver_receive_internal (
 	char *packet_buffer, const size_t packet_buffer_size
 );
 
-// receive all incoming data from the socket
-CERVER_PRIVATE void cerver_receive (void *ptr);
-
 #pragma endregion
 
 #pragma region register

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -16,12 +16,14 @@
 #include "cerver/game/lobby.h"
 
 struct _Socket;
+
+struct _Admin;
 struct _Cerver;
 struct _Client;
 struct _Connection;
 struct _Lobby;
+
 struct _Packet;
-struct _Admin;
 
 #pragma region handler
 
@@ -48,7 +50,9 @@ typedef struct HandlerData {
 struct _Handler {
 
 	HandlerType type;
-	int unique_id;                  // added every time a new handler gets created
+
+	// added every time a new handler gets created
+	int unique_id;
 
 	int id;
 	pthread_t thread_id;
@@ -69,7 +73,7 @@ struct _Handler {
 	// the method that this handler will execute to handle packets
 	Action handler;
 
-	// 27/05/2020 - used to avoid pushing job to the queue and instead handle
+	// used to avoid pushing job to the queue and instead handle
 	// the packet directly in the same thread
 	// this option is set to false as default
 	// pros - inmediate handle with no delays
@@ -94,16 +98,23 @@ CERVER_PRIVATE void handler_delete (void *handler_ptr);
 // handler method is your actual app packet handler
 CERVER_EXPORT Handler *handler_create (Action handler_method);
 
-// creates a new handler that will be used for cerver's multiple app handlers configuration
+// creates a new handler that will be used for
+// cerver's multiple app handlers configuration
 // it should be registered to the cerver before it starts
-// the user is responsible for setting the unique id, which will be used to match
+// the user is responsible for setting the unique id,
+// which will be used to match
 // incoming packets
 // handler method is your actual app packet handler
-CERVER_EXPORT Handler *handler_create_with_id (int id, Action handler_method);
+CERVER_EXPORT Handler *handler_create_with_id (
+	int id, Action handler_method
+);
 
 // sets the handler's data directly
-// this data will be passed to the handler method using a HandlerData structure
-CERVER_EXPORT void handler_set_data (Handler *handler, void *data);
+// this data will be passed to the handler method
+// using a HandlerData structure
+CERVER_EXPORT void handler_set_data (
+	Handler *handler, void *data
+);
 
 // set a method to create the handler's data before it starts handling any packet
 // this data will be passed to the handler method using a HandlerData structure
@@ -113,7 +124,9 @@ CERVER_EXPORT void handler_set_data_create (
 );
 
 // set the method to be used to delete the handler's data
-CERVER_EXPORT void handler_set_data_delete (Handler *handler, Action data_delete);
+CERVER_EXPORT void handler_set_data_delete (
+	Handler *handler, Action data_delete
+);
 
 // used to avoid pushing job to the queue and instead handle
 // the packet directly in the same thread
@@ -121,7 +134,9 @@ CERVER_EXPORT void handler_set_data_delete (Handler *handler, Action data_delete
 //          - handler method can be called from multiple threads
 // neutral  - data create and delete will be executed every time
 // cons     - calling thread will be busy until handler method is done
-CERVER_EXPORT void handler_set_direct_handle (Handler *handler, bool direct_handle);
+CERVER_EXPORT void handler_set_direct_handle (
+	Handler *handler, bool direct_handle
+);
 
 // starts the new handler by creating a dedicated thread for it
 // called by internal cerver methods
@@ -132,13 +147,19 @@ CERVER_PRIVATE int handler_start (Handler *handler);
 #pragma region handlers
 
 // handles a request from a client to get a file
-CERVER_PRIVATE void cerver_request_get_file (struct _Packet *packet);
+CERVER_PRIVATE void cerver_request_get_file (
+	struct _Packet *packet
+);
 
 // handles a request from a client to upload a file
-CERVER_PRIVATE void cerver_request_send_file (struct _Packet *packet);
+CERVER_PRIVATE void cerver_request_send_file (
+	struct _Packet *packet
+);
 
 // sends back a test packet to the client!
-CERVER_PRIVATE void cerver_test_packet_handler (struct _Packet *packet);
+CERVER_PRIVATE void cerver_test_packet_handler (
+	struct _Packet *packet
+);
 
 #pragma endregion
 
@@ -168,7 +189,7 @@ CERVER_PRIVATE void sock_receive_delete (void *sock_receive_ptr);
 #pragma region receive
 
 // the default timeout when handling a connection in dedicated thread
-#define DEFAULT_SOCKET_RECV_TIMEOUT         5
+#define CERVER_DEFAULT_SOCKET_RECV_TIMEOUT         5
 
 typedef struct ReceiveHandle {
 
@@ -211,7 +232,11 @@ typedef struct CerverReceive {
 
 CERVER_PRIVATE void cerver_receive_delete (void *ptr);
 
-CERVER_PRIVATE CerverReceive *cerver_receive_create (ReceiveType receive_type, struct _Cerver *cerver, const i32 sock_fd);
+CERVER_PRIVATE CerverReceive *cerver_receive_create (
+	ReceiveType receive_type,
+	struct _Cerver *cerver,
+	const i32 sock_fd
+);
 
 CERVER_PRIVATE CerverReceive *cerver_receive_create_full (
 	ReceiveType receive_type,
@@ -219,7 +244,9 @@ CERVER_PRIVATE CerverReceive *cerver_receive_create_full (
 	struct _Client *client, struct _Connection *connection
 );
 
-CERVER_PRIVATE void cerver_switch_receive_handle_failed (CerverReceive *cr);
+CERVER_PRIVATE void cerver_switch_receive_handle_failed (
+	CerverReceive *cr
+);
 
 CERVER_PRIVATE void cerver_receive_internal (
 	CerverReceive *cr,
@@ -232,7 +259,9 @@ CERVER_PRIVATE void cerver_receive_internal (
 
 // select how client connection will be handled based on cerver's handler type
 CERVER_PRIVATE u8 cerver_register_new_connection_normal_default_select_handler (
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection
+	struct _Cerver *cerver,
+	struct _Client *client,
+	struct _Connection *connection
 );
 
 #pragma endregion
@@ -241,26 +270,38 @@ CERVER_PRIVATE u8 cerver_register_new_connection_normal_default_select_handler (
 
 // reallocs main cerver poll fds
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 cerver_realloc_main_poll_fds (struct _Cerver *cerver);
+CERVER_PRIVATE u8 cerver_realloc_main_poll_fds (
+	struct _Cerver *cerver
+);
 
 // get a free index in the main cerver poll strcuture
-CERVER_PRIVATE i32 cerver_poll_get_free_idx (struct _Cerver *cerver);
+CERVER_PRIVATE i32 cerver_poll_get_free_idx (
+	struct _Cerver *cerver
+);
 
 // get the idx of the connection sock fd in the cerver poll fds
-CERVER_PRIVATE i32 cerver_poll_get_idx_by_sock_fd (struct _Cerver *cerver, i32 sock_fd);
+CERVER_PRIVATE i32 cerver_poll_get_idx_by_sock_fd (
+	struct _Cerver *cerver, i32 sock_fd
+);
 
 // regsiters a client connection to the cerver's mains poll structure
 // and maps the sock fd to the client
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 cerver_poll_register_connection (struct _Cerver *cerver, struct _Connection *connection);
+CERVER_PRIVATE u8 cerver_poll_register_connection (
+	struct _Cerver *cerver, struct _Connection *connection
+);
 
 // removes a sock fd from the cerver's main poll array
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 cerver_poll_unregister_sock_fd (struct _Cerver *cerver, const i32 sock_fd);
+CERVER_PRIVATE u8 cerver_poll_unregister_sock_fd (
+	struct _Cerver *cerver, const i32 sock_fd
+);
 
 // unregsiters a client connection from the cerver's main poll structure
 // returns 0 on success, 1 on error
-CERVER_PRIVATE u8 cerver_poll_unregister_connection (struct _Cerver *cerver, struct _Connection *connection);
+CERVER_PRIVATE u8 cerver_poll_unregister_connection (
+	struct _Cerver *cerver, struct _Connection *connection
+);
 
 // server poll loop to handle events in the registered socket's fds
 CERVER_PRIVATE u8 cerver_poll (struct _Cerver *cerver);

--- a/include/cerver/network.h
+++ b/include/cerver/network.h
@@ -57,4 +57,9 @@ CERVER_PUBLIC int sock_set_timeout (
 	int sock_fd, time_t timeout
 );
 
+// sets the socket's reusable options
+// this should avoid errors when binding sockets
+// returns 0 on success, 1 on any error
+CERVER_PUBLIC int sock_set_reusable (int sock_fd);
+
 #endif

--- a/include/cerver/network.h
+++ b/include/cerver/network.h
@@ -4,11 +4,11 @@
 #include <stdbool.h>
 
 #include <unistd.h>
-
-#include <sys/socket.h>
-#include <netinet/in.h>
 #include <fcntl.h>
+
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 #include "cerver/config.h"
 
@@ -26,18 +26,28 @@ typedef enum Protocol {
 
 // enable/disable blocking on a socket
 // true on success, false if there was an error
-CERVER_PUBLIC bool sock_set_blocking (int32_t fd, bool blocking);
+CERVER_PUBLIC bool sock_set_blocking (
+	int32_t fd, bool blocking
+);
 
-CERVER_PUBLIC char *sock_ip_to_string ( const struct sockaddr *address);
+CERVER_PUBLIC char *sock_ip_to_string (
+	const struct sockaddr *address
+);
 
-CERVER_PUBLIC bool sock_ip_equal (const struct sockaddr *a, const struct sockaddr *b);
+CERVER_PUBLIC bool sock_ip_equal (
+	const struct sockaddr *a, const struct sockaddr *b
+);
 
-CERVER_PUBLIC in_port_t sock_ip_port (const struct sockaddr *address);
+CERVER_PUBLIC in_port_t sock_ip_port (
+	const struct sockaddr *address
+);
 
 // sets a timeout (in seconds) for a socket
 // the socket will still block until the timeout is completed
 // if no data was read, a EAGAIN error is returned
 // returns 0 on success, 1 on error
-CERVER_PUBLIC int sock_set_timeout (int sock_fd, time_t timeout);
+CERVER_PUBLIC int sock_set_timeout (
+	int sock_fd, time_t timeout
+);
 
 #endif

--- a/include/cerver/network.h
+++ b/include/cerver/network.h
@@ -24,6 +24,13 @@ typedef enum Protocol {
 
 #define SOCK_SIZEOF_MEMBER(type, member) (sizeof(((type *) NULL)->member))
 
+// gets the ip related to the hostname
+// returns a newly allocated c string if found
+// returns NULL on error or not found
+CERVER_PUBLIC char *network_hostname_to_ip (
+	const char *hostname
+);
+
 // enable/disable blocking on a socket
 // true on success, false if there was an error
 CERVER_PUBLIC bool sock_set_blocking (

--- a/include/cerver/packets.h
+++ b/include/cerver/packets.h
@@ -118,9 +118,13 @@ typedef struct _PacketsPerType PacketsPerType;
 
 CERVER_PUBLIC PacketsPerType *packets_per_type_new (void);
 
-CERVER_PUBLIC void packets_per_type_delete (void *ptr);
+CERVER_PUBLIC void packets_per_type_delete (
+	void *packets_per_type_ptr
+);
 
-CERVER_PUBLIC void packets_per_type_print (PacketsPerType *packets_per_type);
+CERVER_PUBLIC void packets_per_type_print (
+	PacketsPerType *packets_per_type
+);
 
 #pragma endregion
 
@@ -143,16 +147,25 @@ typedef struct _PacketHeader PacketHeader;
 
 CERVER_PUBLIC PacketHeader *packet_header_new (void);
 
-CERVER_PUBLIC void packet_header_delete (PacketHeader *header);
+CERVER_PUBLIC void packet_header_delete (
+	PacketHeader *header
+);
 
-CERVER_PUBLIC PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, u32 req_type);
+CERVER_PUBLIC PacketHeader *packet_header_create (
+	PacketType packet_type, size_t packet_size, u32 req_type
+);
 
-// prints an already existing PacketHeader. Mostly used for debugging
-CERVER_PUBLIC void packet_header_print (PacketHeader *header);
+// prints an already existing PacketHeader
+// mostly used for debugging
+CERVER_PUBLIC void packet_header_print (
+	PacketHeader *header
+);
 
 // allocates space for the dest packet header and copies the data from source
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 packet_header_copy (PacketHeader **dest, PacketHeader *source);
+CERVER_PUBLIC u8 packet_header_copy (
+	PacketHeader **dest, PacketHeader *source
+);
 
 #pragma endregion
 
@@ -267,17 +280,23 @@ CERVER_PUBLIC void packet_delete (void *ptr);
 
 // creates a new packet with the option to pass values directly
 // data is copied into packet buffer and can be safely freed
-CERVER_EXPORT Packet *packet_create (PacketType type, void *data, size_t data_size);
+CERVER_EXPORT Packet *packet_create (
+	PacketType type, void *data, size_t data_size
+);
 
 // sets the packet destinatary to whom this packet is going to be sent
 CERVER_EXPORT void packet_set_network_values (
 	Packet *packet,
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
+	struct _Lobby *lobby
 );
 
 // sets the packet's header
 // copies the header's values into the packet
-CERVER_EXPORT void packet_set_header (Packet *packet, PacketHeader *header);
+CERVER_EXPORT void packet_set_header (
+	Packet *packet, PacketHeader *header
+);
 
 // sets the packet's header values
 // if the packet does NOT yet have a header, it will be created
@@ -291,33 +310,43 @@ CERVER_EXPORT void packet_set_header_values (
 // sets the data of the packet -> copies the data into the packet
 // if the packet had data before it is deleted and replaced with the new one
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_set_data (Packet *packet, void *data, size_t data_size);
+CERVER_EXPORT u8 packet_set_data (
+	Packet *packet, void *data, size_t data_size
+);
 
 // appends the data to the end if the packet already has data
 // if the packet is empty, creates a new buffer
 // it creates a new copy of the data and the original can be safely freed
 // this does not work if the data has been set using a reference
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_append_data (Packet *packet, void *data, size_t data_size);
+CERVER_EXPORT u8 packet_append_data (
+	Packet *packet, void *data, size_t data_size
+);
 
 // sets a reference to a data buffer to send
 // data will not be copied into the packet and will not be freed after use
 // this method is usefull for example if you just want to send a raw json packet to a non-cerver
 // use this method with packet_send () with the raw flag on
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_set_data_ref (Packet *packet, void *data, size_t data_size);
+CERVER_EXPORT u8 packet_set_data_ref (
+	Packet *packet, void *data, size_t data_size
+);
 
 // sets a packet's packet by copying the passed data, so you will be able to free your data
 // this data is expected to already contain a header, otherwise, send with raw flag
 // deletes the previuos packet's packet
 // returns 0 on succes, 1 on error
-CERVER_EXPORT u8 packet_set_packet (Packet *packet, void *data, size_t data_size);
+CERVER_EXPORT u8 packet_set_packet (
+	Packet *packet, void *data, size_t data_size
+);
 
 // sets a reference to a data buffer to send as the packet
 // data will not be copied into the packet and will not be freed after use
 // usefull when you need to generate your own cerver type packet by hand
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_set_packet_ref (Packet *packet, void *data, size_t packet_size);
+CERVER_EXPORT u8 packet_set_packet_ref (
+	Packet *packet, void *data, size_t packet_size
+);
 
 // prepares the packet to be ready to be sent
 // WARNING: dont call this method if you have set the packet directly
@@ -335,12 +364,16 @@ CERVER_EXPORT Packet *packet_generate_request (
 // sends a packet using its network values
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw);
+CERVER_EXPORT u8 packet_send (
+	const Packet *packet, int flags, size_t *total_sent, bool raw
+);
 
 // works just as packet_send () but the socket's write mutex won't be locked
 // useful when you need to lock the mutex manually
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 packet_send_unsafe (const Packet *packet, int flags, size_t *total_sent, bool raw);
+CERVER_PUBLIC u8 packet_send_unsafe (
+	const Packet *packet, int flags, size_t *total_sent, bool raw
+);
 
 // sends a packet to the specified destination
 // sets flags to 0
@@ -350,7 +383,9 @@ CERVER_PUBLIC u8 packet_send_unsafe (const Packet *packet, int flags, size_t *to
 CERVER_EXPORT u8 packet_send_to (
 	const Packet *packet,
 	size_t *total_sent, bool raw,
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
+	struct _Lobby *lobby
 );
 
 // sends a packet to the socket in two parts, first the header & then the data
@@ -359,7 +394,9 @@ CERVER_EXPORT u8 packet_send_to (
 // the socket's write mutex will be locked to ensure that the packet
 // is sent correctly and to avoid race conditions
 // returns 0 on success, 1 on error
-CERVER_EXPORT u8 packet_send_split (const Packet *packet, int flags, size_t *total_sent);
+CERVER_EXPORT u8 packet_send_split (
+	const Packet *packet, int flags, size_t *total_sent
+);
 
 // sends a packet to the socket in two parts, first the header & then the data
 // works just as packet_send_split () but with the flags set to 0
@@ -367,7 +404,9 @@ CERVER_EXPORT u8 packet_send_split (const Packet *packet, int flags, size_t *tot
 CERVER_EXPORT u8 packet_send_to_split (
 	const Packet *packet,
 	size_t *total_sent,
-	struct _Cerver *cerver, struct _Client *client, struct _Connection *connection, struct _Lobby *lobby
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection,
+	struct _Lobby *lobby
 );
 
 // sends a packet in pieces, taking the header from the packet's field

--- a/include/cerver/threads/thread.h
+++ b/include/cerver/threads/thread.h
@@ -7,13 +7,18 @@
 
 #include "cerver/config.h"
 
-#define THREAD_OK           0
+#define THREAD_OK						0
+
+#define THREAD_NAME_BUFFER_LEN			64
 
 #pragma region threads
 
-// creates a custom detachable thread (will go away on its own upon completion)
+// creates a custom detachable thread
+// will go away on its own upon completion
 // returns 0 on success, 1 on error
-CERVER_PUBLIC u8 thread_create_detachable (pthread_t *thread, void *(*work) (void *), void *args);
+CERVER_PUBLIC u8 thread_create_detachable (
+    pthread_t *thread, void *(*work) (void *), void *args
+);
 
 // sets thread name from inisde it
 CERVER_PUBLIC int thread_set_name (const char *name);

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "1.6.3b-4"
-#define CERVER_VERSION_NAME             "Beta 1.6.3b-4"
-#define CERVER_VERSION_DATE			    "20/12/2020"
-#define CERVER_VERSION_TIME			    "00:28 CST"
+#define CERVER_VERSION                  "1.6.3b-5"
+#define CERVER_VERSION_NAME             "Beta 1.6.3b-5"
+#define CERVER_VERSION_DATE			    "24/12/2020"
+#define CERVER_VERSION_TIME			    "20:29 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -504,6 +504,8 @@ AdminCerver *admin_cerver_new (void) {
 
 		admin_cerver->n_bad_packets_limit = ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS;
 
+		admin_cerver->receive_buffer_size = ADMIN_CERVER_DEFAULT_RECEIVE_BUFFER_SIZE;
+
 		admin_cerver->fds = NULL;
 		admin_cerver->max_n_fds = ADMIN_CERVER_DEFAULT_POLL_FDS;
 		admin_cerver->current_n_fds = 0;
@@ -623,6 +625,17 @@ void admin_cerver_set_bad_packets_limit (
 	if (admin_cerver) {
 		admin_cerver->n_bad_packets_limit = n_bad_packets_limit > 0 ?
 			n_bad_packets_limit : ADMIN_CERVER_DEFAULT_MAX_BAD_PACKETS;
+	}
+
+}
+
+// sets the admin cerver's receive buffer size used for recv ()
+void cerver_set_receive_buffer_size (
+	AdminCerver *admin_cerver, const size_t buffer_size
+) {
+
+	if (admin_cerver) {
+		admin_cerver->receive_buffer_size = buffer_size;
 	}
 
 }

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -630,7 +630,7 @@ void admin_cerver_set_bad_packets_limit (
 }
 
 // sets the admin cerver's receive buffer size used for recv ()
-void cerver_set_receive_buffer_size (
+void admin_cerver_set_receive_buffer_size (
 	AdminCerver *admin_cerver, const size_t buffer_size
 ) {
 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -1497,6 +1497,34 @@ u8 admin_cerver_end (AdminCerver *admin_cerver) {
 
 #pragma region handler
 
+const char *admin_cerver_handler_error_to_string (
+	const AdminCerverHandlerError error
+) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case ADMIN_CERVER_HANDLER_ERROR_##name: return #string;
+		ADMIN_CERVER_HANDLER_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return admin_cerver_handler_error_to_string (ADMIN_CERVER_HANDLER_ERROR_NONE);
+
+}
+
+const char *admin_cerver_handler_error_description (
+	const AdminCerverHandlerError error
+) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case ADMIN_CERVER_HANDLER_ERROR_##name: return #description;
+		ADMIN_CERVER_HANDLER_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return admin_cerver_handler_error_description (ADMIN_CERVER_HANDLER_ERROR_NONE);
+
+}
+
 // handles a packet of type PACKET_TYPE_CLIENT
 static void admin_cerver_client_packet_handler (Packet *packet) {
 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -1878,14 +1878,22 @@ u8 admin_packet_handler (Packet *packet) {
 
 	u8 retval = 1;
 
-	if (!admin_packet_handler_check_version (packet)) {
-		switch (admin_packet_handler_actual (packet)) {
-			case ADMIN_CERVER_HANDLER_ERROR_NONE:
-				retval = 0;
-				break;
+	switch (admin_packet_handler_check_version (packet)) {
+		case ADMIN_CERVER_HANDLER_ERROR_NONE: {
+			switch (admin_packet_handler_actual (packet)) {
+				case ADMIN_CERVER_HANDLER_ERROR_NONE:
+					retval = 0;
+					break;
 
-			default: break;
-		}
+				default: break;
+			}
+		} break;
+
+		case ADMIN_CERVER_HANDLER_ERROR_PACKET:
+			retval = 0;
+			break;
+
+		default: break;
 	}
 
 	return retval;

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -1002,7 +1002,7 @@ u8 admin_cerver_drop_admin (
 	u8 retval = 1;
 
 	if (admin_cerver && admin) {
-		admin_cerver_unregister_admin (admin_cerver, admin);
+		retval = admin_cerver_unregister_admin (admin_cerver, admin);
 		admin_delete (admin);
 	}
 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -126,6 +126,34 @@ static void admin_cerver_packet_send_update_stats (
 
 #pragma region admin
 
+const char *admin_connections_status_to_string (
+	const AdminConnectionsStatus status
+) {
+
+	switch (status) {
+		#define XX(num, name, string, description) case ADMIN_CONNECTIONS_STATUS_##name: return #string;
+		ADMIN_CONNECTIONS_STATUS_MAP(XX)
+		#undef XX
+	}
+
+	return admin_connections_status_to_string (ADMIN_CONNECTIONS_STATUS_NONE);
+
+}
+
+const char *admin_connections_status_description (
+	const AdminConnectionsStatus status
+) {
+
+	switch (status) {
+		#define XX(num, name, string, description) case ADMIN_CONNECTIONS_STATUS_##name: return #description;
+		ADMIN_CONNECTIONS_STATUS_MAP(XX)
+		#undef XX
+	}
+
+	return admin_connections_status_description (ADMIN_CONNECTIONS_STATUS_NONE);
+
+}
+
 Admin *admin_new (void) {
 
 	Admin *admin = (Admin *) malloc (sizeof (Admin));

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -30,6 +30,34 @@ static u8 on_hold_poll_register_connection (Cerver *cerver, Connection *connecti
 u8 on_hold_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd);
 static u8 on_hold_poll_unregister_connection (Cerver *cerver, Connection *connection);
 
+#pragma region errors
+
+const char *cerver_auth_error_to_string (const CerverAuthError error) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case CERVER_AUTH_ERROR_##name: return #string;
+		CERVER_AUTH_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return cerver_auth_error_to_string (CERVER_AUTH_ERROR_NONE);
+
+}
+
+const char *cerver_auth_error_description (const CerverAuthError error) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case CERVER_AUTH_ERROR_##name: return #description;
+		CERVER_AUTH_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return cerver_auth_error_description (CERVER_AUTH_ERROR_NONE);
+
+}
+
+#pragma endregion
+
 #pragma region data
 
 static AuthData *auth_data_new (void) {

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -947,6 +947,7 @@ static CerverAuthError on_hold_packet_handler_check_version (
 			packet->version = (PacketVersion *) packet->data_ptr;
 			packet->data_ptr += sizeof (PacketVersion);
 
+			// TODO: return errors to client
 			if (packet_check (packet)) {
 				error = cerver_on_hold_handle_max_bad_packets (
 					packet->cerver, packet->connection
@@ -970,7 +971,7 @@ static CerverAuthError on_hold_packet_handler_check_version (
 
 }
 
-// handles an packet from an on hold connection
+// handles a packet from an on hold connection
 // returns 0 if we can / need to handle more packets
 // returns 1 if the connection has been ended or removed from on hold
 u8 on_hold_packet_handler (Packet *packet) {

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -334,7 +334,7 @@ static CerverAuthError auth_with_token_admin (
 
 }
 
-static u8 auth_with_token_normal (
+static CerverAuthError auth_with_token_normal (
 	const Packet *packet, const AuthData *auth_data
 ) {
 

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -772,19 +772,17 @@ static void cerver_on_hold_handle_max_bad_packets (
 	Cerver *cerver, Connection *connection
 ) {
 
-	if (cerver && connection) {
-		connection->bad_packets += 1;
+	connection->bad_packets += 1;
 
-		if (connection->bad_packets >= cerver->on_hold_max_bad_packets) {
-			#ifdef AUTH_DEBUG
-			cerver_log_debug (
-				"ON HOLD connection <%d> has reached max bad packets, dropping...",
-				connection->socket->sock_fd
-			);
-			#endif
+	if (connection->bad_packets >= cerver->on_hold_max_bad_packets) {
+		#ifdef AUTH_DEBUG
+		cerver_log_debug (
+			"ON HOLD connection <%d> has reached max bad packets, dropping...",
+			connection->socket->sock_fd
+		);
+		#endif
 
-			on_hold_connection_drop (cerver, connection);
-		}
+		on_hold_connection_drop (cerver, connection);
 	}
 
 }
@@ -807,14 +805,18 @@ static void cerver_auth_packet_handler (Packet *packet) {
 				);
 				#endif
 
-				cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+				cerver_on_hold_handle_max_bad_packets (
+					packet->cerver, packet->connection
+				);
 			} break;
 		}
 	}
 
 	else {
 		// bad packet
-		cerver_on_hold_handle_max_bad_packets (packet->cerver, packet->connection);
+		cerver_on_hold_handle_max_bad_packets (
+			packet->cerver, packet->connection
+		);
 	}
 
 }

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -1120,8 +1120,7 @@ static u8 on_hold_poll_unregister_connection (Cerver *cerver, Connection *connec
 }
 
 static inline void on_hold_poll_handle (
-	Cerver *cerver,
-	char *packet_buffer
+	Cerver *cerver, char *packet_buffer
 ) {
 
 	// one or more fd(s) are readable, need to determine which ones they are
@@ -1235,6 +1234,12 @@ void *on_hold_poll (void *cerver_ptr) {
 			#endif
 
 			free (packet_buffer);
+		}
+
+		else {
+			cerver_log_error (
+				"Failed to allocate cerver ON HOLD poll's packet buffer!"
+			);
 		}
 	}
 

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -343,6 +343,7 @@ Cerver *cerver_new (void) {
 		cerver->on_hold_poll_lock = NULL;
 		cerver->on_hold_max_bad_packets = CERVER_DEFAULT_ON_HOLD_MAX_BAD_PACKETS;
 		cerver->on_hold_check_packets = CERVER_DEFAULT_ON_HOLD_CHECK_PACKETS;
+		cerver->on_hold_receive_buffer_size = CERVER_DEFAULT_ON_HOLD_RECEIVE_BUFFER_SIZE;
 
 		cerver->use_sessions = CERVER_DEFAULT_USE_SESSIONS;
 		cerver->session_id_generator = NULL;
@@ -648,9 +649,23 @@ void cerver_set_on_hold_max_bad_packets (
 
 // sets whether to check for packets using the packet_check () method in ON HOLD handler or NOT
 // any packet that fails the check will be considered as a bad packet
-void cerver_set_on_hold_check_packets (Cerver *cerver, bool check) {
+void cerver_set_on_hold_check_packets (
+	Cerver *cerver, bool check
+) {
 
 	if (cerver) cerver->on_hold_check_packets = check;
+
+}
+
+// sets the size of the buffer to be allocated
+// to receive packets from on hold connections
+void cerver_set_on_hold_receive_buffer_size (
+	Cerver *cerver, const size_t on_hold_receive_buffer_size
+) {
+
+	if (cerver) {
+		cerver->on_hold_receive_buffer_size = on_hold_receive_buffer_size;
+	}
 
 }
 

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -171,6 +171,34 @@ void client_file_stats_print (Client *client) {
 
 #pragma region main
 
+const char *client_connections_status_to_string (
+	const ClientConnectionsStatus status
+) {
+
+	switch (status) {
+		#define XX(num, name, string, description) case CLIENT_CONNECTIONS_STATUS_##name: return #string;
+		CLIENT_CONNECTIONS_STATUS_MAP(XX)
+		#undef XX
+	}
+
+	return client_connections_status_to_string (CLIENT_CONNECTIONS_STATUS_NONE);
+
+}
+
+const char *client_connections_status_description (
+	const ClientConnectionsStatus status
+) {
+
+	switch (status) {
+		#define XX(num, name, string, description) case CLIENT_CONNECTIONS_STATUS_##name: return #description;
+		CLIENT_CONNECTIONS_STATUS_MAP(XX)
+		#undef XX
+	}
+
+	return client_connections_status_description (CLIENT_CONNECTIONS_STATUS_NONE);
+
+}
+
 Client *client_new (void) {
 
 	Client *client = (Client *) malloc (sizeof (Client));

--- a/src/cerver/client.c
+++ b/src/cerver/client.c
@@ -45,7 +45,9 @@ static u64 next_client_id = 0;
 
 #pragma region aux
 
-static ClientConnection *client_connection_aux_new (Client *client, Connection *connection) {
+static ClientConnection *client_connection_aux_new (
+	Client *client, Connection *connection
+) {
 
 	ClientConnection *cc = (ClientConnection *) malloc (sizeof (ClientConnection));
 	if (cc) {
@@ -68,7 +70,7 @@ static ClientStats *client_stats_new (void) {
 
 	ClientStats *client_stats = (ClientStats *) malloc (sizeof (ClientStats));
 	if (client_stats) {
-		memset (client_stats, 0, sizeof (ClientStats));
+		(void) memset (client_stats, 0, sizeof (ClientStats));
 		client_stats->received_packets = packets_per_type_new ();
 		client_stats->sent_packets = packets_per_type_new ();
 	}
@@ -131,7 +133,7 @@ static ClientFileStats *client_file_stats_new (void) {
 
 	ClientFileStats *file_stats = (ClientFileStats *) malloc (sizeof (ClientFileStats));
 	if (file_stats) {
-		memset (file_stats, 0, sizeof (ClientFileStats));
+		(void) memset (file_stats, 0, sizeof (ClientFileStats));
 	}
 
 	return file_stats;
@@ -241,7 +243,6 @@ void client_delete (void *ptr) {
 			else free (client->data);
 		}
 
-		// 16/06/2020
 		if (client->handlers_lock) {
 			pthread_mutex_destroy (client->handlers_lock);
 			free (client->handlers_lock);
@@ -288,9 +289,11 @@ Client *client_create (void) {
 
 		client->name = str_new ("no-name");
 
-		time (&client->connected_timestamp);
+		(void) time (&client->connected_timestamp);
 
-		client->connections = dlist_init (connection_delete, connection_comparator);
+		client->connections = dlist_init (
+			connection_delete, connection_comparator
+		);
 
 		client->lock = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t));
 		pthread_mutex_init (client->lock, NULL);
@@ -305,8 +308,10 @@ Client *client_create (void) {
 }
 
 // creates a new client and registers a new connection
-Client *client_create_with_connection (Cerver *cerver,
-	const i32 sock_fd, const struct sockaddr_storage address) {
+Client *client_create_with_connection (
+	Cerver *cerver,
+	const i32 sock_fd, const struct sockaddr_storage address
+) {
 
 	Client *client = client_create ();
 	if (client) {
@@ -334,9 +339,11 @@ void client_set_name (Client *client, const char *name) {
 }
 
 // this methods is primarily used for logging
-// returns the client's name directly (if any) & should NOT be deleted, if not
+// returns the client's name directly (if any) & should NOT be deleted
 // returns a newly allocated string with the clients id that should be deleted after use
-char *client_get_identifier (Client *client, bool *is_name) {
+char *client_get_identifier (
+	Client *client, bool *is_name
+) {
 
 	char *retval = NULL;
 
@@ -358,7 +365,9 @@ char *client_get_identifier (Client *client, bool *is_name) {
 
 // sets the client's session id
 // returns 0 on succes, 1 on error
-u8 client_set_session_id (Client *client, const char *session_id) {
+u8 client_set_session_id (
+	Client *client, const char *session_id
+) {
 
 	u8 retval = 1;
 
@@ -374,11 +383,17 @@ u8 client_set_session_id (Client *client, const char *session_id) {
 }
 
 // returns the client's app data
-void *client_get_data (Client *client) { return (client ? client->data : NULL); }
+void *client_get_data (Client *client) {
+
+	return (client ? client->data : NULL);
+
+}
 
 // sets client's data and a way to destroy it
 // deletes the previous data of the client
-void client_set_data (Client *client, void *data, Action delete_data) {
+void client_set_data (
+	Client *client, void *data, Action delete_data
+) {
 
 	if (client) {
 		if (client->data) {
@@ -393,8 +408,10 @@ void client_set_data (Client *client, void *data, Action delete_data) {
 }
 
 // sets customs PACKET_TYPE_APP and PACKET_TYPE_APP_ERROR packet types handlers
-void client_set_app_handlers (Client *client,
-	Handler *app_handler, Handler *app_error_handler) {
+void client_set_app_handlers (
+	Client *client,
+	Handler *app_handler, Handler *app_error_handler
+) {
 
 	if (client) {
 		client->app_packet_handler = app_handler;
@@ -413,7 +430,9 @@ void client_set_app_handlers (Client *client,
 }
 
 // sets a PACKET_TYPE_CUSTOM packet type handler
-void client_set_custom_handler (Client *client, Handler *custom_handler) {
+void client_set_custom_handler (
+	Client *client, Handler *custom_handler
+) {
 
 	if (client) {
 		client->custom_packet_handler = custom_handler;
@@ -430,7 +449,9 @@ void client_set_custom_handler (Client *client, Handler *custom_handler) {
 // if packets do not pass the checks, won't be handled and will be inmediately destroyed
 // packets size must be cheked in individual methods (handlers)
 // by default, this option is turned off
-void client_set_check_packets (Client *client, bool check_packets) {
+void client_set_check_packets (
+	Client *client, bool check_packets
+) {
 
 	if (client) {
 		client->check_packets = check_packets;
@@ -439,7 +460,9 @@ void client_set_check_packets (Client *client, bool check_packets) {
 }
 
 // compare clients based on their client ids
-int client_comparator_client_id (const void *a, const void *b) {
+int client_comparator_client_id (
+	const void *a, const void *b
+) {
 
 	if (a && b) {
 		Client *client_a = (Client *) a;
@@ -455,9 +478,14 @@ int client_comparator_client_id (const void *a, const void *b) {
 }
 
 // compare clients based on their session ids
-int client_comparator_session_id (const void *a, const void *b) {
+int client_comparator_session_id (
+	const void *a, const void *b
+) {
 
-	if (a && b) return str_compare (((Client *) a)->session_id, ((Client *) b)->session_id);
+	if (a && b) return str_compare (
+		((Client *) a)->session_id, ((Client *) b)->session_id
+	);
+
 	if (a && !b) return -1;
 	if (!a && b) return 1;
 
@@ -519,26 +547,36 @@ void client_drop (Cerver *cerver, Client *client) {
 u8 client_connection_add (Client *client, Connection *connection) {
 
 	return (client && connection) ?
-		(u8) dlist_insert_after (client->connections, dlist_end (client->connections), connection) : 1;
+		(u8) dlist_insert_after (
+			client->connections, dlist_end (client->connections), connection
+		) : 1;
 
 }
 
 // removes the connection from the client
 // returns 0 on success, 1 on error
-u8 client_connection_remove (Client *client, Connection *connection) {
+u8 client_connection_remove (
+	Client *client, Connection *connection
+) {
 
 	u8 retval = 1;
 
-	if (client && connection) retval = dlist_remove (client->connections, connection, NULL) ? 0 : 1;
+	if (client && connection)
+		retval = dlist_remove (
+			client->connections, connection, NULL
+		) ? 0 : 1;
 
 	return retval;
 
 }
 
-// closes the connection & then removes it from the client & finally deletes the connection
+// closes the connection & then removes it from the client
+// finally deletes the connection
 // moves the socket to the cerver's socket pool
 // returns 0 on success, 1 on error
-u8 client_connection_drop (Cerver *cerver, Client *client, Connection *connection) {
+u8 client_connection_drop (
+	Cerver *cerver, Client *client, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -558,7 +596,9 @@ u8 client_connection_drop (Cerver *cerver, Client *client, Connection *connectio
 // and also remove the client & connection from the cerver's structures when needed
 // also checks if there is another active connection in the client, if not it will be dropped
 // returns 0 on success, 1 on error
-u8 client_remove_connection_by_sock_fd (Cerver *cerver, Client *client, i32 sock_fd) {
+u8 client_remove_connection_by_sock_fd (
+	Cerver *cerver, Client *client, i32 sock_fd
+) {
 
 	u8 retval = 1;
 
@@ -669,7 +709,9 @@ u8 client_remove_connection_by_sock_fd (Cerver *cerver, Client *client, i32 sock
 
 // registers all the active connections from a client to the cerver's structures (like maps)
 // returns 0 on success registering at least one, 1 if all connections failed
-u8 client_register_connections_to_cerver (Cerver *cerver, Client *client) {
+u8 client_register_connections_to_cerver (
+	Cerver *cerver, Client *client
+) {
 
 	u8 retval = 1;
 
@@ -705,7 +747,9 @@ u8 client_register_connections_to_cerver (Cerver *cerver, Client *client) {
 
 // unregiters all the active connections from a client from the cerver's structures (like maps)
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
-u8 client_unregister_connections_from_cerver (Cerver *cerver, Client *client) {
+u8 client_unregister_connections_from_cerver (
+	Cerver *cerver, Client *client
+) {
 
 	u8 retval = 1;
 
@@ -741,7 +785,9 @@ u8 client_unregister_connections_from_cerver (Cerver *cerver, Client *client) {
 
 // registers all the active connections from a client to the cerver's poll
 // returns 0 on success registering at least one, 1 if all connections failed
-u8 client_register_connections_to_cerver_poll (Cerver *cerver, Client *client) {
+u8 client_register_connections_to_cerver_poll (
+	Cerver *cerver, Client *client
+) {
 
 	u8 retval = 1;
 
@@ -778,7 +824,9 @@ u8 client_register_connections_to_cerver_poll (Cerver *cerver, Client *client) {
 
 // unregisters all the active connections from a client from the cerver's poll
 // returns 0 on success unregistering at least 1 connection, 1 failed to unregister all
-u8 client_unregister_connections_from_cerver_poll (Cerver *cerver, Client *client) {
+u8 client_unregister_connections_from_cerver_poll (
+	Cerver *cerver, Client *client
+) {
 
 	u8 retval = 1;
 
@@ -813,9 +861,10 @@ u8 client_unregister_connections_from_cerver_poll (Cerver *cerver, Client *clien
 
 }
 
-// 07/06/2020
 // removes the client from cerver data structures, not taking into account its connections
-Client *client_remove_from_cerver (Cerver *cerver, Client *client) {
+Client *client_remove_from_cerver (
+	Cerver *cerver, Client *client
+) {
 
 	Client *retval = NULL;
 
@@ -856,14 +905,17 @@ Client *client_remove_from_cerver (Cerver *cerver, Client *client) {
 
 }
 
-static void client_register_to_cerver_internal (Cerver *cerver, Client *client) {
+static void client_register_to_cerver_internal (
+	Cerver *cerver, Client *client
+) {
 
 	(void) avl_insert_node (cerver->clients, client);
 
 	#ifdef CLIENT_DEBUG
 	cerver_log (
 		LOG_TYPE_SUCCESS, LOG_TYPE_CLIENT,
-		"Registered a new client to cerver %s.", cerver->info->name->str
+		"Registered a new client to cerver %s.",
+		cerver->info->name->str
 	);
 	#endif
 
@@ -874,7 +926,8 @@ static void client_register_to_cerver_internal (Cerver *cerver, Client *client) 
 	cerver_log (
 		LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
 		"Connected clients to cerver %s: %i.",
-		cerver->info->name->str, cerver->stats->current_n_connected_clients
+		cerver->info->name->str,
+		cerver->stats->current_n_connected_clients
 	);
 	#endif
 
@@ -883,7 +936,9 @@ static void client_register_to_cerver_internal (Cerver *cerver, Client *client) 
 // registers a client to the cerver --> add it to cerver's structures
 // registers all of the current active client connections to the cerver poll
 // returns 0 on success, 1 on error
-u8 client_register_to_cerver (Cerver *cerver, Client *client) {
+u8 client_register_to_cerver (
+	Cerver *cerver, Client *client
+) {
 
 	u8 retval = 1;
 
@@ -916,7 +971,9 @@ u8 client_register_to_cerver (Cerver *cerver, Client *client) {
 }
 
 // unregisters a client from a cerver -- removes it from cerver's structures
-Client *client_unregister_from_cerver (Cerver *cerver, Client *client) {
+Client *client_unregister_from_cerver (
+	Cerver *cerver, Client *client
+) {
 
 	Client *retval = NULL;
 
@@ -963,7 +1020,9 @@ Client *client_get_by_sock_fd (Cerver *cerver, i32 sock_fd) {
 
 // searches the avl tree to get the client associated with the session id
 // the cerver must support sessions
-Client *client_get_by_session_id (Cerver *cerver, const char *session_id) {
+Client *client_get_by_session_id (
+	Cerver *cerver, const char *session_id
+) {
 
 	Client *client = NULL;
 
@@ -1019,7 +1078,7 @@ void client_broadcast_to_all_avl (
 u8 client_event_unregister (Client *client, ClientEventType event_type);
 
 // get the description for the current event type
-const char *client_event_type_description (ClientEventType type) {
+const char *client_event_type_description (const ClientEventType type) {
 
 	switch (type) {
 		#define XX(num, name, description) case CLIENT_EVENT_##name: return #description;
@@ -1160,7 +1219,9 @@ u8 client_event_register (
 // unregister the action associated with an event
 // deletes the action args using the delete_action_args () if NOT NULL
 // returns 0 on success, 1 on error or if event is NOT registered
-u8 client_event_unregister (Client *client, const ClientEventType event_type) {
+u8 client_event_unregister (
+	Client *client, const ClientEventType event_type
+) {
 
 	u8 retval = 1;
 
@@ -1239,7 +1300,7 @@ void client_event_trigger (
 u8 client_error_unregister (Client *client, const ClientErrorType error_type);
 
 // get the description for the current error type
-const char *client_error_type_description (ClientErrorType type) {
+const char *client_error_type_description (const ClientErrorType type) {
 
 	switch (type) {
 		#define XX(num, name, description) case CLIENT_ERROR_##name: return #description;
@@ -1553,7 +1614,9 @@ static void client_error_packet_handler (Packet *packet) {
 }
 
 // creates an error packet ready to be sent
-Packet *client_error_packet_generate (const ClientErrorType type, const char *msg) {
+Packet *client_error_packet_generate (
+	const ClientErrorType type, const char *msg
+) {
 
 	Packet *packet = packet_new ();
 	if (packet) {
@@ -1723,7 +1786,7 @@ static u8 client_custom_handler_start (Client *client) {
 
 }
 
-// 16/06/2020 -- starts all client's handlers
+// starts all client's handlers
 static u8 client_handlers_start (Client *client) {
 
 	u8 errors = 0;
@@ -1813,7 +1876,9 @@ Connection *client_connection_create (
 
 // registers an existing connection to a client
 // retuns 0 on success, 1 on error
-int client_connection_register (Client *client, Connection *connection) {
+int client_connection_register (
+	Client *client, Connection *connection
+) {
 
 	int retval = 1;
 
@@ -1831,7 +1896,9 @@ int client_connection_register (Client *client, Connection *connection) {
 
 // unregister an exitsing connection from the client
 // returns 0 on success, 1 on error or if the connection does not belong to the client
-int client_connection_unregister (Client *client, Connection *connection) {
+int client_connection_unregister (
+	Client *client, Connection *connection
+) {
 
 	int retval = 1;
 
@@ -1846,7 +1913,9 @@ int client_connection_unregister (Client *client, Connection *connection) {
 }
 
 // performs a receive in the connection's socket to get a complete packet & handle it
-void client_connection_get_next_packet (Client *client, Connection *connection) {
+void client_connection_get_next_packet (
+	Client *client, Connection *connection
+) {
 
 	if (client && connection) {
 		connection->full_packet = false;
@@ -1866,7 +1935,9 @@ void client_connection_get_next_packet (Client *client, Connection *connection) 
 // this is a blocking method, as it will wait until the connection has been successfull or a timeout
 // user must manually handle how he wants to receive / handle incomming packets and also send requests
 // returns 0 when the connection has been established, 1 on error or failed to connect
-unsigned int client_connect (Client *client, Connection *connection) {
+unsigned int client_connect (
+	Client *client, Connection *connection
+) {
 
 	unsigned int retval = 1;
 
@@ -1893,7 +1964,9 @@ unsigned int client_connect (Client *client, Connection *connection) {
 // performs a first read to get the cerver info packet
 // this is a blocking method, and works exactly the same as if only calling client_connect ()
 // returns 0 when the connection has been established, 1 on error or failed to connect
-unsigned int client_connect_to_cerver (Client *client, Connection *connection) {
+unsigned int client_connect_to_cerver (
+	Client *client, Connection *connection
+) {
 
 	unsigned int retval = 1;
 
@@ -1934,20 +2007,26 @@ static void *client_connect_thread (void *client_connection_ptr) {
 // open a success connection, EVENT_CONNECTED will be triggered, otherwise, EVENT_CONNECTION_FAILED will be triggered
 // user must manually handle how he wants to receive / handle incomming packets and also send requests
 // returns 0 on success connection thread creation, 1 on error
-unsigned int client_connect_async (Client *client, Connection *connection) {
+unsigned int client_connect_async (
+	Client *client, Connection *connection
+) {
 
 	unsigned int retval = 1;
 
 	if (client && connection) {
 		ClientConnection *cc = client_connection_aux_new (client, connection);
 		if (cc) {
-			if (!thread_create_detachable (&cc->connection_thread_id, client_connect_thread, cc)) {
+			if (!thread_create_detachable (
+				&cc->connection_thread_id, client_connect_thread, cc
+			)) {
 				retval = 0;         // success
 			}
 
 			else {
 				#ifdef CLIENT_DEBUG
-				cerver_log_error ("Failed to create client_connect_thread () detachable thread!");
+				cerver_log_error (
+					"Failed to create client_connect_thread () detachable thread!"
+				);
 				#endif
 			}
 		}
@@ -2064,7 +2143,9 @@ u8 client_connect_and_start_async (Client *client, Connection *connection) {
 // this method only works if your response consists only of one packet
 // neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
 // retruns 0 when the response has been handled, 1 on error
-unsigned int client_request_to_cerver (Client *client, Connection *connection, Packet *request) {
+unsigned int client_request_to_cerver (
+	Client *client, Connection *connection, Packet *request
+) {
 
 	unsigned int retval = 1;
 
@@ -2116,7 +2197,9 @@ static void *client_request_to_cerver_thread (void *cc_ptr) {
 // this method only works if your response consists only of one packet
 // neither client nor the connection will be stopped after the request has ended, the request packet won't be deleted
 // returns 0 on success request, 1 on error
-unsigned int client_request_to_cerver_async (Client *client, Connection *connection, Packet *request) {
+unsigned int client_request_to_cerver_async (
+	Client *client, Connection *connection, Packet *request
+) {
 
 	unsigned int retval = 1;
 
@@ -2127,7 +2210,9 @@ unsigned int client_request_to_cerver_async (Client *client, Connection *connect
 			ClientConnection *cc = client_connection_aux_new (client, connection);
 			if (cc) {
 				// create a new thread to receive & handle the response
-				if (!thread_create_detachable (&cc->connection_thread_id, client_request_to_cerver_thread, cc)) {
+				if (!thread_create_detachable (
+					&cc->connection_thread_id, client_request_to_cerver_thread, cc
+				)) {
 					retval = 0;         // success
 				}
 
@@ -2201,7 +2286,9 @@ u8 client_files_add_path (Client *client, const char *path) {
 }
 
 // sets the default uploads path to be used when receiving a file
-void client_files_set_uploads_path (Client *client, const char *uploads_path) {
+void client_files_set_uploads_path (
+	Client *client, const char *uploads_path
+) {
 
 	if (client && uploads_path) {
 		str_delete (client->uploads_path);
@@ -2246,7 +2333,9 @@ void client_files_set_file_upload_cb (
 
 // search for the requested file in the configured paths
 // returns the actual filename (path + directory) where it was found, NULL on error
-String *client_files_search_file (Client *client, const char *filename) {
+String *client_files_search_file (
+	Client *client, const char *filename
+) {
 
 	String *retval = NULL;
 
@@ -2273,7 +2362,10 @@ String *client_files_search_file (Client *client, const char *filename) {
 // requests a file from the cerver
 // the client's uploads_path should have been configured before calling this method
 // returns 0 on success sending request, 1 on failed to send request
-u8 client_file_get (Client *client, Connection *connection, const char *filename) {
+u8 client_file_get (
+	Client *client, Connection *connection,
+	const char *filename
+) {
 
 	u8 retval = 1;
 
@@ -2312,7 +2404,10 @@ u8 client_file_get (Client *client, Connection *connection, const char *filename
 
 // sends a file to the cerver
 // returns 0 on success sending request, 1 on failed to send request
-u8 client_file_send (Client *client, Connection *connection, const char *filename) {
+u8 client_file_send (
+	Client *client, Connection *connection,
+	const char *filename
+) {
 
 	u8 retval = 1;
 
@@ -2368,8 +2463,14 @@ static void client_cerver_packet_handle_info (Packet *packet) {
 		#endif
 
 		CerverReport *cerver_report = cerver_deserialize ((SCerver *) end);
-		if (cerver_report_check_info (cerver_report, packet->client, packet->connection))
-			cerver_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to correctly check cerver info!");
+		if (cerver_report_check_info (
+			cerver_report, packet->client, packet->connection
+		)) {
+			cerver_log (
+				LOG_TYPE_ERROR, LOG_TYPE_NONE,
+				"Failed to correctly check cerver info!"
+			);
+		}
 	}
 
 }
@@ -2595,13 +2696,20 @@ static void client_request_packet_handler (Packet *packet) {
 	if (packet->header) {
 		switch (packet->header->request_type) {
 			// request from a cerver to get a file
-			case REQUEST_PACKET_TYPE_GET_FILE: client_request_get_file (packet); break;
+			case REQUEST_PACKET_TYPE_GET_FILE:
+				client_request_get_file (packet);
+				break;
 
 			// request from a cerver to receive a file
-			case REQUEST_PACKET_TYPE_SEND_FILE: client_request_send_file (packet); break;
+			case REQUEST_PACKET_TYPE_SEND_FILE:
+				client_request_send_file (packet);
+				break;
 
 			default:
-				cerver_log (LOG_TYPE_WARNING, LOG_TYPE_HANDLER, "Unknown request from cerver");
+				cerver_log (
+					LOG_TYPE_WARNING, LOG_TYPE_HANDLER,
+					"Unknown request from cerver"
+				);
 				break;
 		}
 	}
@@ -2639,21 +2747,25 @@ static void client_auth_success_handler (Packet *packet) {
 				#ifdef AUTH_DEBUG
 				cerver_log_debug (
 					"Got client's <%s> session id <%s>",
-					packet->client->name->str, packet->client->session_id->str
+					packet->client->name->str,
+					packet->client->session_id->str
 				);
 				#endif
 			}
 		}
 	}
 
-	client_event_trigger (CLIENT_EVENT_SUCCESS_AUTH, packet->client, packet->connection);
+	client_event_trigger (
+		CLIENT_EVENT_SUCCESS_AUTH,
+		packet->client, packet->connection
+	);
 
 }
 
 static void client_auth_packet_handler (Packet *packet) {
 
 	switch (packet->header->request_type) {
-		// 24/01/2020 -- cerver requested authentication, if not, we will be disconnected
+		// cerver requested authentication, if not, we will be disconnected
 		case AUTH_PACKET_TYPE_REQUEST_AUTH:
 			break;
 
@@ -2667,13 +2779,15 @@ static void client_auth_packet_handler (Packet *packet) {
 			break;
 
 		default:
-			cerver_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown auth packet type.");
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_NONE,
+				"Unknown auth packet type"
+			);
 			break;
 	}
 
 }
 
-// 16/06/2020
 // handles a PACKET_TYPE_APP packet type
 static void client_app_packet_handler (Packet *packet) {
 
@@ -2708,7 +2822,6 @@ static void client_app_packet_handler (Packet *packet) {
 
 }
 
-// 16/06/2020
 // handles a PACKET_TYPE_APP_ERROR packet type
 static void client_app_error_packet_handler (Packet *packet) {
 
@@ -2743,7 +2856,6 @@ static void client_app_error_packet_handler (Packet *packet) {
 
 }
 
-// 16/06/2020
 // handles a PACKET_TYPE_CUSTOM packet type
 static void client_custom_packet_handler (Packet *packet) {
 
@@ -3104,7 +3216,9 @@ static void client_receive_handle_buffer (
 
 // handles a failed recive from a connection associatd with a client
 // end sthe connection to prevent seg faults or signals for bad sock fd
-static void client_receive_handle_failed (Client *client, Connection *connection) {
+static void client_receive_handle_failed (
+	Client *client, Connection *connection
+) {
 
 	if (connection->active) {
 		if (!client_connection_end (client, connection)) {
@@ -3202,13 +3316,19 @@ unsigned int client_receive_internal (
 }
 
 // allocates a new packet buffer to receive incoming data from the connection's socket
-// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
-unsigned int client_receive (Client *client, Connection *connection) {
+// returns 0 on success handle
+// returns 1 if any error ocurred and must likely the connection was ended
+unsigned int client_receive (
+	Client *client, Connection *connection
+) {
 
 	unsigned int retval = 1;
 
 	if (client && connection) {
-		char *packet_buffer = (char *) calloc (connection->receive_packet_buffer_size, sizeof (char));
+		char *packet_buffer = (char *) calloc (
+			connection->receive_packet_buffer_size, sizeof (char)
+		);
+
 		if (packet_buffer) {
 			retval = client_receive_internal (
 				client, connection,
@@ -3236,14 +3356,20 @@ unsigned int client_receive (Client *client, Connection *connection) {
 
 #pragma region end
 
-// ends a connection with a cerver by sending a disconnect packet and the closing the connection
-static void client_connection_terminate (Client *client, Connection *connection) {
+// ends a connection with a cerver
+// by sending a disconnect packet and the closing the connection
+static void client_connection_terminate (
+	Client *client, Connection *connection
+) {
 
 	if (connection) {
 		if (connection->active) {
 			if (connection->cerver_report) {
 				// send a close connection packet
-				Packet *packet = packet_generate_request (PACKET_TYPE_CLIENT, CLIENT_PACKET_TYPE_CLOSE_CONNECTION, NULL, 0);
+				Packet *packet = packet_generate_request (
+					PACKET_TYPE_CLIENT, CLIENT_PACKET_TYPE_CLOSE_CONNECTION, NULL, 0
+				);
+
 				if (packet) {
 					packet_set_network_values (packet, NULL, client, connection, NULL);
 					if (packet_send (packet, 0, NULL, false)) {

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1363,7 +1363,6 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 
 		PacketHeader *header = NULL;
 		size_t packet_size = 0;
-		// char *packet_data = NULL;
 
 		size_t remaining_buffer_size = 0;
 		size_t packet_real_size = 0;
@@ -1375,7 +1374,7 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 			remaining_buffer_size = buffer_size - buffer_pos;
 
 			if (sock_receive->complete_header) {
-				packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+				(void) packet_header_copy (&header, (PacketHeader *) sock_receive->header);
 				// header = ((PacketHeader *) sock_receive->header);
 				// packet_header_print (header);
 
@@ -1405,12 +1404,11 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 			}
 
 			if (header) {
+				// TODO: add check for max packet size
 				// check the packet size
 				packet_size = header->packet_size;
 				if ((packet_size > 0) /* && (packet_size < 65536) */) {
 					// printf ("packet_size: %ld\n", packet_size);
-					// end += sizeof (PacketHeader);
-					// buffer_pos += sizeof (PacketHeader);
 					// printf ("first buffer pos: %ld\n", buffer_pos);
 
 					Packet *packet = packet_new ();
@@ -1438,7 +1436,10 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 						}
 
 						else {
-							if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
+							if (
+								(header->packet_type == PACKET_TYPE_REQUEST)
+								&& (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)
+							) {
 								to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 							}
 
@@ -1451,7 +1452,7 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 						}
 
 						// printf ("to copy size: %ld\n", to_copy_size);
-						packet_set_data (packet, (void *) end, to_copy_size);
+						(void) packet_set_data (packet, (void *) end, to_copy_size);
 
 						end += to_copy_size;
 						buffer_pos += to_copy_size;
@@ -1484,17 +1485,19 @@ void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 			}
 
 			else {
-				if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+				if (sock_receive->spare_packet) {
+					(void) packet_append_data (
+						sock_receive->spare_packet, (void *) end, remaining_buffer_size
+					);
+				}
 
 				else {
 					// handle part of a new header
-					// #ifdef CERVER_DEBUG
 					// cerver_log_debug ("Handle part of a new header...");
-					// #endif
 
 					// copy the piece of possible header that was cut of between recv ()
 					sock_receive->header = malloc (sizeof (PacketHeader));
-					memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+					(void) memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
 
 					sock_receive->header_end = (char *) sock_receive->header;
 					sock_receive->header_end += remaining_buffer_size;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1340,7 +1340,11 @@ static void cerver_receive_handle_spare_packet (
 }
 
 // default cerver receive handler
-void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
+void cerver_receive_handle_buffer (
+	void *receive_handle_ptr
+) {
+
+	ReceiveHandle *receive_handle = (ReceiveHandle *) receive_handle_ptr;
 
 	Cerver *cerver = receive_handle->cerver;
 	char *buffer = receive_handle->buffer;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1343,204 +1343,175 @@ static void cerver_receive_handle_spare_packet (
 void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 
 	Cerver *cerver = receive_handle->cerver;
-	// i32 sock_fd = receive_handle->sock_fd;
 	char *buffer = receive_handle->buffer;
 	size_t buffer_size = receive_handle->buffer_size;
 	#ifdef HANDLER_DEBUG
 	i32 sock_fd = receive_handle->socket->sock_fd;
 	#endif
-	// char *buffer = receive_handle->socket->packet_buffer;
-	// size_t buffer_size = receive_handle->socket->packet_buffer_size;
 	Lobby *lobby = receive_handle->lobby;
 
-	pthread_mutex_lock (receive_handle->socket->read_mutex);
+	SockReceive *sock_receive = receive_handle->connection->sock_receive;
+	if (buffer && (buffer_size > 0)) {
+		char *end = buffer;
+		size_t buffer_pos = 0;
 
-	SockReceive *sock_receive = receive_handle->connection ? receive_handle->connection->sock_receive : NULL;
-	if (sock_receive) {
-		if (buffer && (buffer_size > 0)) {
-			char *end = buffer;
-			size_t buffer_pos = 0;
+		cerver_receive_handle_spare_packet (
+			receive_handle,
+			sock_receive,
+			buffer_size, &end, &buffer_pos
+		);
 
-			cerver_receive_handle_spare_packet (
-				receive_handle,
-				sock_receive,
-				buffer_size, &end, &buffer_pos
-			);
+		PacketHeader *header = NULL;
+		size_t packet_size = 0;
+		// char *packet_data = NULL;
 
-			PacketHeader *header = NULL;
-			size_t packet_size = 0;
-			// char *packet_data = NULL;
+		size_t remaining_buffer_size = 0;
+		size_t packet_real_size = 0;
+		size_t to_copy_size = 0;
 
-			size_t remaining_buffer_size = 0;
-			size_t packet_real_size = 0;
-			size_t to_copy_size = 0;
+		bool spare_header = false;
 
-			bool spare_header = false;
+		while (buffer_pos < buffer_size) {
+			remaining_buffer_size = buffer_size - buffer_pos;
 
-			while (buffer_pos < buffer_size) {
-				remaining_buffer_size = buffer_size - buffer_pos;
+			if (sock_receive->complete_header) {
+				packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+				// header = ((PacketHeader *) sock_receive->header);
+				// packet_header_print (header);
 
-				if (sock_receive->complete_header) {
-					packet_header_copy (&header, (PacketHeader *) sock_receive->header);
-					// header = ((PacketHeader *) sock_receive->header);
-					// packet_header_print (header);
+				end += sock_receive->remaining_header;
+				buffer_pos += sock_receive->remaining_header;
+				// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
 
-					end += sock_receive->remaining_header;
-					buffer_pos += sock_receive->remaining_header;
-					// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
+				// reset sock header values
+				free (sock_receive->header);
+				sock_receive->header = NULL;
+				sock_receive->header_end = NULL;
+				// sock_receive->curr_header_pos = 0;
+				// sock_receive->remaining_header = 0;
+				sock_receive->complete_header = false;
 
-					// reset sock header values
-					free (sock_receive->header);
-					sock_receive->header = NULL;
-					sock_receive->header_end = NULL;
-					// sock_receive->curr_header_pos = 0;
-					// sock_receive->remaining_header = 0;
-					sock_receive->complete_header = false;
+				spare_header = true;
+			}
 
-					spare_header = true;
-				}
+			else if (remaining_buffer_size >= sizeof (PacketHeader)) {
+				header = (PacketHeader *) end;
+				end += sizeof (PacketHeader);
+				buffer_pos += sizeof (PacketHeader);
 
-				else if (remaining_buffer_size >= sizeof (PacketHeader)) {
-					header = (PacketHeader *) end;
-					end += sizeof (PacketHeader);
-					buffer_pos += sizeof (PacketHeader);
+				// packet_header_print (header);
 
-					// packet_header_print (header);
+				spare_header = false;
+			}
 
-					spare_header = false;
-				}
+			if (header) {
+				// check the packet size
+				packet_size = header->packet_size;
+				if ((packet_size > 0) /* && (packet_size < 65536) */) {
+					// printf ("packet_size: %ld\n", packet_size);
+					// end += sizeof (PacketHeader);
+					// buffer_pos += sizeof (PacketHeader);
+					// printf ("first buffer pos: %ld\n", buffer_pos);
 
-				if (header) {
-					// check the packet size
-					packet_size = header->packet_size;
-					if ((packet_size > 0) /* && (packet_size < 65536) */) {
-						// printf ("packet_size: %ld\n", packet_size);
-						// end += sizeof (PacketHeader);
-						// buffer_pos += sizeof (PacketHeader);
-						// printf ("first buffer pos: %ld\n", buffer_pos);
+					Packet *packet = packet_new ();
+					if (packet) {
+						packet_header_copy (&packet->header, header);
+						packet->packet_size = header->packet_size;
+						packet->cerver = cerver;
+						packet->lobby = lobby;
 
-						Packet *packet = packet_new ();
-						if (packet) {
-							packet_header_copy (&packet->header, header);
-							packet->packet_size = header->packet_size;
-							packet->cerver = cerver;
-							packet->lobby = lobby;
+						if (spare_header) {
+							free (header);
+							header = NULL;
+						}
 
-							if (spare_header) {
-								free (header);
-								header = NULL;
-							}
+						// check for packet size and only copy what is in the current buffer
+						packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
+						to_copy_size = 0;
+						if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
+							sock_receive->spare_packet = packet;
 
-							// check for packet size and only copy what is in the current buffer
-							packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
-							to_copy_size = 0;
-							if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
-								sock_receive->spare_packet = packet;
+							if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
+							else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 
-								if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
-								else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-
-								sock_receive->missing_packet = packet_real_size - to_copy_size;
-							}
-
-							else {
-								if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
-									to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-								}
-
-								else {
-									to_copy_size = packet_real_size;
-								}
-
-								packet_delete (sock_receive->spare_packet);
-								sock_receive->spare_packet = NULL;
-							}
-
-							// printf ("to copy size: %ld\n", to_copy_size);
-							packet_set_data (packet, (void *) end, to_copy_size);
-
-							end += to_copy_size;
-							buffer_pos += to_copy_size;
-							// printf ("second buffer pos: %ld\n", buffer_pos);
-
-							if (!sock_receive->spare_packet) {
-								cerver_packet_select_handler (receive_handle, packet);
-							}
-
+							sock_receive->missing_packet = packet_real_size - to_copy_size;
 						}
 
 						else {
-							cerver_log (
-								LOG_TYPE_ERROR, LOG_TYPE_PACKET,
-								"Failed to create a new packet in cerver_handle_receive_buffer ()"
-							);
+							if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
+								to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+							}
+
+							else {
+								to_copy_size = packet_real_size;
+							}
+
+							packet_delete (sock_receive->spare_packet);
+							sock_receive->spare_packet = NULL;
 						}
+
+						// printf ("to copy size: %ld\n", to_copy_size);
+						packet_set_data (packet, (void *) end, to_copy_size);
+
+						end += to_copy_size;
+						buffer_pos += to_copy_size;
+						// printf ("second buffer pos: %ld\n", buffer_pos);
+
+						if (!sock_receive->spare_packet) {
+							cerver_packet_select_handler (receive_handle, packet);
+						}
+
 					}
 
 					else {
 						cerver_log (
-							LOG_TYPE_WARNING, LOG_TYPE_PACKET,
-							"Got a packet of invalid size: %ld", packet_size
+							LOG_TYPE_ERROR, LOG_TYPE_PACKET,
+							"Failed to create a new packet in cerver_handle_receive_buffer ()"
 						);
-
-						// FIXME: what to do next?
-
-						break;
 					}
 				}
 
 				else {
-					if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+					cerver_log (
+						LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+						"Got a packet of invalid size: %ld", packet_size
+					);
 
-					else {
-						// handle part of a new header
-						// #ifdef CERVER_DEBUG
-						// cerver_log_debug ("Handle part of a new header...");
-						// #endif
+					// FIXME: what to do next?
 
-						// copy the piece of possible header that was cut of between recv ()
-						sock_receive->header = malloc (sizeof (PacketHeader));
-						memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
-
-						sock_receive->header_end = (char *) sock_receive->header;
-						sock_receive->header_end += remaining_buffer_size;
-
-						// sock_receive->curr_header_pos = remaining_buffer_size;
-						sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
-
-						// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
-						// printf ("remaining header: %d\n", sock_receive->remaining_header);
-
-						buffer_pos += remaining_buffer_size;
-					}
+					break;
 				}
-
-				header = NULL;
 			}
+
+			else {
+				if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+
+				else {
+					// handle part of a new header
+					// #ifdef CERVER_DEBUG
+					// cerver_log_debug ("Handle part of a new header...");
+					// #endif
+
+					// copy the piece of possible header that was cut of between recv ()
+					sock_receive->header = malloc (sizeof (PacketHeader));
+					memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+
+					sock_receive->header_end = (char *) sock_receive->header;
+					sock_receive->header_end += remaining_buffer_size;
+
+					// sock_receive->curr_header_pos = remaining_buffer_size;
+					sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
+
+					// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
+					// printf ("remaining header: %d\n", sock_receive->remaining_header);
+
+					buffer_pos += remaining_buffer_size;
+				}
+			}
+
+			header = NULL;
 		}
 	}
-
-	else {
-		#ifdef HANDLER_DEBUG
-		cerver_log (
-			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-			"Sock fd: %d does not have an associated sock_receive in cerver %s.",
-			sock_fd, cerver->info->name->str
-		);
-		#endif
-	}
-
-	// 28/05/2020 -- deleting the created buffer from cerver_receive ()
-	// to correct handle both cases: using thpool and single threaded
-	if (cerver->handler_type != CERVER_HANDLER_TYPE_THREADS) {
-		// TODO: avoid deleting buffer every time
-		if (buffer) free (receive_handle->buffer);
-	}
-
-	// free (receive->socket->packet_buffer);
-	// receive->socket->packet_buffer = NULL;
-
-	pthread_mutex_unlock (receive_handle->socket->read_mutex);
 
 	receive_handle_delete (receive_handle);
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1293,47 +1293,47 @@ static void cerver_receive_handle_spare_packet (
 	char **end, size_t *buffer_pos
 ) {
 
-	if (sock_receive) {
-		if (sock_receive->header) {
-			// copy the remaining header size
-			memcpy (sock_receive->header_end, (void *) *end, sock_receive->remaining_header);
-			// *end += sock_receive->remaining_header;
-			// *buffer_pos += sock_receive->remaining_header;
+	if (sock_receive->header) {
+		// copy the remaining header size
+		(void) memcpy (sock_receive->header_end, (void *) *end, sock_receive->remaining_header);
+		// *end += sock_receive->remaining_header;
+		// *buffer_pos += sock_receive->remaining_header;
 
-			// printf ("size in new header: %ld\n", ((PacketHeader *) sock_receive->header)->packet_size);
-			// packet_header_print (((PacketHeader *) sock_receive->header));
+		// printf ("size in new header: %ld\n", ((PacketHeader *) sock_receive->header)->packet_size);
+		// packet_header_print (((PacketHeader *) sock_receive->header));
 
-			sock_receive->complete_header = true;
-		}
+		sock_receive->complete_header = true;
+	}
 
-		else if (sock_receive->spare_packet) {
-			size_t copy_to_spare = 0;
-			if (sock_receive->missing_packet < buffer_size)
-				copy_to_spare = sock_receive->missing_packet;
+	else if (sock_receive->spare_packet) {
+		size_t copy_to_spare = 0;
+		if (sock_receive->missing_packet < buffer_size)
+			copy_to_spare = sock_receive->missing_packet;
 
-			else copy_to_spare = buffer_size;
+		else copy_to_spare = buffer_size;
 
-			// printf ("copy to spare: %ld\n", copy_to_spare);
+		// printf ("copy to spare: %ld\n", copy_to_spare);
 
-			// append new data from buffer to the spare packet
-			if (copy_to_spare > 0) {
-				packet_append_data (sock_receive->spare_packet, (void *) *end, copy_to_spare);
+		// append new data from buffer to the spare packet
+		if (copy_to_spare > 0) {
+			(void) packet_append_data (sock_receive->spare_packet, (void *) *end, copy_to_spare);
 
-				// check if we can handle the packet
-				size_t curr_packet_size = sock_receive->spare_packet->data_size + sizeof (PacketHeader);
-				if (sock_receive->spare_packet->header->packet_size == curr_packet_size) {
-					cerver_packet_select_handler (receive_handle, sock_receive->spare_packet);
-					sock_receive->spare_packet = NULL;
-					sock_receive->missing_packet = 0;
-				}
-
-				else sock_receive->missing_packet -= copy_to_spare;
-
-				// offset for the buffer
-				if (copy_to_spare < buffer_size) *end += copy_to_spare;
-				*buffer_pos += copy_to_spare;
-				// printf ("buffer pos after copy to spare: %ld\n", *buffer_pos);
+			// check if we can handle the packet
+			size_t curr_packet_size = sock_receive->spare_packet->data_size + sizeof (PacketHeader);
+			if (sock_receive->spare_packet->header->packet_size == curr_packet_size) {
+				cerver_packet_select_handler (receive_handle, sock_receive->spare_packet);
+				sock_receive->spare_packet = NULL;
+				sock_receive->missing_packet = 0;
 			}
+
+			else {
+				sock_receive->missing_packet -= copy_to_spare;
+			}
+
+			// offset for the buffer
+			if (copy_to_spare < buffer_size) *end += copy_to_spare;
+			*buffer_pos += copy_to_spare;
+			// printf ("buffer pos after copy to spare: %ld\n", *buffer_pos);
 		}
 	}
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -492,7 +492,11 @@ const char *cerver_handler_error_description (
 }
 
 // handles a packet of type PACKET_TYPE_CLIENT
-static void cerver_client_packet_handler (Packet *packet) {
+static CerverHandlerError cerver_client_packet_handler (
+	Packet *packet
+) {
+
+	CerverHandlerError error = CERVER_HANDLER_ERROR_NONE;
 
 	if (packet->header) {
 		switch (packet->header->request_type) {
@@ -518,15 +522,28 @@ static void cerver_client_packet_handler (Packet *packet) {
 					#endif
 
 					// remove the player from the lobby
-					Player *player = player_get_by_sock_fd_list (packet->lobby, packet->connection->socket->sock_fd);
-					player_unregister_from_lobby (packet->lobby, player);
+					(void) player_unregister_from_lobby (
+						packet->lobby,
+						player_get_by_sock_fd_list (
+							packet->lobby, packet->connection->socket->sock_fd
+						)
+					);
 				}
 
-				client_remove_connection_by_sock_fd (packet->cerver,
-					packet->client, packet->connection->socket->sock_fd);
+				switch (client_remove_connection_by_sock_fd (
+					packet->cerver,
+					packet->client, packet->connection->socket->sock_fd
+				)) {
+					case CLIENT_CONNECTIONS_STATUS_DROPPED:
+						error = CERVER_HANDLER_ERROR_DROPPED;
+						break;
+
+					default: break;
+				}
 			} break;
 
-			// the client is going to disconnect and will close all of its active connections
+			// the client is going to disconnect
+			// and will close all of its active connections
 			// so drop it from the server
 			case CLIENT_PACKET_TYPE_DISCONNECT: {
 				// check if the client is inside a lobby
@@ -540,8 +557,12 @@ static void cerver_client_packet_handler (Packet *packet) {
 					#endif
 
 					// remove the player from the lobby
-					Player *player = player_get_by_sock_fd_list (packet->lobby, packet->connection->socket->sock_fd);
-					player_unregister_from_lobby (packet->lobby, player);
+					(void) player_unregister_from_lobby (
+						packet->lobby,
+						player_get_by_sock_fd_list (
+							packet->lobby, packet->connection->socket->sock_fd
+						)
+					);
 				}
 
 				client_drop (packet->cerver, packet->client);
@@ -565,6 +586,8 @@ static void cerver_client_packet_handler (Packet *packet) {
 		}
 	}
 
+	return error;
+
 }
 
 static inline void cerver_request_get_file_actual (Packet *packet) {
@@ -579,7 +602,10 @@ static inline void cerver_request_get_file_actual (Packet *packet) {
 		FileHeader *file_header = (FileHeader *) end;
 
 		// search for the requested file in the configured paths
-		String *actual_filename = file_cerver_search_file (file_cerver, file_header->filename);
+		String *actual_filename = file_cerver_search_file (
+			file_cerver, file_header->filename
+		);
+
 		if (actual_filename) {
 			#ifdef HANDLER_DEBUG
 			cerver_log_debug (
@@ -770,10 +796,14 @@ static void cerver_request_packet_handler (Packet *packet) {
 	if (packet->header) {
 		switch (packet->header->request_type) {
 			// request from a client to get a file
-			case REQUEST_PACKET_TYPE_GET_FILE: cerver_request_get_file (packet); break;
+			case REQUEST_PACKET_TYPE_GET_FILE:
+				cerver_request_get_file (packet);
+				break;
 
 			// request from a client to upload a file
-			case REQUEST_PACKET_TYPE_SEND_FILE: cerver_request_send_file (packet); break;
+			case REQUEST_PACKET_TYPE_SEND_FILE:
+				cerver_request_send_file (packet);
+				break;
 
 			default: {
 				#ifdef HANDLER_DEBUG
@@ -822,11 +852,9 @@ void cerver_test_packet_handler (Packet *packet) {
 
 }
 
-// 27/01/2020
 // handles an PACKET_TYPE_APP packet type
 static void cerver_app_packet_handler (Packet *packet) {
 
-	// 11/05/2020
 	if (packet->cerver->multiple_handlers) {
 		// select which handler to use
 		if (packet->header->handler_id < packet->cerver->n_handlers) {
@@ -851,7 +879,8 @@ static void cerver_app_packet_handler (Packet *packet) {
 			if (packet->cerver->app_packet_handler->direct_handle) {
 				// printf ("app_packet_handler - direct handle!\n");
 				packet->cerver->app_packet_handler->handler (packet);
-				if (packet->cerver->app_packet_handler_delete_packet) packet_delete (packet);
+				if (packet->cerver->app_packet_handler_delete_packet)
+					packet_delete (packet);
 			}
 
 			else {
@@ -879,7 +908,6 @@ static void cerver_app_packet_handler (Packet *packet) {
 
 }
 
-// 27/05/2020
 // handles an PACKET_TYPE_APP_ERROR packet type
 static void cerver_app_error_packet_handler (Packet *packet) {
 
@@ -887,7 +915,8 @@ static void cerver_app_error_packet_handler (Packet *packet) {
 		if (packet->cerver->app_error_packet_handler->direct_handle) {
 			// printf ("app_error_packet_handler - direct handle!\n");
 			packet->cerver->app_error_packet_handler->handler (packet);
-			if (packet->cerver->app_error_packet_handler_delete_packet) packet_delete (packet);
+			if (packet->cerver->app_error_packet_handler_delete_packet)
+				packet_delete (packet);
 		}
 
 		else {
@@ -914,7 +943,6 @@ static void cerver_app_error_packet_handler (Packet *packet) {
 
 }
 
-// 27/05/2020
 // handles a PACKET_TYPE_CUSTOM packet type
 static void cerver_custom_packet_handler (Packet *packet) {
 
@@ -922,7 +950,8 @@ static void cerver_custom_packet_handler (Packet *packet) {
 		if (packet->cerver->custom_packet_handler->direct_handle) {
 			// printf ("custom_packet_handler - direct handle!\n");
 			packet->cerver->custom_packet_handler->handler (packet);
-			if (packet->cerver->custom_packet_handler_delete_packet) packet_delete (packet);
+			if (packet->cerver->custom_packet_handler_delete_packet)
+				packet_delete (packet);
 		}
 
 		else {
@@ -949,135 +978,179 @@ static void cerver_custom_packet_handler (Packet *packet) {
 
 }
 
+static CerverHandlerError cerver_packet_handler_check_version (
+	Packet *packet
+) {
+
+	CerverHandlerError error = CERVER_HANDLER_ERROR_NONE;
+
+	// we expect the packet version in the packet's data
+	if (packet->data) {
+		packet->version = (PacketVersion *) packet->data_ptr;
+		packet->data_ptr += sizeof (PacketVersion);
+		
+		// TODO: return errors to client
+		// TODO: drop client on max bad packets
+		if (packet_check (packet)) {
+			error = CERVER_HANDLER_ERROR_PACKET;
+		}
+	}
+
+	else {
+		cerver_log_error (
+			"cerver_packet_handler () - No packet version to check!"
+		);
+		
+		// TODO: add to bad packets count
+
+		error = CERVER_HANDLER_ERROR_PACKET;
+	}
+
+	return error;
+
+}
+
+static CerverHandlerError cerver_packet_handler_actual (
+	Packet *packet
+) {
+
+	CerverHandlerError error = CERVER_HANDLER_ERROR_NONE;
+
+	switch (packet->header->packet_type) {
+		case PACKET_TYPE_NONE: break;
+
+		case PACKET_TYPE_CERVER: break;
+
+		case PACKET_TYPE_CLIENT:
+			packet->cerver->stats->received_packets->n_client_packets += 1;
+			packet->client->stats->received_packets->n_client_packets += 1;
+			packet->connection->stats->received_packets->n_client_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_client_packets += 1;
+			error = cerver_client_packet_handler (packet);
+			packet_delete (packet);
+			break;
+
+		// handles an error from the client
+		case PACKET_TYPE_ERROR:
+			packet->cerver->stats->received_packets->n_error_packets += 1;
+			packet->client->stats->received_packets->n_error_packets += 1;
+			packet->connection->stats->received_packets->n_error_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_error_packets += 1;
+			cerver_error_packet_handler (packet);
+			packet_delete (packet);
+			break;
+
+		// handles a request made from the client
+		case PACKET_TYPE_REQUEST:
+			packet->cerver->stats->received_packets->n_request_packets += 1;
+			packet->client->stats->received_packets->n_request_packets += 1;
+			packet->connection->stats->received_packets->n_request_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_request_packets += 1;
+			cerver_request_packet_handler (packet);
+			packet_delete (packet);
+			break;
+
+		// handles authentication packets
+		case PACKET_TYPE_AUTH:
+			packet->cerver->stats->received_packets->n_auth_packets += 1;
+			packet->client->stats->received_packets->n_auth_packets += 1;
+			packet->connection->stats->received_packets->n_auth_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_auth_packets += 1;
+			/* TODO: */
+			packet_delete (packet);
+			break;
+
+		// handles a game packet sent from the client
+		case PACKET_TYPE_GAME:
+			packet->cerver->stats->received_packets->n_game_packets += 1;
+			packet->client->stats->received_packets->n_game_packets += 1;
+			packet->connection->stats->received_packets->n_game_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_game_packets += 1;
+			game_packet_handler (packet);
+			break;
+
+		// user set handler to handle app specific packets
+		case PACKET_TYPE_APP:
+			packet->cerver->stats->received_packets->n_app_packets += 1;
+			packet->client->stats->received_packets->n_app_packets += 1;
+			packet->connection->stats->received_packets->n_app_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_app_packets += 1;
+			cerver_app_packet_handler (packet);
+			break;
+
+		// user set handler to handle app specific errors
+		case PACKET_TYPE_APP_ERROR:
+			packet->cerver->stats->received_packets->n_app_error_packets += 1;
+			packet->client->stats->received_packets->n_app_error_packets += 1;
+			packet->connection->stats->received_packets->n_app_error_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_app_error_packets += 1;
+			cerver_app_error_packet_handler (packet);
+			break;
+
+		// custom packet hanlder
+		case PACKET_TYPE_CUSTOM:
+			packet->cerver->stats->received_packets->n_custom_packets += 1;
+			packet->client->stats->received_packets->n_custom_packets += 1;
+			packet->connection->stats->received_packets->n_custom_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_custom_packets += 1;
+			cerver_custom_packet_handler (packet);
+			break;
+
+		// acknowledge the client we have received his test packet
+		case PACKET_TYPE_TEST:
+			packet->cerver->stats->received_packets->n_test_packets += 1;
+			packet->client->stats->received_packets->n_test_packets += 1;
+			packet->connection->stats->received_packets->n_test_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_test_packets += 1;
+			cerver_test_packet_handler (packet);
+			packet_delete (packet);
+			break;
+
+		default: {
+			packet->cerver->stats->received_packets->n_bad_packets += 1;
+			packet->client->stats->received_packets->n_bad_packets += 1;
+			packet->connection->stats->received_packets->n_bad_packets += 1;
+			if (packet->lobby) packet->lobby->stats->received_packets->n_bad_packets += 1;
+			#ifdef HANDLER_DEBUG
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+				"Got a packet of unknown type in cerver %s.",
+				packet->cerver->info->name->str
+			);
+			#endif
+			packet_delete (packet);
+		} break;
+	}
+
+	return error;
+
+}
+
 // handle packet based on type
-static void cerver_packet_handler (Packet *packet) {
+static u8 cerver_packet_handler (Packet *packet) {
 
-	packet->cerver->stats->client_n_packets_received += 1;
-	packet->cerver->stats->total_n_packets_received += 1;
-	if (packet->lobby) packet->lobby->stats->n_packets_received += 1;
+	u8 retval = 1;
 
-	bool good = true;
+	CerverHandlerError error = CERVER_HANDLER_ERROR_NONE;
 	if (packet->cerver->check_packets) {
-		// we expect the packet version in the packet's data
-		if (packet->data) {
-			packet->version = (PacketVersion *) packet->data_ptr;
-			packet->data_ptr += sizeof (PacketVersion);
-			good = packet_check (packet);
-		}
-
-		else {
-			cerver_log_error ("cerver_packet_handler () - No packet version to check!");
-			good = false;
+		if (!cerver_packet_handler_check_version (packet)) {
+			error = cerver_packet_handler_actual (packet);
 		}
 	}
 
-	if (good) {
-		switch (packet->header->packet_type) {
-			case PACKET_TYPE_NONE: break;
-
-			case PACKET_TYPE_CERVER: break;
-
-			case PACKET_TYPE_CLIENT:
-				packet->cerver->stats->received_packets->n_client_packets += 1;
-				packet->client->stats->received_packets->n_client_packets += 1;
-				packet->connection->stats->received_packets->n_client_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_client_packets += 1;
-				cerver_client_packet_handler (packet);
-				packet_delete (packet);
-				break;
-
-			// handles an error from the client
-			case PACKET_TYPE_ERROR:
-				packet->cerver->stats->received_packets->n_error_packets += 1;
-				packet->client->stats->received_packets->n_error_packets += 1;
-				packet->connection->stats->received_packets->n_error_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_error_packets += 1;
-				cerver_error_packet_handler (packet);
-				packet_delete (packet);
-				break;
-
-			// handles a request made from the client
-			case PACKET_TYPE_REQUEST:
-				packet->cerver->stats->received_packets->n_request_packets += 1;
-				packet->client->stats->received_packets->n_request_packets += 1;
-				packet->connection->stats->received_packets->n_request_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_request_packets += 1;
-				cerver_request_packet_handler (packet);
-				packet_delete (packet);
-				break;
-
-			// handles authentication packets
-			case PACKET_TYPE_AUTH:
-				packet->cerver->stats->received_packets->n_auth_packets += 1;
-				packet->client->stats->received_packets->n_auth_packets += 1;
-				packet->connection->stats->received_packets->n_auth_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_auth_packets += 1;
-				/* TODO: */
-				packet_delete (packet);
-				break;
-
-			// handles a game packet sent from the client
-			case PACKET_TYPE_GAME:
-				packet->cerver->stats->received_packets->n_game_packets += 1;
-				packet->client->stats->received_packets->n_game_packets += 1;
-				packet->connection->stats->received_packets->n_game_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_game_packets += 1;
-				game_packet_handler (packet);
-				break;
-
-			// user set handler to handle app specific packets
-			case PACKET_TYPE_APP:
-				packet->cerver->stats->received_packets->n_app_packets += 1;
-				packet->client->stats->received_packets->n_app_packets += 1;
-				packet->connection->stats->received_packets->n_app_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_app_packets += 1;
-				cerver_app_packet_handler (packet);
-				break;
-
-			// user set handler to handle app specific errors
-			case PACKET_TYPE_APP_ERROR:
-				packet->cerver->stats->received_packets->n_app_error_packets += 1;
-				packet->client->stats->received_packets->n_app_error_packets += 1;
-				packet->connection->stats->received_packets->n_app_error_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_app_error_packets += 1;
-				cerver_app_error_packet_handler (packet);
-				break;
-
-			// custom packet hanlder
-			case PACKET_TYPE_CUSTOM:
-				packet->cerver->stats->received_packets->n_custom_packets += 1;
-				packet->client->stats->received_packets->n_custom_packets += 1;
-				packet->connection->stats->received_packets->n_custom_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_custom_packets += 1;
-				cerver_custom_packet_handler (packet);
-				break;
-
-			// acknowledge the client we have received his test packet
-			case PACKET_TYPE_TEST:
-				packet->cerver->stats->received_packets->n_test_packets += 1;
-				packet->client->stats->received_packets->n_test_packets += 1;
-				packet->connection->stats->received_packets->n_test_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_test_packets += 1;
-				cerver_test_packet_handler (packet);
-				packet_delete (packet);
-				break;
-
-			default: {
-				packet->cerver->stats->received_packets->n_bad_packets += 1;
-				packet->client->stats->received_packets->n_bad_packets += 1;
-				packet->connection->stats->received_packets->n_bad_packets += 1;
-				if (packet->lobby) packet->lobby->stats->received_packets->n_bad_packets += 1;
-				#ifdef HANDLER_DEBUG
-				cerver_log (
-					LOG_TYPE_WARNING, LOG_TYPE_PACKET,
-					"Got a packet of unknown type in cerver %s.",
-					packet->cerver->info->name->str
-				);
-				#endif
-				packet_delete (packet);
-			} break;
-		}
+	else {
+		error = cerver_packet_handler_actual (packet);
 	}
+
+	switch (error) {
+		case CERVER_HANDLER_ERROR_NONE:
+			retval = 0;
+			break;
+
+		default: break;
+	}
+
+	return retval;
 
 }
 
@@ -1096,10 +1169,14 @@ static u8 cerver_packet_select_handler (
 			packet->connection = receive_handle->connection;
 
 			packet->cerver->stats->client_n_packets_received += 1;
+			packet->cerver->stats->total_n_packets_received += 1;
+
 			packet->client->stats->n_packets_received += 1;
 			packet->connection->stats->n_packets_received += 1;
 
-			cerver_packet_handler (packet);
+			if (packet->lobby) packet->lobby->stats->n_packets_received += 1;
+
+			retval = cerver_packet_handler (packet);
 		} break;
 
 		case RECEIVE_TYPE_ON_HOLD: {
@@ -1123,7 +1200,7 @@ static u8 cerver_packet_select_handler (
 
 			packet->connection->stats->n_packets_received += 1;
 
-			admin_packet_handler (packet);
+			retval = admin_packet_handler (packet);
 		} break;
 
 		default: break;
@@ -1141,7 +1218,9 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd);
 
 static ReceiveHandle *receive_handle_new (void) {
 
-	ReceiveHandle *receive_handle = (ReceiveHandle *) malloc (sizeof (ReceiveHandle));
+	ReceiveHandle *receive_handle =
+		(ReceiveHandle *) malloc (sizeof (ReceiveHandle));
+
 	if (receive_handle) {
 		receive_handle->type = RECEIVE_TYPE_NONE;
 
@@ -1162,7 +1241,11 @@ static ReceiveHandle *receive_handle_new (void) {
 
 }
 
-void receive_handle_delete (void *receive_ptr) { if (receive_ptr) free (receive_ptr); }
+void receive_handle_delete (void *receive_ptr) {
+	
+	if (receive_ptr) free (receive_ptr);
+	
+}
 
 CerverReceive *cerver_receive_new (void) {
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1340,214 +1340,209 @@ static void cerver_receive_handle_spare_packet (
 }
 
 // default cerver receive handler
-void cerver_receive_handle_buffer (void *receive_handle_ptr) {
+void cerver_receive_handle_buffer (ReceiveHandle *receive_handle) {
 
-	if (receive_handle_ptr) {
-		// printf ("cerver_receive_handle_buffer ()\n");
-		ReceiveHandle *receive_handle = (ReceiveHandle *) receive_handle_ptr;
+	Cerver *cerver = receive_handle->cerver;
+	// i32 sock_fd = receive_handle->sock_fd;
+	char *buffer = receive_handle->buffer;
+	size_t buffer_size = receive_handle->buffer_size;
+	#ifdef HANDLER_DEBUG
+	i32 sock_fd = receive_handle->socket->sock_fd;
+	#endif
+	// char *buffer = receive_handle->socket->packet_buffer;
+	// size_t buffer_size = receive_handle->socket->packet_buffer_size;
+	Lobby *lobby = receive_handle->lobby;
 
-		Cerver *cerver = receive_handle->cerver;
-		// i32 sock_fd = receive_handle->sock_fd;
-		char *buffer = receive_handle->buffer;
-		size_t buffer_size = receive_handle->buffer_size;
-		#ifdef HANDLER_DEBUG
-		i32 sock_fd = receive_handle->socket->sock_fd;
-		#endif
-		// char *buffer = receive_handle->socket->packet_buffer;
-		// size_t buffer_size = receive_handle->socket->packet_buffer_size;
-		Lobby *lobby = receive_handle->lobby;
+	pthread_mutex_lock (receive_handle->socket->read_mutex);
 
-		pthread_mutex_lock (receive_handle->socket->read_mutex);
+	SockReceive *sock_receive = receive_handle->connection ? receive_handle->connection->sock_receive : NULL;
+	if (sock_receive) {
+		if (buffer && (buffer_size > 0)) {
+			char *end = buffer;
+			size_t buffer_pos = 0;
 
-		SockReceive *sock_receive = receive_handle->connection ? receive_handle->connection->sock_receive : NULL;
-		if (sock_receive) {
-			if (buffer && (buffer_size > 0)) {
-				char *end = buffer;
-				size_t buffer_pos = 0;
+			cerver_receive_handle_spare_packet (
+				receive_handle,
+				sock_receive,
+				buffer_size, &end, &buffer_pos
+			);
 
-				cerver_receive_handle_spare_packet (
-					receive_handle,
-					sock_receive,
-					buffer_size, &end, &buffer_pos
-				);
+			PacketHeader *header = NULL;
+			size_t packet_size = 0;
+			// char *packet_data = NULL;
 
-				PacketHeader *header = NULL;
-				size_t packet_size = 0;
-				// char *packet_data = NULL;
+			size_t remaining_buffer_size = 0;
+			size_t packet_real_size = 0;
+			size_t to_copy_size = 0;
 
-				size_t remaining_buffer_size = 0;
-				size_t packet_real_size = 0;
-				size_t to_copy_size = 0;
+			bool spare_header = false;
 
-				bool spare_header = false;
+			while (buffer_pos < buffer_size) {
+				remaining_buffer_size = buffer_size - buffer_pos;
 
-				while (buffer_pos < buffer_size) {
-					remaining_buffer_size = buffer_size - buffer_pos;
+				if (sock_receive->complete_header) {
+					packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+					// header = ((PacketHeader *) sock_receive->header);
+					// packet_header_print (header);
 
-					if (sock_receive->complete_header) {
-						packet_header_copy (&header, (PacketHeader *) sock_receive->header);
-						// header = ((PacketHeader *) sock_receive->header);
-						// packet_header_print (header);
+					end += sock_receive->remaining_header;
+					buffer_pos += sock_receive->remaining_header;
+					// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
 
-						end += sock_receive->remaining_header;
-						buffer_pos += sock_receive->remaining_header;
-						// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
+					// reset sock header values
+					free (sock_receive->header);
+					sock_receive->header = NULL;
+					sock_receive->header_end = NULL;
+					// sock_receive->curr_header_pos = 0;
+					// sock_receive->remaining_header = 0;
+					sock_receive->complete_header = false;
 
-						// reset sock header values
-						free (sock_receive->header);
-						sock_receive->header = NULL;
-						sock_receive->header_end = NULL;
-						// sock_receive->curr_header_pos = 0;
-						// sock_receive->remaining_header = 0;
-						sock_receive->complete_header = false;
+					spare_header = true;
+				}
 
-						spare_header = true;
-					}
+				else if (remaining_buffer_size >= sizeof (PacketHeader)) {
+					header = (PacketHeader *) end;
+					end += sizeof (PacketHeader);
+					buffer_pos += sizeof (PacketHeader);
 
-					else if (remaining_buffer_size >= sizeof (PacketHeader)) {
-						header = (PacketHeader *) end;
-						end += sizeof (PacketHeader);
-						buffer_pos += sizeof (PacketHeader);
+					// packet_header_print (header);
 
-						// packet_header_print (header);
+					spare_header = false;
+				}
 
-						spare_header = false;
-					}
+				if (header) {
+					// check the packet size
+					packet_size = header->packet_size;
+					if ((packet_size > 0) /* && (packet_size < 65536) */) {
+						// printf ("packet_size: %ld\n", packet_size);
+						// end += sizeof (PacketHeader);
+						// buffer_pos += sizeof (PacketHeader);
+						// printf ("first buffer pos: %ld\n", buffer_pos);
 
-					if (header) {
-						// check the packet size
-						packet_size = header->packet_size;
-						if ((packet_size > 0) /* && (packet_size < 65536) */) {
-							// printf ("packet_size: %ld\n", packet_size);
-							// end += sizeof (PacketHeader);
-							// buffer_pos += sizeof (PacketHeader);
-							// printf ("first buffer pos: %ld\n", buffer_pos);
+						Packet *packet = packet_new ();
+						if (packet) {
+							packet_header_copy (&packet->header, header);
+							packet->packet_size = header->packet_size;
+							packet->cerver = cerver;
+							packet->lobby = lobby;
 
-							Packet *packet = packet_new ();
-							if (packet) {
-								packet_header_copy (&packet->header, header);
-								packet->packet_size = header->packet_size;
-								packet->cerver = cerver;
-								packet->lobby = lobby;
+							if (spare_header) {
+								free (header);
+								header = NULL;
+							}
 
-								if (spare_header) {
-									free (header);
-									header = NULL;
-								}
+							// check for packet size and only copy what is in the current buffer
+							packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
+							to_copy_size = 0;
+							if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
+								sock_receive->spare_packet = packet;
 
-								// check for packet size and only copy what is in the current buffer
-								packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
-								to_copy_size = 0;
-								if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
-									sock_receive->spare_packet = packet;
+								if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
+								else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 
-									if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
-									else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-
-									sock_receive->missing_packet = packet_real_size - to_copy_size;
-								}
-
-								else {
-									if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
-										to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-									}
-
-									else {
-										to_copy_size = packet_real_size;
-									}
-
-									packet_delete (sock_receive->spare_packet);
-									sock_receive->spare_packet = NULL;
-								}
-
-								// printf ("to copy size: %ld\n", to_copy_size);
-								packet_set_data (packet, (void *) end, to_copy_size);
-
-								end += to_copy_size;
-								buffer_pos += to_copy_size;
-								// printf ("second buffer pos: %ld\n", buffer_pos);
-
-								if (!sock_receive->spare_packet) {
-									cerver_packet_select_handler (receive_handle, packet);
-								}
-
+								sock_receive->missing_packet = packet_real_size - to_copy_size;
 							}
 
 							else {
-								cerver_log (
-									LOG_TYPE_ERROR, LOG_TYPE_PACKET,
-									"Failed to create a new packet in cerver_handle_receive_buffer ()"
-								);
+								if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
+									to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+								}
+
+								else {
+									to_copy_size = packet_real_size;
+								}
+
+								packet_delete (sock_receive->spare_packet);
+								sock_receive->spare_packet = NULL;
 							}
+
+							// printf ("to copy size: %ld\n", to_copy_size);
+							packet_set_data (packet, (void *) end, to_copy_size);
+
+							end += to_copy_size;
+							buffer_pos += to_copy_size;
+							// printf ("second buffer pos: %ld\n", buffer_pos);
+
+							if (!sock_receive->spare_packet) {
+								cerver_packet_select_handler (receive_handle, packet);
+							}
+
 						}
 
 						else {
 							cerver_log (
-								LOG_TYPE_WARNING, LOG_TYPE_PACKET,
-								"Got a packet of invalid size: %ld", packet_size
+								LOG_TYPE_ERROR, LOG_TYPE_PACKET,
+								"Failed to create a new packet in cerver_handle_receive_buffer ()"
 							);
-
-							// FIXME: what to do next?
-
-							break;
 						}
 					}
 
 					else {
-						if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+						cerver_log (
+							LOG_TYPE_WARNING, LOG_TYPE_PACKET,
+							"Got a packet of invalid size: %ld", packet_size
+						);
 
-						else {
-							// handle part of a new header
-							// #ifdef CERVER_DEBUG
-							// cerver_log_debug ("Handle part of a new header...");
-							// #endif
+						// FIXME: what to do next?
 
-							// copy the piece of possible header that was cut of between recv ()
-							sock_receive->header = malloc (sizeof (PacketHeader));
-							memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
-
-							sock_receive->header_end = (char *) sock_receive->header;
-							sock_receive->header_end += remaining_buffer_size;
-
-							// sock_receive->curr_header_pos = remaining_buffer_size;
-							sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
-
-							// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
-							// printf ("remaining header: %d\n", sock_receive->remaining_header);
-
-							buffer_pos += remaining_buffer_size;
-						}
+						break;
 					}
-
-					header = NULL;
 				}
+
+				else {
+					if (sock_receive->spare_packet) packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
+
+					else {
+						// handle part of a new header
+						// #ifdef CERVER_DEBUG
+						// cerver_log_debug ("Handle part of a new header...");
+						// #endif
+
+						// copy the piece of possible header that was cut of between recv ()
+						sock_receive->header = malloc (sizeof (PacketHeader));
+						memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+
+						sock_receive->header_end = (char *) sock_receive->header;
+						sock_receive->header_end += remaining_buffer_size;
+
+						// sock_receive->curr_header_pos = remaining_buffer_size;
+						sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
+
+						// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
+						// printf ("remaining header: %d\n", sock_receive->remaining_header);
+
+						buffer_pos += remaining_buffer_size;
+					}
+				}
+
+				header = NULL;
 			}
 		}
-
-		else {
-			#ifdef HANDLER_DEBUG
-			cerver_log (
-				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-				"Sock fd: %d does not have an associated sock_receive in cerver %s.",
-				sock_fd, cerver->info->name->str
-			);
-			#endif
-		}
-
-		// 28/05/2020 -- deleting the created buffer from cerver_receive ()
-		// to correct handle both cases: using thpool and single threaded
-		if (cerver->handler_type != CERVER_HANDLER_TYPE_THREADS) {
-			// TODO: avoid deleting buffer every time
-			if (buffer) free (receive_handle->buffer);
-		}
-
-		// free (receive->socket->packet_buffer);
-		// receive->socket->packet_buffer = NULL;
-
-		pthread_mutex_unlock (receive_handle->socket->read_mutex);
-
-		receive_handle_delete (receive_handle);
 	}
+
+	else {
+		#ifdef HANDLER_DEBUG
+		cerver_log (
+			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+			"Sock fd: %d does not have an associated sock_receive in cerver %s.",
+			sock_fd, cerver->info->name->str
+		);
+		#endif
+	}
+
+	// 28/05/2020 -- deleting the created buffer from cerver_receive ()
+	// to correct handle both cases: using thpool and single threaded
+	if (cerver->handler_type != CERVER_HANDLER_TYPE_THREADS) {
+		// TODO: avoid deleting buffer every time
+		if (buffer) free (receive_handle->buffer);
+	}
+
+	// free (receive->socket->packet_buffer);
+	// receive->socket->packet_buffer = NULL;
+
+	pthread_mutex_unlock (receive_handle->socket->read_mutex);
+
+	receive_handle_delete (receive_handle);
 
 }
 
@@ -1640,37 +1635,7 @@ static inline void cerver_receive_success_receive_handle (
 			case CERVER_HANDLER_TYPE_NONE: break;
 
 			case CERVER_HANDLER_TYPE_POLL: {
-				if (cr->cerver->thpool) {
-					// 28/05/2020 -- 02:37 -- added thpool here instead of cerver_poll ()
-					// and it seems to be working as expected
-					if (!thpool_add_work (cr->cerver->thpool, cr->cerver->handle_received_buffer, receive_handle)) {
-						// cerver_log_debug (
-						// 	"Added %s cr->cerver->handle_received_buffer () to thpool!",
-						//     cr->cerver->info->name->str
-						// );
-					}
-
-					else {
-						cerver_log_error (
-							"Failed to add %s cr->cerver->handle_received_buffer () to thpool!",
-							cr->cerver->info->name->str
-						);
-					}
-
-					// cerver_log (
-					// 	LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
-					// 	"Cerver %s active thpool threads: %d",
-					//     cr->cerver->info->name->str,
-					//     thpool_get_num_threads_working (cr->cerver->thpool)
-					// );
-				}
-
-				else {
-					cr->cerver->handle_received_buffer (receive_handle);
-
-					// 28/05/2020 -- called from inside cerver_receive_handle_buffer ()
-					// receive_handle_delete (receive);
-				}
+				cr->cerver->handle_received_buffer (receive_handle);
 
 				cerver_receive_delete (cr);
 			} break;

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -463,6 +463,34 @@ void sock_receive_delete (void *sock_receive_ptr) {
 
 #pragma region handlers
 
+const char *cerver_handler_error_to_string (
+	const CerverHandlerError error
+) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case CERVER_HANDLER_ERROR_##name: return #string;
+		CERVER_HANDLER_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return cerver_handler_error_to_string (CERVER_HANDLER_ERROR_NONE);
+
+}
+
+const char *cerver_handler_error_description (
+	const CerverHandlerError error
+) {
+
+	switch (error) {
+		#define XX(num, name, string, description) case CERVER_HANDLER_ERROR_##name: return #description;
+		CERVER_HANDLER_ERROR_MAP(XX)
+		#undef XX
+	}
+
+	return cerver_handler_error_description (CERVER_HANDLER_ERROR_NONE);
+
+}
+
 // handles a packet of type PACKET_TYPE_CLIENT
 static void cerver_client_packet_handler (Packet *packet) {
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1825,7 +1825,7 @@ static void *cerver_receive_threads (void *cerver_receive_ptr) {
 	#endif
 
 	// set the socket's timeout to prevent thread from getting stuck if no more data to read
-	(void) sock_set_timeout (sock_fd, DEFAULT_SOCKET_RECV_TIMEOUT);
+	(void) sock_set_timeout (sock_fd, CERVER_DEFAULT_SOCKET_RECV_TIMEOUT);
 
 	const size_t buffer_size = cr->cerver->receive_buffer_size;
 	char *buffer = (char *) calloc (buffer_size, sizeof (char));

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -63,7 +63,7 @@ char *sock_ip_to_string (const struct sockaddr *address) {
 			switch (address->sa_family) {
 				case AF_INET:
 					inet_ntop (
-						AF_INET, 
+						AF_INET,
 						&((struct sockaddr_in *) address)->sin_addr,
 						retval, INET6_ADDRSTRLEN
 					);
@@ -71,7 +71,7 @@ char *sock_ip_to_string (const struct sockaddr *address) {
 
 				case AF_INET6:
 					inet_ntop (
-						AF_INET6, 
+						AF_INET6,
 						&((struct sockaddr_in6 *) address)->sin6_addr,
 						retval, INET6_ADDRSTRLEN
 					);
@@ -156,9 +156,26 @@ int sock_set_timeout (int sock_fd, time_t timeout) {
 	tv.tv_usec = 0;
 
 	return setsockopt (
-		sock_fd, 
-		SOL_SOCKET, SO_RCVTIMEO, 
+		sock_fd,
+		SOL_SOCKET, SO_RCVTIMEO,
 		(const char *) &tv, sizeof (struct timeval)
 	);
+
+}
+
+// sets the socket's reusable options
+// this should avoid errors when binding sockets
+// returns 0 on success, 1 on any error
+int sock_set_reusable (int sock_fd) {
+
+	int errors = 0;
+
+	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof (int));
+
+	#ifdef SO_REUSEPORT
+	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof (int));
+	#endif
+
+	return errors;
 
 }

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -1,9 +1,37 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <netdb.h>
+
+#include <arpa/inet.h>
+
+#include <sys/socket.h>
 #include <sys/time.h>
 
 #include "cerver/network.h"
+
+// gets the ip related to the hostname
+// returns a newly allocated c string if found
+// returns NULL on error or not found
+char *network_hostname_to_ip (
+	const char *hostname
+) {
+
+	char *retval = NULL;
+
+	struct hostent *he = gethostbyname (hostname);
+	if (he) {
+		struct in_addr **addr_list = (struct in_addr **) he->h_addr_list;
+		if (addr_list) {
+			if (inet_ntoa (*addr_list[0])) {
+				retval = strdup (*addr_list[0]);
+			}
+		}
+	}
+
+	return retval;
+
+}
 
 // enable/disable blocking on a socket
 // true on success, false if there was an error

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -1,23 +1,21 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <fcntl.h>
-
 #include <sys/time.h>
 
 #include "cerver/network.h"
 
 // enable/disable blocking on a socket
 // true on success, false if there was an error
-bool sock_set_blocking (int32_t fd, bool isBlocking) {
+bool sock_set_blocking (int32_t fd, bool blocking) {
 
 	bool retval = false;
 
 	if (fd >= 0) {
 		int flags = fcntl (fd, F_GETFL, 0);
 		if (flags >= 0) {
-			// flags = isBlocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK);   // original
-			flags = isBlocking ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK);
+			// flags = isBlocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK);
+			flags = blocking ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK);
 
 			retval = (fcntl (fd, F_SETFL, flags) == 0) ? true : false;
 		}
@@ -29,17 +27,17 @@ bool sock_set_blocking (int32_t fd, bool isBlocking) {
 
 char *sock_ip_to_string (const struct sockaddr *address) {
 
-	char *ipstr = NULL;
+	char *retval = NULL;
 
 	if (address) {
-		ipstr = (char *) calloc (INET6_ADDRSTRLEN, sizeof (char));
-		if (ipstr) {
+		retval = (char *) calloc (INET6_ADDRSTRLEN, sizeof (char));
+		if (retval) {
 			switch (address->sa_family) {
 				case AF_INET:
 					inet_ntop (
 						AF_INET, 
 						&((struct sockaddr_in *) address)->sin_addr,
-						ipstr, INET6_ADDRSTRLEN
+						retval, INET6_ADDRSTRLEN
 					);
 					break;
 
@@ -47,50 +45,54 @@ char *sock_ip_to_string (const struct sockaddr *address) {
 					inet_ntop (
 						AF_INET6, 
 						&((struct sockaddr_in6 *) address)->sin6_addr,
-						ipstr, INET6_ADDRSTRLEN
+						retval, INET6_ADDRSTRLEN
 					);
 					break;
 
 				default: {
-					free (ipstr);
-					ipstr = NULL;
+					free (retval);
+					retval = NULL;
 				} break;
 			}
 		}
 	}
 
-	return ipstr;
+	return retval;
 
 }
 
-bool sock_ip_equal (const struct sockaddr *a, const struct sockaddr *b) {
+bool sock_ip_equal (
+	const struct sockaddr *a, const struct sockaddr *b
+) {
+
+	bool retval = false;
 
 	if (a && b) {
-		if (a->sa_family != b->sa_family) return false;
+		if (a->sa_family == b->sa_family) {
+			switch (a->sa_family) {
+				case AF_INET: {
+					struct sockaddr_in *a_in = (struct sockaddr_in *) a;
+					struct sockaddr_in *b_in = (struct sockaddr_in *) b;
+					retval = a_in->sin_port == b_in->sin_port
+						&& a_in->sin_addr.s_addr == b_in->sin_addr.s_addr;
+				} break;
 
-		switch (a->sa_family) {
-			case AF_INET: {
-				struct sockaddr_in *a_in = (struct sockaddr_in *) a;
-				struct sockaddr_in *b_in = (struct sockaddr_in *) b;
-				return a_in->sin_port == b_in->sin_port
-					&& a_in->sin_addr.s_addr == b_in->sin_addr.s_addr;
+				case AF_INET6: {
+					struct sockaddr_in6 *a_in6 = (struct sockaddr_in6 *) a;
+					struct sockaddr_in6 *b_in6 = (struct sockaddr_in6 *) b;
+					retval = a_in6->sin6_port == b_in6->sin6_port
+						&& a_in6->sin6_flowinfo == b_in6->sin6_flowinfo
+						&& memcmp(a_in6->sin6_addr.s6_addr, b_in6->sin6_addr.s6_addr,
+								SOCK_SIZEOF_MEMBER (struct in6_addr, s6_addr)) == 0
+						&& a_in6->sin6_scope_id == b_in6->sin6_scope_id;
+				} break;
+
+				default: break;
 			}
-
-			case AF_INET6: {
-				struct sockaddr_in6 *a_in6 = (struct sockaddr_in6 *) a;
-				struct sockaddr_in6 *b_in6 = (struct sockaddr_in6 *) b;
-				return a_in6->sin6_port == b_in6->sin6_port
-					&& a_in6->sin6_flowinfo == b_in6->sin6_flowinfo
-					&& memcmp(a_in6->sin6_addr.s6_addr, b_in6->sin6_addr.s6_addr,
-							SOCK_SIZEOF_MEMBER (struct in6_addr, s6_addr)) == 0
-					&& a_in6->sin6_scope_id == b_in6->sin6_scope_id;
-			}
-
-			default: return false;
 		}
 	}
 
-	return false;
+	return retval;
 
 }
 
@@ -100,8 +102,13 @@ in_port_t sock_ip_port (const struct sockaddr *address) {
 
 	if (address) {
 		switch (address->sa_family) {
-			case AF_INET: retval = ntohs (((struct sockaddr_in *) address)->sin_port); break;
-			case AF_INET6: retval = ntohs (((struct sockaddr_in6 *) address)->sin6_port); break;
+			case AF_INET:
+				retval = ntohs (((struct sockaddr_in *) address)->sin_port);
+				break;
+			case AF_INET6:
+				retval = ntohs (((struct sockaddr_in6 *) address)->sin6_port);
+				break;
+
 			default: break;
 		}
 	}

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -170,10 +170,12 @@ int sock_set_reusable (int sock_fd) {
 
 	int errors = 0;
 
-	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof (int));
+	int reusable = 1;
+
+	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEADDR, &reusable, sizeof (int));
 
 	#ifdef SO_REUSEPORT
-	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof (int));
+	errors |= setsockopt (sock_fd, SOL_SOCKET, SO_REUSEPORT, &reusable, sizeof (int));
 	#endif
 
 	return errors;

--- a/src/cerver/network.c
+++ b/src/cerver/network.c
@@ -24,7 +24,7 @@ char *network_hostname_to_ip (
 		struct in_addr **addr_list = (struct in_addr **) he->h_addr_list;
 		if (addr_list) {
 			if (inet_ntoa (*addr_list[0])) {
-				retval = strdup (*addr_list[0]);
+				retval = strdup (inet_ntoa (*addr_list[0]));
 			}
 		}
 	}

--- a/src/cerver/packets.c
+++ b/src/cerver/packets.c
@@ -69,8 +69,11 @@ PacketVersion *packet_version_create (void) {
 void packet_version_print (PacketVersion *version) {
 
 	if (version) {
-		printf ("Protocol id: %d\n", version->protocol_id);
-		printf ("Protocol version: { %d - %d }\n", version->protocol_version.major, version->protocol_version.minor);
+		(void) printf ("Protocol id: %d\n", version->protocol_id);
+		(void) printf (
+			"Protocol version: { %d - %d }\n",
+			version->protocol_version.major, version->protocol_version.minor
+		);
 	}
 
 }
@@ -82,12 +85,19 @@ void packet_version_print (PacketVersion *version) {
 PacketsPerType *packets_per_type_new (void) {
 
 	PacketsPerType *packets_per_type = (PacketsPerType *) malloc (sizeof (PacketsPerType));
-	if (packets_per_type) memset (packets_per_type, 0, sizeof (PacketsPerType));
+	if (packets_per_type) {
+		(void) memset (packets_per_type, 0, sizeof (PacketsPerType));
+	}
+
 	return packets_per_type;
 
 }
 
-void packets_per_type_delete (void *ptr) { if (ptr) free (ptr); }
+void packets_per_type_delete (void *packets_per_type_ptr) {
+		
+	if (packets_per_type_ptr) free (packets_per_type_ptr);
+
+}
 
 void packets_per_type_print (PacketsPerType *packets_per_type) {
 
@@ -116,16 +126,22 @@ PacketHeader *packet_header_new (void) {
 
 	PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
 	if (header) {
-		memset (header, 0, sizeof (PacketHeader));
+		(void) memset (header, 0, sizeof (PacketHeader));
 	}
 
 	return header;
 
 }
 
-void packet_header_delete (PacketHeader *header) { if (header) free (header); }
+void packet_header_delete (PacketHeader *header) {
+	
+	if (header) free (header);
+	
+}
 
-PacketHeader *packet_header_create (PacketType packet_type, size_t packet_size, u32 req_type) {
+PacketHeader *packet_header_create (
+	PacketType packet_type, size_t packet_size, u32 req_type
+) {
 
 	PacketHeader *header = (PacketHeader *) malloc (sizeof (PacketHeader));
 	if (header) {
@@ -164,7 +180,7 @@ u8 packet_header_copy (PacketHeader **dest, PacketHeader *source) {
 	if (source) {
 		*dest = (PacketHeader *) malloc (sizeof (PacketHeader));
 		if (*dest) {
-			memcpy (*dest, source, sizeof (PacketHeader));
+			(void) memcpy (*dest, source, sizeof (PacketHeader));
 			retval = 0;
 		}
 	}
@@ -210,7 +226,9 @@ Packet *packet_new (void) {
 
 // create a new packet with the option to pass values directly
 // data is copied into packet buffer and can be safely freed
-Packet *packet_create (PacketType type, void *data, size_t data_size) {
+Packet *packet_create (
+	PacketType type, void *data, size_t data_size
+) {
 
 	Packet *packet = packet_new ();
 	if (packet) {
@@ -222,10 +240,10 @@ Packet *packet_create (PacketType type, void *data, size_t data_size) {
 
 }
 
-void packet_delete (void *ptr) {
+void packet_delete (void *packet_ptr) {
 
-	if (ptr) {
-		Packet *packet = (Packet *) ptr;
+	if (packet_ptr) {
+		Packet *packet = (Packet *) packet_ptr;
 
 		packet->cerver = NULL;
 		packet->client = NULL;
@@ -249,8 +267,12 @@ void packet_delete (void *ptr) {
 }
 
 // sets the pakcet destinatary is directed to and the protocol to use
-void packet_set_network_values (Packet *packet, Cerver *cerver,
-	Client *client, Connection *connection, Lobby *lobby) {
+void packet_set_network_values (
+	Packet *packet,
+	Cerver *cerver,
+	Client *client, Connection *connection,
+	Lobby *lobby
+) {
 
 	if (packet) {
 		packet->cerver = cerver;
@@ -263,11 +285,16 @@ void packet_set_network_values (Packet *packet, Cerver *cerver,
 
 // sets the packet's header
 // copies the header's values into the packet
-void packet_set_header (Packet *packet, PacketHeader *header) {
+void packet_set_header (
+	Packet *packet, PacketHeader *header
+) {
 
 	if (packet && header) {
-		if (!packet->header) packet->header = (PacketHeader *) malloc (sizeof (PacketHeader));
-		if (packet->header) memcpy (&packet->header, header, sizeof (PacketHeader));
+		if (!packet->header)
+			packet->header = (PacketHeader *) malloc (sizeof (PacketHeader));
+
+		if (packet->header)
+			(void) memcpy (&packet->header, header, sizeof (PacketHeader));
 	}
 
 }
@@ -297,7 +324,9 @@ void packet_set_header_values (
 // sets the data of the packet -> copies the data into the packet
 // if the packet had data before it is deleted and replaced with the new one
 // returns 0 on success, 1 on error
-u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
+u8 packet_set_data (
+	Packet *packet, void *data, size_t data_size
+) {
 
 	u8 retval = 1;
 
@@ -310,7 +339,7 @@ u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
 		packet->data_size = data_size;
 		packet->data = malloc (packet->data_size);
 		if (packet->data) {
-			memcpy (packet->data, data, data_size);
+			(void) memcpy (packet->data, data, data_size);
 			packet->data_end = (char *) packet->data;
 			packet->data_end += packet->data_size;
 
@@ -329,7 +358,9 @@ u8 packet_set_data (Packet *packet, void *data, size_t data_size) {
 // if the packet is empty, creates a new buffer
 // it creates a new copy of the data and the original can be safely freed
 // this does not work if the data has been set using a reference
-u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
+u8 packet_append_data (
+	Packet *packet, void *data, size_t data_size
+) {
 
 	u8 retval = 1;
 
@@ -343,7 +374,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 				packet->data_end += packet->data_size;
 
 				// copy the new buffer
-				memcpy (packet->data_end, data, data_size);
+				(void) memcpy (packet->data_end, data, data_size);
 				packet->data_end += data_size;
 
 				packet->data = new_data;
@@ -370,7 +401,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 			packet->data = malloc (packet->data_size);
 			if (packet->data) {
 				// copy the data to the packet data buffer
-				memcpy (packet->data, data, data_size);
+				(void) memcpy (packet->data, data, data_size);
 				packet->data_end = (char *) packet->data;
 				packet->data_end += packet->data_size;
 
@@ -398,7 +429,9 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 // data will not be copied into the packet and will not be freed after use
 // this method is usefull for example if you just want to send a raw json packet to a non-cerver
 // use this method with packet_send () with the raw flag on
-u8 packet_set_data_ref (Packet *packet, void *data, size_t data_size) {
+u8 packet_set_data_ref (
+	Packet *packet, void *data, size_t data_size
+) {
 
 	u8 retval = 1;
 
@@ -421,7 +454,9 @@ u8 packet_set_data_ref (Packet *packet, void *data, size_t data_size) {
 // sets a the packet's packet using by copying the passed data
 // deletes the previuos packet's packet
 // returns 0 on succes, 1 on error
-u8 packet_set_packet (Packet *packet, void *data, size_t data_size) {
+u8 packet_set_packet (
+	Packet *packet, void *data, size_t data_size
+) {
 
 	u8 retval = 1;
 
@@ -433,7 +468,7 @@ u8 packet_set_packet (Packet *packet, void *data, size_t data_size) {
 		packet->packet_size = data_size;
 		packet->packet = malloc (packet->packet_size);
 		if (packet->packet) {
-			memcpy (packet->packet, data, data_size);
+			(void) memcpy (packet->packet, data, data_size);
 
 			retval = 0;
 		}
@@ -446,7 +481,9 @@ u8 packet_set_packet (Packet *packet, void *data, size_t data_size) {
 // sets a reference to a data buffer to send as the packet
 // data will not be copied into the packet and will not be freed after use
 // usefull when you need to generate your own cerver type packet by hand
-u8 packet_set_packet_ref (Packet *packet, void *data, size_t packet_size) {
+u8 packet_set_packet_ref (
+	Packet *packet, void *data, size_t packet_size
+) {
 
 	u8 retval = 1;
 
@@ -487,11 +524,11 @@ u8 packet_generate (Packet *packet) {
 		packet->packet = malloc (packet->packet_size);
 		if (packet->packet) {
 			char *end = (char *) packet->packet;
-			memcpy (end, packet->header, sizeof (PacketHeader));
+			(void) memcpy (end, packet->header, sizeof (PacketHeader));
 
 			if (packet->data_size > 0) {
 				end += sizeof (PacketHeader);
-				memcpy (end, packet->data, packet->data_size);
+				(void) memcpy (end, packet->data, packet->data_size);
 			}
 
 			retval = 0;
@@ -535,7 +572,9 @@ Packet *packet_generate_request (
 }
 
 static inline u8 packet_send_tcp_actual (
-	const Packet *packet, Connection *connection, int flags, size_t *total_sent, bool raw
+	const Packet *packet,
+	Connection *connection,
+	int flags, size_t *total_sent, bool raw
 ) {
 
 	ssize_t sent = 0;
@@ -561,16 +600,20 @@ static inline u8 packet_send_tcp_actual (
 // sends a packet directly using the tcp protocol and the packet sock fd
 // returns 0 on success, 1 on error
 static u8 packet_send_tcp (
-	const Packet *packet, Connection *connection, int flags, size_t *total_sent, bool raw
+	const Packet *packet,
+	Connection *connection,
+	int flags, size_t *total_sent, bool raw
 ) {
 
 	u8 retval = 1;
 
-	pthread_mutex_lock (connection->socket->write_mutex);
+	(void) pthread_mutex_lock (connection->socket->write_mutex);
 
-	retval = packet_send_tcp_actual (packet, connection, flags, total_sent, raw);
+	retval = packet_send_tcp_actual (
+		packet, connection, flags, total_sent, raw
+	);
 
-	pthread_mutex_unlock (connection->socket->write_mutex);
+	(void) pthread_mutex_unlock (connection->socket->write_mutex);
 
 	return retval;
 
@@ -578,12 +621,16 @@ static u8 packet_send_tcp (
 
 // sends a packet to the socket in two parts, first the header & then the data
 // returns 0 on success, 1 on error
-static u8 packet_send_split_tcp (const Packet *packet, Connection *connection, int flags, size_t *total_sent) {
+static u8 packet_send_split_tcp (
+	const Packet *packet,
+	Connection *connection,
+	int flags, size_t *total_sent
+) {
 
 	u8 retval = 1;
 
 	if (packet && connection) {
-		pthread_mutex_lock (connection->socket->write_mutex);
+		(void) pthread_mutex_lock (connection->socket->write_mutex);
 
 		size_t actual_sent = 0;
 
@@ -625,7 +672,7 @@ static u8 packet_send_split_tcp (const Packet *packet, Connection *connection, i
 			retval = 0;
 		}
 
-		pthread_mutex_unlock (connection->socket->write_mutex);
+		(void) pthread_mutex_unlock (connection->socket->write_mutex);
 	}
 
 	return retval;
@@ -645,7 +692,9 @@ static u8 packet_send_udp (const void *packet, size_t packet_size) {
 
 static void packet_send_update_stats (
 	PacketType packet_type, size_t sent,
-	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+	Cerver *cerver,
+	Client *client, Connection *connection,
+	Lobby *lobby
 ) {
 
 	if (cerver) {
@@ -753,7 +802,9 @@ static inline u8 packet_send_internal (
 	const Packet *packet,
 	int flags, size_t *total_sent,
 	bool raw, bool split, bool unsafe,
-	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+	Cerver *cerver,
+	Client *client, Connection *connection,
+	Lobby *lobby
 ) {
 
 	u8 retval = 1;
@@ -779,9 +830,9 @@ static inline u8 packet_send_internal (
 
 				else {
 					#ifdef PACKETS_DEBUG
-					printf ("\n");
+					(void) printf ("\n");
 					perror ("packet_send_internal () - Error");
-					printf ("\n");
+					(void) printf ("\n");
 					#endif
 
 					if (cerver) cerver->stats->sent_packets->n_bad_packets += 1;
@@ -806,7 +857,9 @@ static inline u8 packet_send_internal (
 // sends a packet using its network values
 // raw flag to send a raw packet (only the data that was set to the packet, without any header)
 // returns 0 on success, 1 on error
-u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw) {
+u8 packet_send (
+	const Packet *packet, int flags, size_t *total_sent, bool raw
+) {
 
 	return packet_send_internal (
 		packet, flags, total_sent,
@@ -819,7 +872,9 @@ u8 packet_send (const Packet *packet, int flags, size_t *total_sent, bool raw) {
 // works just as packet_send () but the socket's write mutex won't be locked
 // useful when you need to lock the mutex manually
 // returns 0 on success, 1 on error
-u8 packet_send_unsafe (const Packet *packet, int flags, size_t *total_sent, bool raw) {
+u8 packet_send_unsafe (
+	const Packet *packet, int flags, size_t *total_sent, bool raw
+) {
 
 	return packet_send_internal (
 		packet, flags, total_sent,
@@ -837,7 +892,9 @@ u8 packet_send_unsafe (const Packet *packet, int flags, size_t *total_sent, bool
 u8 packet_send_to (
 	const Packet *packet,
 	size_t *total_sent, bool raw,
-	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+	Cerver *cerver,
+	Client *client, Connection *connection,
+	Lobby *lobby
 ) {
 
 	return packet_send_internal (
@@ -854,7 +911,9 @@ u8 packet_send_to (
 // the socket's write mutex will be locked to ensure that the packet
 // is sent correctly and to avoid race conditions
 // returns 0 on success, 1 on error
-u8 packet_send_split (const Packet *packet, int flags, size_t *total_sent) {
+u8 packet_send_split (
+	const Packet *packet, int flags, size_t *total_sent
+) {
 
 	return packet_send_internal (
 		packet, flags, total_sent,
@@ -870,7 +929,9 @@ u8 packet_send_split (const Packet *packet, int flags, size_t *total_sent) {
 u8 packet_send_to_split (
 	const Packet *packet,
 	size_t *total_sent,
-	Cerver *cerver, Client *client, Connection *connection, Lobby *lobby
+	Cerver *cerver,
+	Client *client, Connection *connection,
+	Lobby *lobby
 ) {
 
 	return packet_send_internal (
@@ -922,7 +983,7 @@ u8 packet_send_pieces (
 	u8 retval = 1;
 
 	if (packet && pieces && sizes) {
-		pthread_mutex_lock (packet->connection->socket->write_mutex);
+		(void) pthread_mutex_lock (packet->connection->socket->write_mutex);
 
 		size_t actual_sent = 0;
 
@@ -953,7 +1014,7 @@ u8 packet_send_pieces (
 
 		if (total_sent) *total_sent = actual_sent;
 
-		pthread_mutex_unlock (packet->connection->socket->write_mutex);
+		(void) pthread_mutex_unlock (packet->connection->socket->write_mutex);
 	}
 
 	return retval;
@@ -975,7 +1036,7 @@ u8 packet_send_to_socket (
 		const char *p = raw ? (char *) packet->data : (char *) packet->packet;
 		size_t packet_size = raw ? packet->data_size : packet->packet_size;
 
-		pthread_mutex_lock (socket->write_mutex);
+		(void) pthread_mutex_lock (socket->write_mutex);
 
 		while (packet_size > 0) {
 			sent = send (socket->sock_fd, p, packet_size, flags);
@@ -990,7 +1051,7 @@ u8 packet_send_to_socket (
 
 		if (total_sent) *total_sent = (size_t) sent;
 
-		pthread_mutex_unlock (socket->write_mutex);
+		(void) pthread_mutex_unlock (socket->write_mutex);
 	}
 
 	return retval;


### PR DESCRIPTION
## General
- Added THREAD_NAME_BUFFER_LEN definition in main threads header
- Refactored packets methods organization
- Added base network_hostname_to_ip ()
- Added base sock_set_reusable () to set socket's reusable flags

## Clients
- Refactored client header & sources organization
- Added base client connections status definitions
- Refactored client_remove_connection () to use ClientConnectionsStatus

## Handler
- Removed original cerver_receive () as it will not be needed anymore
- Refactored cerver_receive_handle_buffer () to be used in one thread
- Removed sock receive check & mutex locks in receive_handle_buffer ()
- Removed extra check in cerver_receive_handle_spare_packet ()
- Passing received size to cerver_receive related methods & structures
- Removed checks for buffer & size in cerver_receive_handle_buffer ()
- Replaced buffer_size with received_size in receive_handle_buffer ()
- Added base main handler errors definitions
- Refactored main cerver handler methods to use CerverHandlerError

## Auth
- Changed auth header indentation from spaces to tabs
- Added ability to set cerver's on hold receive buffer size
- Refactored on hold poll to use a constant buffer to handle receives
- Added auth errors definitions to be used in internal auth methods

## Admins
- Added the ability to set a custom admin cerver receive buffer size
- Refactored admin poll methods to be used in just one thread
- Added base admin cerver handler errors definitions
- Added base admin connections status definitions
- Fixed return value in auth_with_token_normal ()