### PR TITLE
Beta 1.6.3b-6

### DIFF
--- a/examples/auth.c
+++ b/examples/auth.c
@@ -334,8 +334,13 @@ int main (void) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		// cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_reusable_address_flags (my_cerver, true);
+
 		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_THREADS);
 		cerver_set_handle_detachable_threads (my_cerver, true);
+
+		// cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
+		// cerver_set_poll_time_out (my_cerver, 2000);
 
 		Handler *app_handler = handler_create (handler);
 		handler_set_direct_handle (app_handler, true);

--- a/examples/test.c
+++ b/examples/test.c
@@ -213,6 +213,8 @@ int main (int argc, char **argv) {
 		cerver_set_receive_buffer_size (my_cerver, 4096);
 		cerver_set_thpool_n_threads (my_cerver, 4);
 
+		cerver_set_reusable_address_flags (my_cerver, true);
+
 		cerver_set_handler_type (my_cerver, CERVER_HANDLER_TYPE_POLL);
 		cerver_set_poll_time_out (my_cerver, 2000);
 

--- a/include/cerver/admin.h
+++ b/include/cerver/admin.h
@@ -41,20 +41,20 @@ struct _AdminCerver;
 
 struct _AdminCerverStats {
 
-	time_t threshold_time;                          // every time we want to reset cerver stats (like packets), defaults 24hrs
+	time_t threshold_time;				// every time we want to reset cerver stats (like packets), defaults 24hrs
 
-	u64 total_n_packets_received;                   // total number of packets received (packet header + data)
-	u64 total_n_receives_done;                      // total amount of actual calls to recv ()
-	u64 total_bytes_received;                       // total amount of bytes received in the cerver
+	u64 total_n_packets_received;		// total number of packets received (packet header + data)
+	u64 total_n_receives_done;			// total amount of actual calls to recv ()
+	u64 total_bytes_received;			// total amount of bytes received in the cerver
 
-	u64 total_n_packets_sent;                       // total number of packets that were sent
-	u64 total_bytes_sent;                           // total amount of bytes sent by the cerver
+	u64 total_n_packets_sent;			// total number of packets that were sent
+	u64 total_bytes_sent;				// total amount of bytes sent by the cerver
 
-	u64 current_connections;      					// all of the current active connections from all the admins (registered in the poll array)
-	u64 current_connected_admins;            		// the current number of auth admins connected (unique clients)
+	u64 current_connections;			// all of the current active connections from all the admins (registered in the poll array)
+	u64 current_connected_admins;		// the current number of auth admins connected (unique clients)
 
-	u64 total_admin_connections;                   	// the total amount of admin connections that have been done to the cerver
-	u64 total_n_admins;                            	// the total amount of admins that were registered to the cerver
+	u64 total_admin_connections;		// the total amount of admin connections that have been done to the cerver
+	u64 total_n_admins;					// the total amount of admins that were registered to the cerver
 
 	struct _PacketsPerType *received_packets;
 	struct _PacketsPerType *sent_packets;
@@ -97,15 +97,15 @@ struct _Admin {
 
 	struct _AdminCerver *admin_cerver;
 
-	String *id;						// unique admin identifier
+	String *id;					// unique admin identifier
 
-	struct _Client *client;				// network values for the admin
+	struct _Client *client;		// network values for the admin
 
 	// a place to store dedicated admin data
 	void *data;
 	Action delete_data;
 
-	u32 bad_packets;					// disconnect after a number of bad packets
+	u32 bad_packets;			// disconnect after a number of bad packets
 
 };
 
@@ -177,7 +177,7 @@ struct _AdminCerver {
 
 	DoubleList *admins;					// connected admins to the cerver
 
-	delegate authenticate;              // authentication method
+	delegate authenticate;				// authentication method
 
 	u8 max_admins;						// the max numbers of admins allowed at any time
 	u8 max_admin_connections;			// the max number of connections allowed per admin

--- a/include/cerver/cerver.h
+++ b/include/cerver/cerver.h
@@ -31,7 +31,11 @@
 #define CERVER_DEFAULT_PROTOCOL						PROTOCOL_TCP
 #define CERVER_DEFAULT_USE_IPV6						false
 #define CERVER_DEFAULT_CONNECTION_QUEUE				10
+
 #define CERVER_DEFAULT_RECEIVE_BUFFER_SIZE			4096
+
+#define CERVER_DEFAULT_REUSABLE_FLAGS				false
+
 #define CERVER_DEFAULT_POOL_THREADS					4
 
 #define CERVER_DEFAULT_SOCKETS_INIT					10
@@ -214,6 +218,7 @@ struct _Cerver {
 
 	bool isRunning;                     // the server is recieving and/or sending packetss
 	bool blocking;                      // sokcet fd is blocking?
+	bool reusable;						// socket fd with reusable flags?
 
 	void *cerver_data;
 	Action delete_cerver_data;
@@ -347,6 +352,13 @@ CERVER_EXPORT void cerver_set_connection_queue (
 // sets the cerver's receive buffer size used in recv method
 CERVER_EXPORT void cerver_set_receive_buffer_size (
 	Cerver *cerver, const u32 size
+);
+
+// sets the cerver's ability to use reusable flags in sock fd
+// if TRUE, this can prevent failing when trying to bind address
+// the default value is CERVER_DEFAULT_REUSABLE_FLAGS
+CERVER_EXPORT void cerver_set_reusable_address_flags (
+	Cerver *cerver, bool value
 );
 
 // sets the cerver's data and a way to free it

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -268,7 +268,9 @@ CERVER_PRIVATE CerverReceive *cerver_receive_create_full (
 	struct _Client *client, struct _Connection *connection
 );
 
-CERVER_PRIVATE void cerver_switch_receive_handle_failed (
+// handles a failed receive from a connection associatd with a client
+// ends the connection to prevent seg faults or signals for bad sock fd
+CERVER_PRIVATE void cerver_receive_handle_failed (
 	CerverReceive *cr
 );
 

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -283,6 +283,12 @@ CERVER_PRIVATE void cerver_receive_internal (
 
 #pragma region register
 
+// select how client connection will be handled based on cerver's handler type
+CERVER_PRIVATE u8 cerver_register_new_connection_normal_default_select_handler (
+	struct _Cerver *cerver,
+	struct _Client *client, struct _Connection *connection
+);
+
 // select how a connection will be handled
 // based on cerver's handler type
 // returns 0 on success, 1 on error

--- a/include/cerver/handler.h
+++ b/include/cerver/handler.h
@@ -283,11 +283,12 @@ CERVER_PRIVATE void cerver_receive_internal (
 
 #pragma region register
 
-// select how client connection will be handled based on cerver's handler type
-CERVER_PRIVATE u8 cerver_register_new_connection_normal_default_select_handler (
+// select how a connection will be handled
+// based on cerver's handler type
+// returns 0 on success, 1 on error
+CERVER_PRIVATE u8 cerver_handler_register_connection (
 	struct _Cerver *cerver,
-	struct _Client *client,
-	struct _Connection *connection
+	struct _Client *client, struct _Connection *connection
 );
 
 #pragma endregion

--- a/include/cerver/version.h
+++ b/include/cerver/version.h
@@ -3,10 +3,10 @@
 
 #include "cerver/config.h"
 
-#define CERVER_VERSION                  "1.6.3b-5"
-#define CERVER_VERSION_NAME             "Beta 1.6.3b-5"
-#define CERVER_VERSION_DATE			    "24/12/2020"
-#define CERVER_VERSION_TIME			    "20:29 CST"
+#define CERVER_VERSION                  "1.6.3b-6"
+#define CERVER_VERSION_NAME             "Beta 1.6.3b-6"
+#define CERVER_VERSION_DATE			    "25/12/2020"
+#define CERVER_VERSION_TIME			    "16:04 CST"
 #define CERVER_VERSION_AUTHOR			"Erick Salas"
 
 // print full cerver version information 

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -935,7 +935,9 @@ u8 admin_cerver_register_admin (
 			admin_cerver,
 			(Connection *) dlist_start (admin->client->connections)->data
 		)) {
-			dlist_insert_after (admin_cerver->admins, dlist_end (admin_cerver->admins), admin);
+			(void) dlist_insert_after (
+				admin_cerver->admins, dlist_end (admin_cerver->admins), admin
+			);
 
 			admin->admin_cerver = admin_cerver;
 
@@ -946,7 +948,8 @@ u8 admin_cerver_register_admin (
 			cerver_log (
 				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
 				"Cerver %s ADMIN current connected admins: %ld",
-				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+				admin_cerver->cerver->info->name->str,
+				admin_cerver->stats->current_connected_admins
 			);
 			#endif
 
@@ -981,7 +984,8 @@ u8 admin_cerver_unregister_admin (
 			cerver_log (
 				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
 				"Cerver %s ADMIN current connected admins: %ld",
-				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connected_admins
+				admin_cerver->cerver->info->name->str,
+				admin_cerver->stats->current_connected_admins
 			);
 			#endif
 
@@ -1942,7 +1946,7 @@ u8 admin_cerver_poll_register_connection (
 	u8 retval = 1;
 
 	if (admin_cerver && connection) {
-		pthread_mutex_lock (admin_cerver->poll_lock);
+		(void) pthread_mutex_lock (admin_cerver->poll_lock);
 
 		i32 idx = admin_cerver_poll_get_free_idx (admin_cerver);
 		if (idx >= 0) {
@@ -1957,7 +1961,8 @@ u8 admin_cerver_poll_register_connection (
 			cerver_log (
 				LOG_TYPE_DEBUG, LOG_TYPE_ADMIN,
 				"Added sock fd <%d> to cerver %s ADMIN poll, idx: %i",
-				connection->socket->sock_fd, admin_cerver->cerver->info->name->str, idx
+				connection->socket->sock_fd,
+				admin_cerver->cerver->info->name->str, idx
 			);
 			#endif
 
@@ -1965,7 +1970,8 @@ u8 admin_cerver_poll_register_connection (
 			cerver_log (
 				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
 				"Cerver %s ADMIN current connections: %ld",
-				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+				admin_cerver->cerver->info->name->str,
+				admin_cerver->stats->current_connections
 			);
 			#endif
 
@@ -1982,7 +1988,7 @@ u8 admin_cerver_poll_register_connection (
 			#endif
 		}
 
-		pthread_mutex_unlock (admin_cerver->poll_lock);
+		(void) pthread_mutex_unlock (admin_cerver->poll_lock);
 	}
 
 	return retval;
@@ -1998,7 +2004,7 @@ u8 admin_cerver_poll_unregister_sock_fd (
 	u8 retval = 1;
 
 	if (admin_cerver) {
-		pthread_mutex_lock (admin_cerver->poll_lock);
+		(void) pthread_mutex_lock (admin_cerver->poll_lock);
 
 		i32 idx = admin_cerver_poll_get_idx_by_sock_fd (admin_cerver, sock_fd);
 		if (idx >= 0) {
@@ -2020,7 +2026,8 @@ u8 admin_cerver_poll_unregister_sock_fd (
 			cerver_log (
 				LOG_TYPE_CERVER, LOG_TYPE_ADMIN,
 				"Cerver %s ADMIN current connections: %ld",
-				admin_cerver->cerver->info->name->str, admin_cerver->stats->current_connections
+				admin_cerver->cerver->info->name->str,
+				admin_cerver->stats->current_connections
 			);
 			#endif
 
@@ -2037,7 +2044,7 @@ u8 admin_cerver_poll_unregister_sock_fd (
 			// #endif
 		}
 
-		pthread_mutex_unlock (admin_cerver->poll_lock);
+		(void) pthread_mutex_unlock (admin_cerver->poll_lock);
 	}
 
 	return retval;

--- a/src/cerver/admin.c
+++ b/src/cerver/admin.c
@@ -2080,7 +2080,7 @@ static inline void admin_poll_handle (
 
 					default: {
 						if (admin_cerver->fds[idx].revents != 0) {
-							cerver_switch_receive_handle_failed (cr);
+							cerver_receive_handle_failed (cr);
 						}
 					} break;
 				}

--- a/src/cerver/auth.c
+++ b/src/cerver/auth.c
@@ -1265,7 +1265,7 @@ static inline void on_hold_poll_handle (
 
 					default: {
 						if (cerver->hold_fds[idx].revents != 0) {
-							cerver_switch_receive_handle_failed (cr);
+							cerver_receive_handle_failed (cr);
 						}
 					} break;
 				}

--- a/src/cerver/cerver.c
+++ b/src/cerver/cerver.c
@@ -300,6 +300,7 @@ Cerver *cerver_new (void) {
 
 		cerver->isRunning = false;
 		cerver->blocking = true;
+		cerver->reusable = CERVER_DEFAULT_REUSABLE_FLAGS;
 
 		cerver->cerver_data = NULL;
 		cerver->delete_cerver_data = NULL;
@@ -496,6 +497,17 @@ void cerver_set_receive_buffer_size (
 ) {
 
 	if (cerver) cerver->receive_buffer_size = size;
+
+}
+
+// sets the cerver's ability to use reusable flags in sock fd
+// if TRUE, this can prevent failing when trying to bind address
+// the default value is CERVER_DEFAULT_REUSABLE_FLAGS
+void cerver_set_reusable_address_flags (
+	Cerver *cerver, bool value
+) {
+
+	if (cerver) cerver->reusable = value;
 
 }
 
@@ -1247,7 +1259,7 @@ static u8 cerver_network_init_address (Cerver *cerver) {
 
 	u8 retval = 1;
 
-	memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
+	(void) memset (&cerver->address, 0, sizeof (struct sockaddr_storage));
 
 	if (cerver->use_ipv6) {
 		struct sockaddr_in6 *addr = (struct sockaddr_in6 *) &cerver->address;
@@ -1263,14 +1275,28 @@ static u8 cerver_network_init_address (Cerver *cerver) {
 		addr->sin_port = htons (cerver->port);
 	}
 
-	if (!bind (cerver->sock, (const struct sockaddr *) &cerver->address, sizeof (struct sockaddr_storage))) {
+	if (cerver->reusable) {
+		if (sock_set_reusable (cerver->sock)) {
+			cerver_log (
+				LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+				"Failed to set cerver's sock fd reusable falgs"
+			);
+		}
+	}
+
+	if (!bind (
+		cerver->sock,
+		(const struct sockaddr *) &cerver->address,
+		sizeof (struct sockaddr_storage))
+	) {
 		retval = 0;       // success!!
 	}
 
 	else {
 		cerver_log (
 			LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-			"Failed to bind cerver %s socket!", cerver->info->name->str
+			"Failed to bind cerver %s socket!",
+			cerver->info->name->str
 		);
 
 		close (cerver->sock);
@@ -1331,15 +1357,26 @@ static u8 cerver_network_init (Cerver *cerver) {
 	if (cerver) {
 		// init the cerver with the selected protocol
 		switch (cerver->protocol) {
-			case IPPROTO_TCP:
-				cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_STREAM, 0);
-				break;
+			case IPPROTO_TCP: {
+				cerver->sock = socket (
+					(cerver->use_ipv6 ? AF_INET6 : AF_INET),
+					SOCK_STREAM, 0
+				);
+			} break;
 
-			case IPPROTO_UDP:
-				cerver->sock = socket ((cerver->use_ipv6 ? AF_INET6 : AF_INET), SOCK_DGRAM, 0);
-				break;
+			case IPPROTO_UDP: {
+				cerver->sock = socket (
+					(cerver->use_ipv6 ? AF_INET6 : AF_INET),
+					SOCK_DGRAM, 0
+				);
+			} break;
 
-			default: cerver_log (LOG_TYPE_ERROR, LOG_TYPE_CERVER, "Unknown protocol type!"); break;
+			default: 
+				cerver_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+					"Unknown protocol type!"
+				);
+				break;
 		}
 
 		if (cerver->sock >= 0) {
@@ -1360,7 +1397,8 @@ static u8 cerver_network_init (Cerver *cerver) {
 		else {
 			cerver_log (
 				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
-				"Failed to create cerver %s socket!", cerver->info->name->str
+				"Failed to create cerver %s socket!",
+				cerver->info->name->str
 			);
 		}
 	}

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -2395,7 +2395,7 @@ static u8 cerver_register_new_connection_normal_default_select_handler_threads (
 }
 
 // select how client connection will be handled based on cerver's handler type
-static u8 cerver_register_new_connection_normal_default_select_handler (
+u8 cerver_register_new_connection_normal_default_select_handler (
 	Cerver *cerver, Client *client, Connection *connection
 ) {
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -2171,7 +2171,9 @@ static Connection *cerver_connection_create (Cerver *cerver,
 }
 
 // if the cerver requires auth, we put the connection on hold
-static u8 cerver_register_new_connection_auth_required (Cerver *cerver, Connection *connection) {
+static u8 cerver_register_new_connection_auth_required (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -2210,7 +2212,9 @@ static u8 cerver_register_new_connection_auth_required (Cerver *cerver, Connecti
 
 }
 
-static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection *connection) {
+static u8 cerver_register_new_connection_normal_web (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -2225,7 +2229,8 @@ static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection 
 			#ifdef HANDLER_DEBUG
 			cerver_log (
 				LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
-				"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
+				"Cerver %s thpool is full! "
+				"Creating a detachable thread for sock fd <%d> connection...",
 				cerver->info->name->str, connection->socket->sock_fd
 			);
 			#endif
@@ -2240,7 +2245,11 @@ static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection 
 			}
 
 			else {
-				cerver_log_error ("cerver_register_new_connection_normal_web () - failed to create detachable thread!");
+				cerver_log_error (
+					"cerver_register_new_connection_normal_web () - "
+					"failed to create detachable thread!"
+				);
+
 				cerver_receive_delete (cr);
 			}
 		}
@@ -2280,7 +2289,9 @@ static u8 cerver_register_new_connection_normal_web (Cerver *cerver, Connection 
 
 }
 
-static u8 cerver_register_new_connection_normal_default_create_detachable (CerverReceive *cr) {
+static u8 cerver_register_new_connection_normal_default_create_detachable (
+	CerverReceive *cr
+) {
 
 	u8 retval = 1;
 
@@ -2303,7 +2314,8 @@ static u8 cerver_register_new_connection_normal_default_create_detachable (Cerve
 
 	else {
 		cerver_log_error (
-			"cerver_register_new_connection_normal_default () - Failed to create detachable thread for sock fd <%d> connection!",
+			"cerver_register_new_connection_normal_default () - "
+			"Failed to create detachable thread for sock fd <%d> connection!",
 			cr->connection->socket->sock_fd
 		);
 
@@ -2337,7 +2349,8 @@ static u8 cerver_register_new_connection_normal_default_select_handler_threads (
 				#ifdef HANDLER_DEBUG
 				cerver_log (
 					LOG_TYPE_DEBUG, LOG_TYPE_HANDLER,
-					"Cerver %s thpool is full! Creating a detachable thread for sock fd <%d> connection...",
+					"Cerver %s thpool is full! "
+					"Creating a detachable thread for sock fd <%d> connection...",
 					cerver->info->name->str, connection->socket->sock_fd
 				);
 				#endif
@@ -2382,7 +2395,7 @@ static u8 cerver_register_new_connection_normal_default_select_handler_threads (
 }
 
 // select how client connection will be handled based on cerver's handler type
-u8 cerver_register_new_connection_normal_default_select_handler (
+static u8 cerver_register_new_connection_normal_default_select_handler (
 	Cerver *cerver, Client *client, Connection *connection
 ) {
 
@@ -2411,7 +2424,9 @@ u8 cerver_register_new_connection_normal_default_select_handler (
 
 }
 
-static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connection *connection) {
+static u8 cerver_register_new_connection_normal_default (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -2441,7 +2456,8 @@ static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connect
 
 	else {
 		cerver_log_error (
-			"cerver_register_new_connection_normal_default () - Failed to create new client for new connection with sock fd <%d>!",
+			"cerver_register_new_connection_normal_default () - "
+			"Failed to create new client for new connection with sock fd <%d>!",
 			connection->socket->sock_fd
 		);
 	}
@@ -2450,17 +2466,23 @@ static u8 cerver_register_new_connection_normal_default (Cerver *cerver, Connect
 
 }
 
-static u8 cerver_register_new_connection_normal (Cerver *cerver, Connection *connection) {
+static u8 cerver_register_new_connection_normal (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
 	switch (cerver->type) {
 		case CERVER_TYPE_WEB: {
-			retval = cerver_register_new_connection_normal_web (cerver, connection);
+			retval = cerver_register_new_connection_normal_web (
+				cerver, connection
+			);
 		} break;
 
 		default: {
-			retval = cerver_register_new_connection_normal_default (cerver, connection);
+			retval = cerver_register_new_connection_normal_default (
+				cerver, connection
+			);
 		} break;
 	}
 
@@ -2468,7 +2490,9 @@ static u8 cerver_register_new_connection_normal (Cerver *cerver, Connection *con
 
 }
 
-static inline u8 cerver_register_new_connection_select (Cerver *cerver, Connection *connection) {
+static inline u8 cerver_register_new_connection_select (
+	Cerver *cerver, Connection *connection
+) {
 
 	return cerver->auth_required ?
 		cerver_register_new_connection_auth_required (cerver, connection) :
@@ -2505,7 +2529,8 @@ static void cerver_register_new_connection (
 		// internal server error - failed to handle the new connection
 		else {
 			cerver_log_error (
-				"cerver_register_new_connection () - internal error - dropping sock fd <%d> connection...",
+				"cerver_register_new_connection () "
+				"- internal error - dropping sock fd <%d> connection...",
 				connection->socket->sock_fd
 			);
 
@@ -2514,6 +2539,7 @@ static void cerver_register_new_connection (
 	}
 
 	else {
+		// FIXME: close the socket and cleanup
 		// #ifdef CERVER_DEBUG
 		cerver_log (
 			LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
@@ -2556,6 +2582,45 @@ static void cerver_accept (void *cerver_ptr) {
 
 #pragma endregion
 
+#pragma region register
+
+// select how a connection will be handled
+// based on cerver's handler type
+// returns 0 on success, 1 on error
+u8 cerver_handler_register_connection (
+	Cerver *cerver, Client *client, Connection *connection
+) {
+
+	u8 retval = 1;
+
+	if (cerver && connection) {
+		switch (cerver->handler_type) {
+			case CERVER_HANDLER_TYPE_NONE: break;
+
+			// handle connection using the cerver's poll
+			case CERVER_HANDLER_TYPE_POLL: {
+				retval = cerver_poll_register_connection (
+					cerver, connection
+				);
+			} break;
+
+			// handle connection in dedicated thread
+			case CERVER_HANDLER_TYPE_THREADS: {
+				retval = cerver_register_new_connection_normal_default_select_handler_threads (
+					cerver, client, connection
+				);
+			} break;
+
+			default: break;
+		}
+	}
+
+	return retval;
+
+}
+
+#pragma endregion
+
 #pragma region poll
 
 // reallocs main cerver poll fds
@@ -2567,7 +2632,10 @@ u8 cerver_realloc_main_poll_fds (Cerver *cerver) {
 	if (cerver) {
 		u32 current_max = cerver->max_n_fds;
 		cerver->max_n_fds *= 2;
-		cerver->fds = (struct pollfd *) realloc (cerver->fds, cerver->max_n_fds * sizeof (struct pollfd));
+		cerver->fds = (struct pollfd *) realloc (
+			cerver->fds, cerver->max_n_fds * sizeof (struct pollfd)
+		);
+
 		if (cerver->fds) {
 			#pragma GCC diagnostic push
 			#pragma GCC diagnostic ignored "-Wunused-value"
@@ -2609,7 +2677,9 @@ i32 cerver_poll_get_idx_by_sock_fd (Cerver *cerver, i32 sock_fd) {
 
 }
 
-static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *connection) {
+static u8 cerver_poll_register_connection_internal (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
@@ -2633,7 +2703,8 @@ static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *
 		cerver_log (
 			LOG_TYPE_CERVER, LOG_TYPE_NONE,
 			"Cerver %s current active connections: %ld",
-			cerver->info->name->str, cerver->stats->current_active_client_connections
+			cerver->info->name->str,
+			cerver->stats->current_active_client_connections
 		);
 		#endif
 
@@ -2647,14 +2718,18 @@ static u8 cerver_poll_register_connection_internal (Cerver *cerver, Connection *
 // regsiters a client connection to the cerver's mains poll structure
 // and maps the sock fd to the client
 // returns 0 on success, 1 on error
-u8 cerver_poll_register_connection (Cerver *cerver, Connection *connection) {
+u8 cerver_poll_register_connection (
+	Cerver *cerver, Connection *connection
+) {
 
 	u8 retval = 1;
 
 	if (cerver && connection) {
 		pthread_mutex_lock (cerver->poll_lock);
 
-		if (!cerver_poll_register_connection_internal (cerver, connection)) {
+		if (!cerver_poll_register_connection_internal (
+			cerver, connection
+		)) {
 			retval = 0;
 		}
 
@@ -2677,7 +2752,9 @@ u8 cerver_poll_register_connection (Cerver *cerver, Connection *connection) {
 
 			// try again to register the connection
 			else {
-				retval = cerver_poll_register_connection_internal (cerver, connection);
+				retval = cerver_poll_register_connection_internal (
+					cerver, connection
+				);
 			}
 		}
 
@@ -2718,7 +2795,8 @@ u8 cerver_poll_unregister_sock_fd (Cerver *cerver, const i32 sock_fd) {
 			cerver_log (
 				LOG_TYPE_CERVER, LOG_TYPE_NONE,
 				"Cerver %s current active connections: %ld",
-				cerver->info->name->str, cerver->stats->current_active_client_connections
+				cerver->info->name->str,
+				cerver->stats->current_active_client_connections
 			);
 			#endif
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -1269,96 +1269,102 @@ CerverReceive *cerver_receive_new (void) {
 
 void cerver_receive_delete (void *ptr) { if (ptr) free (ptr); }
 
-static inline void cerver_receive_create_normal (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
+static inline void cerver_receive_create_normal (
+	CerverReceive *cr,
+	Cerver *cerver, const i32 sock_fd
+) {
 
-	if (cr) {
-		cr->client = client_get_by_sock_fd (cerver, sock_fd);
-		if (cr->client) {
-			cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
-			if (cr->connection) {
-				cr->socket = cr->connection->socket;
-			}
-		}
-
-		// for what ever reason we have a rogue connection
-		else {
-			// #ifdef CERVER_DEBUG
-			cerver_log_error (
-				"cerver_receive_create () - RECEIVE_TYPE_NORMAL - no client with sock fd <%d>",
-				sock_fd
-			);
-			// #endif
-
-			// remove the sock fd from the cerver's main poll array
-			cerver_poll_unregister_sock_fd (cerver, sock_fd);
-
-			// try to remove the sock fd from the cerver's map
-			const void *key = &sock_fd;
-			htab_remove (cerver->client_sock_fd_map, key, sizeof (i32));
-
-			close (sock_fd);        // just close the socket
-		}
-	}
-
-}
-
-static inline void cerver_receive_create_on_hold (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
-
-	if (cr) {
-		cr->connection = connection_get_by_sock_fd_from_on_hold (cerver, sock_fd);
+	cr->client = client_get_by_sock_fd (cerver, sock_fd);
+	if (cr->client) {
+		cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
 		if (cr->connection) {
 			cr->socket = cr->connection->socket;
 		}
+	}
 
-		// for what ever reason we have a rogue connection
-		else {
-			// #ifdef CERVER_DEBUG
-			cerver_log_error (
-				"cerver_receive_create () - RECEIVE_TYPE_ON_HOLD - no connection with sock fd <%d>",
-				sock_fd
-			);
-			// #endif
+	// for what ever reason we have a rogue connection
+	else {
+		// #ifdef CERVER_DEBUG
+		cerver_log_error (
+			"cerver_receive_create () - RECEIVE_TYPE_NORMAL - no client with sock fd <%d>",
+			sock_fd
+		);
+		// #endif
 
-			// remove the sock fd from the cerver's on hold poll array
-			on_hold_poll_unregister_sock_fd (cerver, sock_fd);
+		// remove the sock fd from the cerver's main poll array
+		cerver_poll_unregister_sock_fd (cerver, sock_fd);
 
-			close (sock_fd);        // just close the socket
-		}
+		// try to remove the sock fd from the cerver's map
+		const void *key = &sock_fd;
+		htab_remove (cerver->client_sock_fd_map, key, sizeof (i32));
+
+		close (sock_fd);        // just close the socket
 	}
 
 }
 
-static inline void cerver_receive_create_admin (CerverReceive *cr, Cerver *cerver, const i32 sock_fd) {
+static inline void cerver_receive_create_on_hold (
+	CerverReceive *cr,
+	Cerver *cerver, const i32 sock_fd
+) {
 
-	if (cr) {
-		cr->admin = admin_get_by_sock_fd (cerver->admin, sock_fd);
-		if (cr->admin) {
-			cr->client = cr->admin->client;
-			cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
-			if (cr->connection) {
-				cr->socket = cr->connection->socket;
-			}
-		}
+	cr->connection = connection_get_by_sock_fd_from_on_hold (cerver, sock_fd);
+	if (cr->connection) {
+		cr->socket = cr->connection->socket;
+	}
 
-		// for what ever reason we have a rogue connection
-		else {
-			// #ifdef ADMIN_DEBUG
-			cerver_log_error (
-				"cerver_receive_create () - RECEIVE_TYPE_ADMIN - no admin with sock fd <%d>",
-				sock_fd
-			);
-			// #endif
+	// for what ever reason we have a rogue connection
+	else {
+		// #ifdef CERVER_DEBUG
+		cerver_log_error (
+			"cerver_receive_create () - RECEIVE_TYPE_ON_HOLD - no connection with sock fd <%d>",
+			sock_fd
+		);
+		// #endif
 
-			// remove the sock fd from the cerver's admin poll array
-			admin_cerver_poll_unregister_sock_fd (cerver->admin, sock_fd);
+		// remove the sock fd from the cerver's on hold poll array
+		on_hold_poll_unregister_sock_fd (cerver, sock_fd);
 
-			close (sock_fd);        // just close the socket
-		}
+		close (sock_fd);        // just close the socket
 	}
 
 }
 
-CerverReceive *cerver_receive_create (ReceiveType receive_type, Cerver *cerver, const i32 sock_fd) {
+static inline void cerver_receive_create_admin (
+	CerverReceive *cr,
+	Cerver *cerver, const i32 sock_fd
+) {
+
+	cr->admin = admin_get_by_sock_fd (cerver->admin, sock_fd);
+	if (cr->admin) {
+		cr->client = cr->admin->client;
+		cr->connection = connection_get_by_sock_fd_from_client (cr->client, sock_fd);
+		if (cr->connection) {
+			cr->socket = cr->connection->socket;
+		}
+	}
+
+	// for what ever reason we have a rogue connection
+	else {
+		// #ifdef ADMIN_DEBUG
+		cerver_log_error (
+			"cerver_receive_create () - RECEIVE_TYPE_ADMIN - no admin with sock fd <%d>",
+			sock_fd
+		);
+		// #endif
+
+		// remove the sock fd from the cerver's admin poll array
+		admin_cerver_poll_unregister_sock_fd (cerver->admin, sock_fd);
+
+		close (sock_fd);        // just close the socket
+	}
+
+}
+
+CerverReceive *cerver_receive_create (
+	ReceiveType receive_type,
+	Cerver *cerver, const i32 sock_fd
+) {
 
 	CerverReceive *cr = cerver_receive_new ();
 	if (cr) {
@@ -1369,11 +1375,17 @@ CerverReceive *cerver_receive_create (ReceiveType receive_type, Cerver *cerver, 
 		switch (cr->type) {
 			case RECEIVE_TYPE_NONE: break;
 
-			case RECEIVE_TYPE_NORMAL: cerver_receive_create_normal (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_NORMAL:
+				cerver_receive_create_normal (cr, cerver, sock_fd);
+				break;
 
-			case RECEIVE_TYPE_ON_HOLD: cerver_receive_create_on_hold (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_ON_HOLD:
+				cerver_receive_create_on_hold (cr, cerver, sock_fd);
+				break;
 
-			case RECEIVE_TYPE_ADMIN: cerver_receive_create_admin (cr, cerver, sock_fd); break;
+			case RECEIVE_TYPE_ADMIN:
+				cerver_receive_create_admin (cr, cerver, sock_fd);
+				break;
 
 			default: break;
 		}
@@ -2904,7 +2916,10 @@ u8 cerver_threads (Cerver *cerver) {
 		);
 
 		#ifdef CERVER_DEBUG
-		cerver_log (LOG_TYPE_DEBUG, LOG_TYPE_CERVER, "Waiting for connections...");
+		cerver_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_CERVER,
+			"Waiting for connections..."
+		);
 		#endif
 
 		while (cerver->isRunning) {
@@ -2914,7 +2929,8 @@ u8 cerver_threads (Cerver *cerver) {
 		#ifdef CERVER_DEBUG
 		cerver_log (
 			LOG_TYPE_CERVER, LOG_TYPE_NONE,
-			"Cerver %s accept thread has stopped!", cerver->info->name->str
+			"Cerver %s accept thread has stopped!",
+			cerver->info->name->str
 		);
 		#endif
 

--- a/src/cerver/handler.c
+++ b/src/cerver/handler.c
@@ -179,9 +179,9 @@ static void handler_do_while_cerver (Handler *handler) {
 			bsem_wait (handler->job_queue->has_jobs);
 
 			if (handler->cerver->isRunning) {
-				pthread_mutex_lock (handler->cerver->handlers_lock);
+				(void) pthread_mutex_lock (handler->cerver->handlers_lock);
 				handler->cerver->num_handlers_working += 1;
-				pthread_mutex_unlock (handler->cerver->handlers_lock);
+				(void) pthread_mutex_unlock (handler->cerver->handlers_lock);
 
 				// read job from queue
 				job = job_queue_pull (handler->job_queue);
@@ -198,17 +198,26 @@ static void handler_do_while_cerver (Handler *handler) {
 					job_delete (job);
 
 					switch (packet_type) {
-						case PACKET_TYPE_APP: if (handler->cerver->app_packet_handler_delete_packet) packet_delete (packet); break;
-						case PACKET_TYPE_APP_ERROR: if (handler->cerver->app_error_packet_handler_delete_packet) packet_delete (packet); break;
-						case PACKET_TYPE_CUSTOM: if (handler->cerver->custom_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_APP: {
+							if (handler->cerver->app_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
+						case PACKET_TYPE_APP_ERROR: {
+							if (handler->cerver->app_error_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
+						case PACKET_TYPE_CUSTOM: {
+							if (handler->cerver->custom_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
 
 						default: packet_delete (packet); break;
 					}
 				}
 
-				pthread_mutex_lock (handler->cerver->handlers_lock);
+				(void) pthread_mutex_lock (handler->cerver->handlers_lock);
 				handler->cerver->num_handlers_working -= 1;
-				pthread_mutex_unlock (handler->cerver->handlers_lock);
+				(void) pthread_mutex_unlock (handler->cerver->handlers_lock);
 			}
 		}
 
@@ -228,9 +237,9 @@ static void handler_do_while_client (Handler *handler) {
 			bsem_wait (handler->job_queue->has_jobs);
 
 			if (handler->client->running) {
-				pthread_mutex_lock (handler->client->handlers_lock);
+				(void) pthread_mutex_lock (handler->client->handlers_lock);
 				handler->client->num_handlers_working += 1;
-				pthread_mutex_unlock (handler->client->handlers_lock);
+				(void) pthread_mutex_unlock (handler->client->handlers_lock);
 
 				// read job from queue
 				job = job_queue_pull (handler->job_queue);
@@ -247,9 +256,9 @@ static void handler_do_while_client (Handler *handler) {
 					packet_delete (packet);
 				}
 
-				pthread_mutex_lock (handler->client->handlers_lock);
+				(void) pthread_mutex_lock (handler->client->handlers_lock);
 				handler->client->num_handlers_working -= 1;
-				pthread_mutex_unlock (handler->client->handlers_lock);
+				(void) pthread_mutex_unlock (handler->client->handlers_lock);
 			}
 		}
 
@@ -270,9 +279,9 @@ static void handler_do_while_admin (Handler *handler) {
 			bsem_wait (handler->job_queue->has_jobs);
 
 			if (handler->cerver->isRunning) {
-				pthread_mutex_lock (handler->cerver->admin->handlers_lock);
+				(void) pthread_mutex_lock (handler->cerver->admin->handlers_lock);
 				handler->cerver->admin->num_handlers_working += 1;
-				pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
+				(void) pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
 
 				// read job from queue
 				job = job_queue_pull (handler->job_queue);
@@ -289,17 +298,26 @@ static void handler_do_while_admin (Handler *handler) {
 					job_delete (job);
 
 					switch (packet_type) {
-						case PACKET_TYPE_APP: if (handler->cerver->admin->app_packet_handler_delete_packet) packet_delete (packet); break;
-						case PACKET_TYPE_APP_ERROR: if (handler->cerver->admin->app_error_packet_handler_delete_packet) packet_delete (packet); break;
-						case PACKET_TYPE_CUSTOM: if (handler->cerver->admin->custom_packet_handler_delete_packet) packet_delete (packet); break;
+						case PACKET_TYPE_APP: {
+							if (handler->cerver->admin->app_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
+						case PACKET_TYPE_APP_ERROR: {
+							if (handler->cerver->admin->app_error_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
+						case PACKET_TYPE_CUSTOM: {
+							if (handler->cerver->admin->custom_packet_handler_delete_packet)
+								packet_delete (packet);
+						} break;
 
 						default: packet_delete (packet); break;
 					}
 				}
 
-				pthread_mutex_lock (handler->cerver->admin->handlers_lock);
+				(void) pthread_mutex_lock (handler->cerver->admin->handlers_lock);
 				handler->cerver->admin->num_handlers_working -= 1;
-				pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
+				(void) pthread_mutex_unlock (handler->cerver->admin->handlers_lock);
 			}
 		}
 
@@ -315,25 +333,46 @@ static void *handler_do (void *handler_ptr) {
 
 		pthread_mutex_t *handlers_lock = NULL;
 		switch (handler->type) {
-			case HANDLER_TYPE_CERVER: handlers_lock = handler->cerver->handlers_lock; break;
-			case HANDLER_TYPE_CLIENT: handlers_lock = handler->client->handlers_lock; break;
-			case HANDLER_TYPE_ADMIN: handlers_lock = handler->cerver->admin->handlers_lock; break;
+			case HANDLER_TYPE_CERVER:
+				handlers_lock = handler->cerver->handlers_lock;
+				break;
+			case HANDLER_TYPE_CLIENT:
+				handlers_lock = handler->client->handlers_lock;
+				break;
+			case HANDLER_TYPE_ADMIN:
+				handlers_lock = handler->cerver->admin->handlers_lock;
+				break;
 			default: break;
 		}
 
 		// set the thread name
 		if (handler->id >= 0) {
-			char thread_name[128] = { 0 };
+			char thread_name[THREAD_NAME_BUFFER_LEN] = { 0 };
 
 			switch (handler->type) {
-				case HANDLER_TYPE_CERVER: snprintf (thread_name, 128, "cerver-handler-%d", handler->unique_id); break;
-				case HANDLER_TYPE_CLIENT: snprintf (thread_name, 128, "client-handler-%d", handler->unique_id); break;
-				case HANDLER_TYPE_ADMIN: snprintf (thread_name, 128, "admin-handler-%d", handler->unique_id); break;
+				case HANDLER_TYPE_CERVER:
+					(void) snprintf (
+						thread_name, THREAD_NAME_BUFFER_LEN,
+						"cerver-handler-%d", handler->unique_id
+					);
+					break;
+				case HANDLER_TYPE_CLIENT:
+					(void) snprintf (
+						thread_name, THREAD_NAME_BUFFER_LEN,
+						"client-handler-%d", handler->unique_id
+					);
+					break;
+				case HANDLER_TYPE_ADMIN:
+					(void) snprintf (
+						thread_name, THREAD_NAME_BUFFER_LEN,
+						"admin-handler-%d", handler->unique_id
+					);
+					break;
 				default: break;
 			}
 
 			// printf ("%s\n", thread_name);
-			prctl (PR_SET_NAME, thread_name);
+			(void) prctl (PR_SET_NAME, thread_name);
 		}
 
 		// TODO: register to signals to handle multiple actions
@@ -342,14 +381,14 @@ static void *handler_do (void *handler_ptr) {
 			handler->data = handler->data_create (handler->data_create_args);
 
 		// mark the handler as alive and ready
-		pthread_mutex_lock (handlers_lock);
+		(void) pthread_mutex_lock (handlers_lock);
 		switch (handler->type) {
 			case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive += 1; break;
 			case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive += 1; break;
 			case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive += 1; break;
 			default: break;
 		}
-		pthread_mutex_unlock (handlers_lock);
+		(void) pthread_mutex_unlock (handlers_lock);
 
 		// while cerver / client is running, check for new jobs and handle them
 		switch (handler->type) {
@@ -362,14 +401,14 @@ static void *handler_do (void *handler_ptr) {
 		if (handler->data_delete)
 			handler->data_delete (handler->data);
 
-		pthread_mutex_lock (handlers_lock);
+		(void) pthread_mutex_lock (handlers_lock);
 		switch (handler->type) {
 			case HANDLER_TYPE_CERVER: handler->cerver->num_handlers_alive -= 1; break;
 			case HANDLER_TYPE_CLIENT: handler->client->num_handlers_alive -= 1; break;
 			case HANDLER_TYPE_ADMIN: handler->cerver->admin->num_handlers_alive -= 1; break;
 			default: break;
 		}
-		pthread_mutex_unlock (handlers_lock);
+		(void) pthread_mutex_unlock (handlers_lock);
 	}
 
 	return NULL;
@@ -504,7 +543,7 @@ static CerverHandlerError cerver_client_packet_handler (
 			// but will remain in the cerver if it has another connection active
 			// if not, it will be dropped
 			case CLIENT_PACKET_TYPE_CLOSE_CONNECTION: {
-				#ifdef CERVER_DEBUG
+				#ifdef HANDLER_DEBUG
 				cerver_log_debug (
 					"Client %ld requested to close the connection",
 					packet->client->id
@@ -513,7 +552,7 @@ static CerverHandlerError cerver_client_packet_handler (
 
 				// check if the client is inside a lobby
 				if (packet->lobby) {
-					#ifdef CERVER_DEBUG
+					#ifdef HANDLER_DEBUG
 					cerver_log (
 						LOG_TYPE_DEBUG, LOG_TYPE_GAME,
 						"Client %ld inside lobby %s wants to close the connection...",
@@ -548,7 +587,7 @@ static CerverHandlerError cerver_client_packet_handler (
 			case CLIENT_PACKET_TYPE_DISCONNECT: {
 				// check if the client is inside a lobby
 				if (packet->lobby) {
-					#ifdef CERVER_DEBUG
+					#ifdef HANDLER_DEBUG
 					cerver_log (
 						LOG_TYPE_DEBUG, LOG_TYPE_GAME,
 						"Client %ld inside lobby %s wants to close the connection...",


### PR DESCRIPTION
## General
- Added dedicated method to set cerver's sock fd reusable flags

## Handler
- Refactored cerver_receive_handle_failed () to be used in one thread
- Refactored cerver receive create methods
- Refactored more cerver handler methods organization
- Added cerver_handler_register_connection () to select handler for con

## Auth
- Refactored admin & normal success auth processes when using sessions
- Refactored admin & auth methods organization
- Quick fix for connections not being handled in threads after auth